### PR TITLE
add maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,10 +188,32 @@
                     <version>${maven-bundle-plugin.version}</version>
                     <extensions>true</extensions>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-java</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireJavaVersion>
+                                        <version>[${javaVersion}, 1.8)</version>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
- mvn validate goal will trigger the enforcer
- ensures the JDK used to compile is the version we claim to support