### PR TITLE
Core #50:  PATCH fails for fields that where null before

### DIFF
--- a/katharsis-core/src/test/java/io/katharsis/dispatcher/controller/resource/ResourcePatchTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/dispatcher/controller/resource/ResourcePatchTest.java
@@ -249,7 +249,17 @@ public class ResourcePatchTest extends BaseControllerTest {
         DataBody data = new DataBody();
         complexPojoPatch.setData(data);
         data.setType("complexpojos");
-        JsonNode patchAttributes = objectMapper.readTree("{\"containedPojo\": { \"updateableProperty1\":\"updated value\"}}");
+
+        String rawPatchData = "" +
+                "{" +
+                "  'containedPojo':{" +
+                "    'updateableProperty1':'updated value'" +
+                "  }," +
+                "  'updateableProperty':'wasNullBefore'" +
+                "}";
+        rawPatchData = rawPatchData.replaceAll("'", "\"");
+
+        JsonNode patchAttributes = objectMapper.readTree(rawPatchData);
         data.setAttributes(patchAttributes);
         JsonPath jsonPath = pathBuilder.buildPath("/complexpojos/" + complexPojoId);
         ResourcePatch sut = new ResourcePatch(resourceRegistry, typeParser, objectMapper);
@@ -262,6 +272,7 @@ public class ResourcePatchTest extends BaseControllerTest {
         assertThat(response.getResponse().getEntity()).isExactlyInstanceOf(ComplexPojo.class);
         assertThat(((ComplexPojo) (response.getResponse().getEntity())).getContainedPojo().getUpdateableProperty1()).isEqualTo("updated value");
         assertThat(((ComplexPojo) (response.getResponse().getEntity())).getContainedPojo().getUpdateableProperty2()).isEqualTo("value from repository mock");
+        assertThat(((ComplexPojo) (response.getResponse().getEntity())).getUpdateableProperty()).isEqualTo("wasNullBefore");
     }
 
 }


### PR DESCRIPTION
Commit fixes the issue. Test slightly extended to cover the problematic case too.

Fixes #50 