### PR TITLE
filter api to enable jpa module #15

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
@@ -1,5 +1,12 @@
 package io.katharsis.dispatcher;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.katharsis.dispatcher.controller.BaseController;
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.dispatcher.filter.FilterChain;
+import io.katharsis.dispatcher.filter.FilterRequestContext;
 import io.katharsis.dispatcher.registry.ControllerRegistry;
 import io.katharsis.errorhandling.mapper.ExceptionMapperRegistry;
 import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
@@ -19,11 +26,16 @@ public class RequestDispatcher {
     private final ControllerRegistry controllerRegistry;
     private final ExceptionMapperRegistry exceptionMapperRegistry;
 
+	private List<Filter> filters = new CopyOnWriteArrayList<Filter>();
+
     public RequestDispatcher(ControllerRegistry controllerRegistry, ExceptionMapperRegistry exceptionMapperRegistry) {
         this.controllerRegistry = controllerRegistry;
         this.exceptionMapperRegistry = exceptionMapperRegistry;
     }
 
+    public void addFilter(Filter filter){
+    	filters.add(filter);
+    }
     /**
      * Dispatch the request from a client
      *
@@ -39,9 +51,12 @@ public class RequestDispatcher {
                                                   @SuppressWarnings("SameParameterValue") RequestBody requestBody) {
 
         try {
-            return controllerRegistry
-                .getController(jsonPath, requestType)
-                .handle(jsonPath, queryParams, parameterProvider, requestBody);
+        	BaseController controller = controllerRegistry.getController(jsonPath, requestType);
+
+			DefaultFilterRequestContext context = new DefaultFilterRequestContext(jsonPath, queryParams,
+					parameterProvider, requestBody);
+			DefaultFilterChain chain = new DefaultFilterChain(controller);
+			return chain.doFilter(context);
         } catch (Exception e) {
             Optional<JsonApiExceptionMapper> exceptionMapper = exceptionMapperRegistry.findMapperFor(e.getClass());
             if (exceptionMapper.isPresent()) {
@@ -53,4 +68,61 @@ public class RequestDispatcher {
             }
         }
     }
+    
+    class DefaultFilterChain implements FilterChain{
+
+		protected int filterIndex = 0;
+		protected BaseController controller;
+		
+		public DefaultFilterChain(BaseController controller){
+			this.controller = controller;
+		}
+		
+		@Override
+		public BaseResponseContext doFilter(FilterRequestContext context) {
+			if (filterIndex == filters.size()) {
+				return controller.handle(context.getJsonPath(), context.getQueryParams(), context.getParameterProvider(), context.getRequestBody());
+			} else {
+				Filter filter = filters.get(filterIndex);
+				filterIndex++;
+				return filter.filter(context, this);
+			}
+		}
+	}
+	
+	class DefaultFilterRequestContext implements FilterRequestContext {
+		
+		protected JsonPath jsonPath;
+		protected QueryParams queryParams;
+		protected RepositoryMethodParameterProvider parameterProvider;
+		protected RequestBody requestBody;
+
+		public DefaultFilterRequestContext(JsonPath jsonPath, QueryParams queryParams,
+				RepositoryMethodParameterProvider parameterProvider, RequestBody requestBody) {
+			this.jsonPath = jsonPath;
+			this.queryParams = queryParams;
+			this.parameterProvider = parameterProvider;
+			this.requestBody = requestBody;
+		}
+
+		@Override
+		public RequestBody getRequestBody() {
+			return requestBody;
+		}
+
+		@Override
+		public RepositoryMethodParameterProvider getParameterProvider() {
+			return parameterProvider;
+		}
+
+		@Override
+		public QueryParams getQueryParams() {
+			return queryParams;
+		}
+
+		@Override
+		public JsonPath getJsonPath() {
+			return jsonPath;
+		}
+	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/AbstractFilter.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/AbstractFilter.java
@@ -1,0 +1,14 @@
+package io.katharsis.dispatcher.filter;
+
+import io.katharsis.response.BaseResponseContext;
+
+/**
+ * Empty {@link Filter} implementation useful as a starting point to write new filters.
+ */
+public class AbstractFilter implements Filter {
+
+	@Override
+	public BaseResponseContext filter(FilterRequestContext context, FilterChain chain) {
+		return chain.doFilter(context);
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/Filter.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/Filter.java
@@ -1,0 +1,19 @@
+package io.katharsis.dispatcher.filter;
+
+import io.katharsis.response.BaseResponseContext;
+
+/**
+ * Allows to intercept and modify incoming requests and responses.
+ */
+public interface Filter {
+
+	/**
+	 * Filters an incoming request. To continue processing the request, {@link FilterChain#doFilter(FilterRequestContext)} must
+	 * be called. Information about the request is available from {@link FilterRequestContext}.
+	 *  
+	 * @param filterRequestContext
+	 * @param chain
+	 */
+	public BaseResponseContext filter(FilterRequestContext filterRequestContext, FilterChain chain);
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/FilterChain.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/FilterChain.java
@@ -1,0 +1,15 @@
+package io.katharsis.dispatcher.filter;
+
+import io.katharsis.response.BaseResponseContext;
+
+/**
+ * Manages the chain of filters and their application to a request.
+ */
+public interface FilterChain {
+
+	/**
+	 * Executes the next filter in the request chain or the actual {@link BaseController} once all filters
+	 * have been invoked.
+	 */
+	public BaseResponseContext doFilter(FilterRequestContext filterRequestContext);
+}

--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/FilterRequestContext.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/filter/FilterRequestContext.java
@@ -1,0 +1,21 @@
+package io.katharsis.dispatcher.filter;
+
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.RepositoryMethodParameterProvider;
+import io.katharsis.request.dto.RequestBody;
+import io.katharsis.request.path.JsonPath;
+
+/**
+ * Provides request information to {@link Filter}.
+ */
+public interface FilterRequestContext {
+
+	RequestBody getRequestBody();
+
+	RepositoryMethodParameterProvider getParameterProvider();
+
+	QueryParams getQueryParams();
+
+	JsonPath getJsonPath();
+
+}

--- a/katharsis-core/src/test/java/io/katharsis/dispatcher/filter/FilterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/dispatcher/filter/FilterTest.java
@@ -1,0 +1,86 @@
+package io.katharsis.dispatcher.filter;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.katharsis.dispatcher.RequestDispatcher;
+import io.katharsis.dispatcher.controller.collection.CollectionGet;
+import io.katharsis.dispatcher.registry.ControllerRegistry;
+import io.katharsis.locator.SampleJsonServiceLocator;
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.RepositoryMethodParameterProvider;
+import io.katharsis.repository.mock.NewInstanceRepositoryMethodParameterProvider;
+import io.katharsis.request.dto.RequestBody;
+import io.katharsis.request.path.JsonPath;
+import io.katharsis.request.path.PathBuilder;
+import io.katharsis.resource.field.ResourceFieldNameTransformer;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.resource.registry.ResourceRegistryBuilder;
+import io.katharsis.resource.registry.ResourceRegistryBuilderTest;
+import io.katharsis.resource.registry.ResourceRegistryTest;
+
+public class FilterTest {
+
+	private ResourceRegistry resourceRegistry;
+	private TestFilter filter;
+	private RequestDispatcher dispatcher;
+	private CollectionGet collectionGet;
+	private PathBuilder pathBuilder;
+
+	String path = "/tasks/";
+	String requestType = "GET";
+
+	@Before
+	public void prepare() {
+		ResourceInformationBuilder resourceInformationBuilder = new ResourceInformationBuilder(
+				new ResourceFieldNameTransformer());
+		ResourceRegistryBuilder registryBuilder = new ResourceRegistryBuilder(new SampleJsonServiceLocator(),
+				resourceInformationBuilder);
+		resourceRegistry = registryBuilder.build(ResourceRegistryBuilderTest.TEST_MODELS_PACKAGE,
+				ResourceRegistryTest.TEST_MODELS_URL);
+		pathBuilder = new PathBuilder(resourceRegistry);
+		ControllerRegistry controllerRegistry = new ControllerRegistry(null);
+		collectionGet = mock(CollectionGet.class);
+		controllerRegistry.addController(collectionGet);
+		dispatcher = new RequestDispatcher(controllerRegistry, null);
+	}
+
+	@Test
+	public void test() throws Exception {
+		// GIVEN
+		filter = mock(TestFilter.class);
+		dispatcher.addFilter(filter);
+
+		// WHEN
+		ArgumentCaptor<FilterRequestContext> captor = ArgumentCaptor.forClass(FilterRequestContext.class);
+		when(collectionGet.isAcceptable(any(JsonPath.class), eq(requestType))).thenCallRealMethod();
+		when(filter.filter(any(FilterRequestContext.class), any(FilterChain.class))).thenCallRealMethod();
+		JsonPath jsonPath = pathBuilder.buildPath(path);
+		QueryParams queryParams = new QueryParams();
+		RepositoryMethodParameterProvider parameterProvider = new NewInstanceRepositoryMethodParameterProvider();
+		RequestBody requestBody = new RequestBody();
+		dispatcher.dispatchRequest(jsonPath, requestType, queryParams, parameterProvider, requestBody );
+
+		// THEN
+		verify(filter).filter(captor.capture(), any(FilterChain.class));
+		verify(collectionGet, times(1)).handle(any(JsonPath.class), any(QueryParams.class),
+				any(RepositoryMethodParameterProvider.class), any(RequestBody.class));
+		verify(filter, times(1)).filter(any(FilterRequestContext.class), any(FilterChain.class));
+
+		FilterRequestContext value = captor.getValue();
+		Assert.assertEquals("tasks", value.getJsonPath().getElementName());
+		Assert.assertEquals(parameterProvider, value.getParameterProvider());
+		Assert.assertEquals(queryParams, value.getQueryParams());
+		Assert.assertEquals(requestBody, value.getRequestBody());
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/dispatcher/filter/TestFilter.java
+++ b/katharsis-core/src/test/java/io/katharsis/dispatcher/filter/TestFilter.java
@@ -1,0 +1,11 @@
+package io.katharsis.dispatcher.filter;
+
+import io.katharsis.response.BaseResponseContext;
+
+public class TestFilter implements Filter {
+
+	@Override
+	public BaseResponseContext filter(FilterRequestContext filterRequestContext, FilterChain chain) {
+		return chain.doFilter(filterRequestContext);
+	}
+}


### PR DESCRIPTION
introduced new interfaces Filter and FilterChain to intercept and wrap requests similar to JAX-RS and servlets. Can be used for transaction mgmt, tracing, metrics, etc.

FYI: depending on order of applied PRs, FilterTest needs to be updated with ResourceInformationBuilder changed to AnnotationResourceInformationBuilder.