### PR TITLE
allow all java versions > 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                        <version>[${javaVersion}, 1.8)</version>
+                                        <version>${javaVersion}</version>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>


### PR DESCRIPTION
I fixed a maven configuration so that maven accepts all java versions above 1.7

Currently it only accepts 1.7 and **1.8**! Meaning if I use 1.8.0_101 it will fail.