### PR TITLE
Module API to allow to extend core katharsis functionality #45

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
@@ -10,6 +10,7 @@ import io.katharsis.dispatcher.filter.FilterRequestContext;
 import io.katharsis.dispatcher.registry.ControllerRegistry;
 import io.katharsis.errorhandling.mapper.ExceptionMapperRegistry;
 import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
+import io.katharsis.module.ModuleRegistry;
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.repository.RepositoryMethodParameterProvider;
 import io.katharsis.request.dto.RequestBody;
@@ -33,7 +34,15 @@ public class RequestDispatcher {
         this.exceptionMapperRegistry = exceptionMapperRegistry;
     }
 
-    public void addFilter(Filter filter){
+    public RequestDispatcher(ModuleRegistry moduleRegistry, ControllerRegistry controllerRegistry,
+			ExceptionMapperRegistry exceptionMapperRegistry) {
+    	this(controllerRegistry, exceptionMapperRegistry);
+    	for(Filter filter : moduleRegistry.getFilters()){
+    		addFilter(filter);
+    	}
+	}
+
+	public void addFilter(Filter filter){
     	filters.add(filter);
     }
 

--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
@@ -1,7 +1,6 @@
 package io.katharsis.dispatcher;
 
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.katharsis.dispatcher.controller.BaseController;
 import io.katharsis.dispatcher.filter.Filter;
@@ -26,24 +25,14 @@ public class RequestDispatcher {
 
     private final ControllerRegistry controllerRegistry;
     private final ExceptionMapperRegistry exceptionMapperRegistry;
-
-	private List<Filter> filters = new CopyOnWriteArrayList<Filter>();
-
-    public RequestDispatcher(ControllerRegistry controllerRegistry, ExceptionMapperRegistry exceptionMapperRegistry) {
-        this.controllerRegistry = controllerRegistry;
-        this.exceptionMapperRegistry = exceptionMapperRegistry;
-    }
+    
+	private ModuleRegistry moduleRegistry;
 
     public RequestDispatcher(ModuleRegistry moduleRegistry, ControllerRegistry controllerRegistry,
 			ExceptionMapperRegistry exceptionMapperRegistry) {
-    	this(controllerRegistry, exceptionMapperRegistry);
-    	for(Filter filter : moduleRegistry.getFilters()){
-    		addFilter(filter);
-    	}
-	}
-
-	public void addFilter(Filter filter){
-    	filters.add(filter);
+    	this.controllerRegistry = controllerRegistry;
+    	this.moduleRegistry = moduleRegistry;
+    	this.exceptionMapperRegistry = exceptionMapperRegistry;
     }
 
     /**
@@ -90,6 +79,7 @@ public class RequestDispatcher {
 
 		@Override
 		public BaseResponseContext doFilter(FilterRequestContext context) {
+			List<Filter> filters = moduleRegistry.getFilters();
 			if (filterIndex == filters.size()) {
 				return controller.handle(context.getJsonPath(), context.getQueryParams(), context.getParameterProvider(), context.getRequestBody());
 			} else {

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/ErrorResponse.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/ErrorResponse.java
@@ -19,6 +19,10 @@ public final class ErrorResponse implements BaseResponseContext {
         this.httpStatus = httpStatus;
     }
 
+    public Iterable<ErrorData> getErrors(){
+    	return data;
+    }
+    
     @Override
     public int getHttpStatus() {
         return httpStatus;

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapper.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapper.java
@@ -1,0 +1,20 @@
+package io.katharsis.errorhandling.mapper;
+
+import io.katharsis.errorhandling.ErrorResponse;
+
+public interface ExceptionMapper<E extends Throwable> extends JsonApiExceptionMapper<E> {
+
+	@Override
+    ErrorResponse toErrorResponse(E exception);
+	
+	/**
+	 * Convert the given error response to an exception.
+
+	 * @return true if mapper can handle the response
+	 */
+	E fromErrorResponse(ErrorResponse errorResponse);
+	
+	boolean accepts(ErrorResponse errorResponse);
+}
+
+

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
@@ -8,10 +8,6 @@ import java.util.Set;
 public final class ExceptionMapperRegistryBuilder {
     private final Set<ExceptionMapperType> exceptionMappers = new HashSet<>();
 
-    public Set<ExceptionMapperType> getExceptionMappers() {
-        return exceptionMappers;
-    }
-
     public ExceptionMapperRegistry build(String resourceSearchPackage) {
         return build(new DefaultExceptionMapperLookup(resourceSearchPackage));
     }

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
@@ -36,7 +36,7 @@ public final class ExceptionMapperRegistryBuilder {
     private Class<? extends Throwable> getGenericType(Class<? extends JsonApiExceptionMapper> mapper) {
         Type[] types = mapper.getGenericInterfaces();
         for (Type type : types) {
-            if (type instanceof ParameterizedType && ((ParameterizedType)type).getRawType() == JsonApiExceptionMapper.class) {
+        	if (type instanceof ParameterizedType && (((ParameterizedType)type).getRawType() == JsonApiExceptionMapper.class || ((ParameterizedType)type).getRawType() == ExceptionMapper.class)) {
                 //noinspection unchecked
                 return (Class<? extends Throwable>)((ParameterizedType)type).getActualTypeArguments()[0];
             }

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/JsonApiExceptionMapper.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/JsonApiExceptionMapper.java
@@ -2,6 +2,10 @@ package io.katharsis.errorhandling.mapper;
 
 import io.katharsis.errorhandling.ErrorResponse;
 
+/**
+ * Use {@link ExceptionMapper} instead which supports katharsis-client as well.
+ */
+@Deprecated
 public interface JsonApiExceptionMapper<E extends Throwable> {
 
     ErrorResponse toErrorResponse(E exception);

--- a/katharsis-core/src/main/java/io/katharsis/module/CoreModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/CoreModule.java
@@ -1,0 +1,21 @@
+package io.katharsis.module;
+
+import io.katharsis.errorhandling.mapper.DefaultExceptionMapperLookup;
+import io.katharsis.resource.field.ResourceFieldNameTransformer;
+import io.katharsis.resource.information.AnnotationResourceInformationBuilder;
+import io.katharsis.resource.registry.DefaultResourceLookup;
+
+/**
+ * Register the Katharsis core feature set as module.
+ */
+public class CoreModule extends SimpleModule {
+
+	public static final String MODULE_NAME = "core";
+
+	public CoreModule(String resourceSearchPackage, ResourceFieldNameTransformer resourceFieldNameTransformer) {
+		super(MODULE_NAME);
+		this.addResourceLookup(new DefaultResourceLookup(resourceSearchPackage));
+		this.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(resourceFieldNameTransformer));
+		this.addExceptionMapperLookup(new DefaultExceptionMapperLookup(resourceSearchPackage));
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/module/Module.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/Module.java
@@ -1,0 +1,89 @@
+package io.katharsis.module;
+
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.errorhandling.mapper.ExceptionMapper;
+import io.katharsis.errorhandling.mapper.ExceptionMapperLookup;
+import io.katharsis.repository.RelationshipRepository;
+import io.katharsis.repository.ResourceRepository;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.resource.registry.ResourceLookup;
+import io.katharsis.resource.registry.ResourceRegistry;
+
+/**
+ * Interface for extensions that can be registered to Katharsis to provide a
+ * well-defined set of extensions on top of the default functionality.
+ */
+public interface Module {
+
+	/**
+	 * Returns the identifier of this module.
+	 */
+	public String getModuleName();
+
+	/**
+	 * Called when the module is registered with Katharsis. Allows the module to
+	 * register functionality it provides.
+	 */
+	public void setupModule(ModuleContext context);
+
+	/**
+	 * Interface Katharsis exposes to modules for purpose of registering
+	 * extended functionality.
+	 */
+	public interface ModuleContext {
+
+		/**
+		 * Register the given {@link ResourceInformationBuilder} in Katharsis.
+		 * 
+		 * @param resourceInformationBuilder
+		 */
+		void addResourceInformationBuilder(ResourceInformationBuilder resourceInformationBuilder);
+
+		/**
+		 * Register the given {@link ResourceLookup} in Katharsis.
+		 * 
+		 * @param resourceLookup
+		 */
+		void addResourceLookup(ResourceLookup resourceLookup);
+
+		/**
+		 * Registers an additional module for Jackson.
+		 */
+		void addJacksonModule(com.fasterxml.jackson.databind.Module module);
+
+		/**
+		 * Adds the given repository for the given type.
+		 */
+		public void addRepository(Class<?> resourceClass, ResourceRepository<?, ?> repository);
+
+		/**
+		 * Adds the given repository for the given source and target type.
+		 */
+		public void addRepository(Class<?> sourceResourceClass, Class<?> targetResourceClass, RelationshipRepository<?, ?, ?, ?> repository);
+
+		/**
+		 * Adds a new exception mapper lookup.
+		 */
+		public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup);
+		
+		/**
+		 * Adds a new exception mapper lookup.
+		 */
+		public void addExceptionMapper(ExceptionMapper<?> exceptionMapper);
+		
+		/**
+		 * Adds a filter to intercept requests.
+		 */
+		public void addFilter(Filter filter);
+		
+		/**
+		 * Returns the ResourceRegistry. Note that instance is not yet available
+		 * when {@link Module#setupModule(ModuleContext)} is called. So
+		 * consumers may have to hold onto the {@link ModuleContext} instead.
+		 * 
+		 * @return ResourceRegistry
+		 */
+		ResourceRegistry getResourceRegistry();
+
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
@@ -1,0 +1,303 @@
+package io.katharsis.module;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.errorhandling.mapper.ExceptionMapper;
+import io.katharsis.errorhandling.mapper.ExceptionMapperLookup;
+import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
+import io.katharsis.module.SimpleModule.RelationshipRepositoryRegistration;
+import io.katharsis.module.SimpleModule.ResourceRepositoryRegistration;
+import io.katharsis.repository.RelationshipRepository;
+import io.katharsis.repository.RepositoryInstanceBuilder;
+import io.katharsis.repository.ResourceRepository;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.resource.registry.RegistryEntry;
+import io.katharsis.resource.registry.ResourceLookup;
+import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.resource.registry.repository.DirectResponseRelationshipEntry;
+import io.katharsis.resource.registry.repository.DirectResponseResourceEntry;
+import io.katharsis.resource.registry.repository.ResponseRelationshipEntry;
+
+/**
+ * Container for setting up and holding {@link Module} instances;
+ */
+public class ModuleRegistry {
+
+	private ObjectMapper objectMapper;
+	private ResourceRegistry resourceRegistry;
+
+	private List<Module> modules = new ArrayList<Module>();
+
+	private SimpleModule aggregatedModule = new SimpleModule(null);
+	private boolean initalized;
+
+	public ModuleRegistry() {
+	}
+
+	/**
+	 * Register an new module to this registry and setup the module.
+	 * 
+	 * @param module
+	 */
+	public void addModule(Module module) {
+		module.setupModule(new ModuleContextImpl());
+		modules.add(module);
+	}
+
+	class ModuleContextImpl implements Module.ModuleContext {
+
+		@Override
+		public void addResourceInformationBuilder(ResourceInformationBuilder resourceInformationBuilder) {
+			checkNotInitialized();
+			aggregatedModule.addResourceInformationBuilder(resourceInformationBuilder);
+		}
+
+		@Override
+		public void addResourceLookup(ResourceLookup resourceLookup) {
+			checkNotInitialized();
+			aggregatedModule.addResourceLookup(resourceLookup);
+		}
+
+		@Override
+		public void addJacksonModule(com.fasterxml.jackson.databind.Module module) {
+			checkNotInitialized();
+			aggregatedModule.addJacksonModule(module);
+			if (objectMapper != null) {
+				objectMapper.registerModule(module);
+			}
+		}
+
+		@Override
+		public ResourceRegistry getResourceRegistry() {
+			if (resourceRegistry == null)
+				throw new IllegalStateException("resourceRegistry not yet available");
+			return resourceRegistry;
+		}
+
+		@Override
+		public void addRepository(Class<?> type, ResourceRepository<?, ?> repository) {
+			checkNotInitialized();
+			aggregatedModule.addRepository(type, repository);
+		}
+
+		@Override
+		public void addRepository(Class<?> sourceType, Class<?> targetType,
+				RelationshipRepository<?, ?, ?, ?> repository) {
+			checkNotInitialized();
+			aggregatedModule.addRepository(sourceType, targetType, repository);
+		}
+
+		@Override
+		public void addFilter(Filter filter) {
+			aggregatedModule.addFilter(filter);			
+		}
+
+		@Override
+		public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
+			aggregatedModule.addExceptionMapperLookup(exceptionMapperLookup);			
+		}
+
+		@Override
+		public void addExceptionMapper(ExceptionMapper<?> exceptionMapper) {
+			aggregatedModule.addExceptionMapper(exceptionMapper);			
+		}
+	}
+
+	/**
+	 * Returns all Jackson modules registered by modules.
+	 */
+	public List<com.fasterxml.jackson.databind.Module> getJacksonModules() {
+		return aggregatedModule.getJacksonModules();
+	}
+
+	/**
+	 * Ensures the {@link ModuleRegistry#init(ObjectMapper, ResourceRegistry)} has not yet been called.
+	 */
+	protected void checkNotInitialized() {
+		if (initalized) {
+			throw new IllegalStateException("already initialized, cannot be changed anymore");
+		}
+	}
+
+	/**
+	 * Returns a {@link ResourceInformationBuilder} instance that combines all 
+	 * instances registered by modules.
+	 */
+	public ResourceInformationBuilder getResourceInformationBuilder() {
+		return new CombinedResourceInformationBuilder(aggregatedModule.getResourceInformationBuilders());
+	}
+
+	/**
+	 * Returns a {@link ResourceLookup} instance that combines all 
+	 * instances registered by modules.
+	 */
+	public ResourceLookup getResourceLookup() {
+		return new CombinedResourceLookup(aggregatedModule.getResourceLookups());
+	}
+
+	/**
+	 * Combines all {@link ResourceInformationBuilder} instances provided by the registered
+	 * {@link Module}.
+	 */
+	static class CombinedResourceInformationBuilder implements ResourceInformationBuilder {
+
+		private Collection<ResourceInformationBuilder> builders;
+
+		public CombinedResourceInformationBuilder(List<ResourceInformationBuilder> builders) {
+			this.builders = builders;
+		}
+
+		@Override
+		public boolean accept(Class<?> resourceClass) {
+			for (ResourceInformationBuilder builder : builders) {
+				if (builder.accept(resourceClass)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public ResourceInformation build(Class<?> resourceClass) {
+			for (ResourceInformationBuilder builder : builders) {
+				if (builder.accept(resourceClass)) {
+					return builder.build(resourceClass);
+				}
+			}
+			throw new UnsupportedOperationException(
+					"no ResourceInformationBuilder for " + resourceClass.getName() + " available");
+		}
+	}
+
+	
+	/**
+	 * Combines all {@link ExceptionMapperLookup} instances provided by the registered
+	 * {@link Module}.
+	 */
+	static class CombinedExceptionMapperLookup implements ExceptionMapperLookup {
+
+		private Collection<ExceptionMapperLookup> lookups;
+
+		public CombinedExceptionMapperLookup(List<ExceptionMapperLookup> lookups) {
+			this.lookups = lookups;
+		}
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public  Set<JsonApiExceptionMapper> getExceptionMappers() {
+			Set<JsonApiExceptionMapper> set = new HashSet<JsonApiExceptionMapper>();
+			for(ExceptionMapperLookup lookup : lookups){
+				set.addAll(lookup.getExceptionMappers());
+			}
+			return set;
+		}
+	}
+	
+	/**
+	 * Combines all {@link ResourceLookup} instances provided by the registered
+	 * {@link Module}.
+	 */
+	static class CombinedResourceLookup implements ResourceLookup {
+
+		private Collection<ResourceLookup> lookups;
+
+		public CombinedResourceLookup(List<ResourceLookup> lookups) {
+			this.lookups = lookups;
+		}
+
+		@Override
+		public Set<Class<?>> getResourceClasses() {
+			Set<Class<?>> set = new HashSet<Class<?>>();
+			for (ResourceLookup lookup : lookups) {
+				set.addAll(lookup.getResourceClasses());
+			}
+			return set;
+		}
+
+		@Override
+		public Set<Class<?>> getResourceRepositoryClasses() {
+			Set<Class<?>> set = new HashSet<Class<?>>();
+			for (ResourceLookup lookup : lookups) {
+				set.addAll(lookup.getResourceRepositoryClasses());
+			}
+			return set;
+		}
+	}
+
+	/**
+	 * Initializes the {@link ModuleRegistry} and applies all pending changes. After the initialization
+	 * completed, it is not possible to add any further modules.
+	 * 
+	 * @param objectMapper
+	 * @param resourceRegistry
+	 */
+	public void init(ObjectMapper objectMapper, ResourceRegistry resourceRegistry) {
+		this.initalized = true;
+		this.objectMapper = objectMapper;
+		this.resourceRegistry = resourceRegistry;
+		this.objectMapper.registerModules(getJacksonModules());
+
+		applyRepositoryRegistration(resourceRegistry);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private void applyRepositoryRegistration(ResourceRegistry resourceRegistry) {
+		List<RelationshipRepositoryRegistration> relationshipRepositoryRegistrations = aggregatedModule
+				.getRelationshipRepositoryRegistrations();
+		List<ResourceRepositoryRegistration> resourceRepositoryRegistrations = aggregatedModule
+				.getResourceRepositoryRegistrations();
+
+		// TODO this needs to be merged with ResourceRegistryBuilder
+		for (final ResourceRepositoryRegistration resourceRepositoryRegistration : resourceRepositoryRegistrations) {
+			Class<?> resourceClass = resourceRepositoryRegistration.getResourceClass();
+			RepositoryInstanceBuilder<ResourceRepository<?, ?>> repositoryInstanceBuilder = new RepositoryInstanceBuilder(
+					null, null) {
+				public Object buildRepository() {
+					return resourceRepositoryRegistration.getRepository();
+				}
+			};
+			DirectResponseResourceEntry resourceEntry = new DirectResponseResourceEntry(repositoryInstanceBuilder);
+			ResourceInformation resourceInformation = getResourceInformationBuilder().build(resourceClass);
+			List<ResponseRelationshipEntry> relationshipEntries = new ArrayList<ResponseRelationshipEntry>();
+			for (final RelationshipRepositoryRegistration relationshipRepositoryRegistration : relationshipRepositoryRegistrations) {
+				if (relationshipRepositoryRegistration.getSourceType() == resourceClass) {
+					RepositoryInstanceBuilder<RelationshipRepository> relationshipInstanceBuilder = new RepositoryInstanceBuilder<RelationshipRepository>(
+							null, null) {
+						public RelationshipRepository buildRepository() {
+							return relationshipRepositoryRegistration.getRepository();
+						}
+					};
+					ResponseRelationshipEntry relationshipEntry = new DirectResponseRelationshipEntry(
+							relationshipInstanceBuilder);
+					relationshipEntries.add(relationshipEntry);
+				}
+			}
+			// TODO get also relations from resource lookup
+			RegistryEntry registryEntry = new RegistryEntry(resourceInformation, resourceEntry, relationshipEntries);
+			resourceRegistry.addEntry(resourceClass, registryEntry);
+		}
+	}
+
+	/**
+	 * @return {@link Filter} added by all modules
+	 */
+	public List<Filter> getFilters() {
+		return aggregatedModule.getFilters();
+	}
+
+	/**
+	 * @return combined {@link ExceptionMapperLookup} added by all modules
+	 */
+	public ExceptionMapperLookup getExceptionMapperLookup() {
+		return new CombinedExceptionMapperLookup(aggregatedModule.getExceptionMapperLookups());
+	}
+	
+}

--- a/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
@@ -97,16 +97,19 @@ public class ModuleRegistry {
 
 		@Override
 		public void addFilter(Filter filter) {
+			checkNotInitialized();
 			aggregatedModule.addFilter(filter);			
 		}
 
 		@Override
 		public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
+			checkNotInitialized();
 			aggregatedModule.addExceptionMapperLookup(exceptionMapperLookup);			
 		}
 
 		@Override
 		public void addExceptionMapper(ExceptionMapper<?> exceptionMapper) {
+			checkNotInitialized();
 			aggregatedModule.addExceptionMapper(exceptionMapper);			
 		}
 	}

--- a/katharsis-core/src/main/java/io/katharsis/module/SimpleModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/SimpleModule.java
@@ -29,6 +29,8 @@ public class SimpleModule implements Module {
 	private List<ExceptionMapperLookup> exceptionMapperLookups = new ArrayList<ExceptionMapperLookup>();
 
 	private String moduleName;
+	
+	private ModuleContext context;
 
 	public SimpleModule(String moduleName) {
 		this.moduleName = moduleName;
@@ -41,6 +43,7 @@ public class SimpleModule implements Module {
 
 	@Override
 	public void setupModule(ModuleContext context) {
+		this.context = context;
 		for (ResourceInformationBuilder resourceInformationBuilder : resourceInformationBuilders) {
 			context.addResourceInformationBuilder(resourceInformationBuilder);
 		}
@@ -63,6 +66,12 @@ public class SimpleModule implements Module {
 			context.addExceptionMapperLookup(exceptionMapperLookup);
 		}
 	}
+	
+	private void checkInitialized(){
+		if(context != null){
+			throw new IllegalStateException("module cannot be changed addModule was called");
+		}
+	}
 
 	/**
 	 * Registers a new {@link ResourceInformationBuilder} with this module.
@@ -70,36 +79,44 @@ public class SimpleModule implements Module {
 	 * @param resourceInformationBuilder
 	 */
 	public void addResourceInformationBuilder(ResourceInformationBuilder resourceInformationBuilder) {
+		checkInitialized();
 		resourceInformationBuilders.add(resourceInformationBuilder);
 	}
 
 
 	public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
+		checkInitialized();
 		exceptionMapperLookups.add(exceptionMapperLookup);
 	}
 	
 	public void addExceptionMapper(@SuppressWarnings("rawtypes") JsonApiExceptionMapper exceptionMapper) {
+		checkInitialized();
 		ExceptionMapperLookup exceptionMapperLookup = new CollectionExceptionMapperLookup(exceptionMapper);
 		exceptionMapperLookups.add(exceptionMapperLookup);
 	}
 	
 	protected List<ResourceInformationBuilder> getResourceInformationBuilders() {
+		checkInitialized();
 		return Collections.unmodifiableList(resourceInformationBuilders);
 	}
 
 	public void addFilter(Filter filter) {
+		checkInitialized();
 		filters.add(filter);
 	}
 
 	protected List<Filter> getFilters() {
+		checkInitialized();
 		return Collections.unmodifiableList(filters);
 	}
 
 	public void addJacksonModule(com.fasterxml.jackson.databind.Module module) {
+		checkInitialized();
 		jacksonModules.add(module);
 	}
 
 	protected List<com.fasterxml.jackson.databind.Module> getJacksonModules() {
+		checkInitialized();
 		return Collections.unmodifiableList(jacksonModules);
 	}
 
@@ -109,18 +126,22 @@ public class SimpleModule implements Module {
 	 * @param resourceInformationBuilder
 	 */
 	public void addResourceLookup(ResourceLookup resourceLookup) {
+		checkInitialized();
 		resourceLookups.add(resourceLookup);
 	}
 
 	protected List<ResourceLookup> getResourceLookups() {
+		checkInitialized();
 		return Collections.unmodifiableList(resourceLookups);
 	}
 
 	public void addRepository(Class<?> type, ResourceRepository<?, ?> repository) {
+		checkInitialized();
 		resourceRepositoryRegistrations.add(new ResourceRepositoryRegistration(type, repository));
 	}
 
 	public void addRepository(Class<?> sourceType, Class<?> targetType, RelationshipRepository<?, ?, ?, ?> repository) {
+		checkInitialized();
 		relationshipRepositoryRegistrations
 				.add(new RelationshipRepositoryRegistration(sourceType, targetType, repository));
 	}

--- a/katharsis-core/src/main/java/io/katharsis/module/SimpleModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/SimpleModule.java
@@ -1,0 +1,205 @@
+package io.katharsis.module;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.errorhandling.mapper.ExceptionMapperLookup;
+import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
+import io.katharsis.repository.RelationshipRepository;
+import io.katharsis.repository.ResourceRepository;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.resource.registry.ResourceLookup;
+
+/**
+ * Vanilla {@link Module} implementation that allows registration of extensions.
+ */
+public class SimpleModule implements Module {
+
+	private List<ResourceInformationBuilder> resourceInformationBuilders = new ArrayList<ResourceInformationBuilder>();
+	private List<Filter> filters = new ArrayList<Filter>();
+	private List<ResourceLookup> resourceLookups = new ArrayList<ResourceLookup>();
+	private List<com.fasterxml.jackson.databind.Module> jacksonModules = new ArrayList<com.fasterxml.jackson.databind.Module>();
+	private List<RelationshipRepositoryRegistration> relationshipRepositoryRegistrations = new ArrayList<RelationshipRepositoryRegistration>();
+	private List<ResourceRepositoryRegistration> resourceRepositoryRegistrations = new ArrayList<ResourceRepositoryRegistration>();
+	private List<ExceptionMapperLookup> exceptionMapperLookups = new ArrayList<ExceptionMapperLookup>();
+
+	private String moduleName;
+
+	public SimpleModule(String moduleName) {
+		this.moduleName = moduleName;
+	}
+
+	@Override
+	public String getModuleName() {
+		return moduleName;
+	}
+
+	@Override
+	public void setupModule(ModuleContext context) {
+		for (ResourceInformationBuilder resourceInformationBuilder : resourceInformationBuilders) {
+			context.addResourceInformationBuilder(resourceInformationBuilder);
+		}
+		for (ResourceLookup resourceLookup : resourceLookups) {
+			context.addResourceLookup(resourceLookup);
+		}
+		for (Filter filter : filters) {
+			context.addFilter(filter);
+		}
+		for (com.fasterxml.jackson.databind.Module jacksonModule : jacksonModules) {
+			context.addJacksonModule(jacksonModule);
+		}
+		for (ResourceRepositoryRegistration reg : resourceRepositoryRegistrations) {
+			context.addRepository(reg.resourceClass, reg.repository);
+		}
+		for (RelationshipRepositoryRegistration reg : relationshipRepositoryRegistrations) {
+			context.addRepository(reg.sourceType, reg.targetType, reg.repository);
+		}
+		for (ExceptionMapperLookup exceptionMapperLookup : exceptionMapperLookups) {
+			context.addExceptionMapperLookup(exceptionMapperLookup);
+		}
+	}
+
+	/**
+	 * Registers a new {@link ResourceInformationBuilder} with this module.
+	 * 
+	 * @param resourceInformationBuilder
+	 */
+	public void addResourceInformationBuilder(ResourceInformationBuilder resourceInformationBuilder) {
+		resourceInformationBuilders.add(resourceInformationBuilder);
+	}
+
+
+	public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
+		exceptionMapperLookups.add(exceptionMapperLookup);
+	}
+	
+	public void addExceptionMapper(@SuppressWarnings("rawtypes") JsonApiExceptionMapper exceptionMapper) {
+		ExceptionMapperLookup exceptionMapperLookup = new CollectionExceptionMapperLookup(exceptionMapper);
+		exceptionMapperLookups.add(exceptionMapperLookup);
+	}
+	
+	protected List<ResourceInformationBuilder> getResourceInformationBuilders() {
+		return Collections.unmodifiableList(resourceInformationBuilders);
+	}
+
+	public void addFilter(Filter filter) {
+		filters.add(filter);
+	}
+
+	protected List<Filter> getFilters() {
+		return Collections.unmodifiableList(filters);
+	}
+
+	public void addJacksonModule(com.fasterxml.jackson.databind.Module module) {
+		jacksonModules.add(module);
+	}
+
+	protected List<com.fasterxml.jackson.databind.Module> getJacksonModules() {
+		return Collections.unmodifiableList(jacksonModules);
+	}
+
+	/**
+	 * Registers a new {@link ResourceLookup} with this module.
+	 * 
+	 * @param resourceInformationBuilder
+	 */
+	public void addResourceLookup(ResourceLookup resourceLookup) {
+		resourceLookups.add(resourceLookup);
+	}
+
+	protected List<ResourceLookup> getResourceLookups() {
+		return Collections.unmodifiableList(resourceLookups);
+	}
+
+	public void addRepository(Class<?> type, ResourceRepository<?, ?> repository) {
+		resourceRepositoryRegistrations.add(new ResourceRepositoryRegistration(type, repository));
+	}
+
+	public void addRepository(Class<?> sourceType, Class<?> targetType, RelationshipRepository<?, ?, ?, ?> repository) {
+		relationshipRepositoryRegistrations
+				.add(new RelationshipRepositoryRegistration(sourceType, targetType, repository));
+	}
+
+	public List<RelationshipRepositoryRegistration> getRelationshipRepositoryRegistrations() {
+		return Collections.unmodifiableList(relationshipRepositoryRegistrations);
+	}
+
+	public List<ResourceRepositoryRegistration> getResourceRepositoryRegistrations() {
+		return Collections.unmodifiableList(resourceRepositoryRegistrations);
+	}
+
+	public static class RelationshipRepositoryRegistration {
+
+		private Class<?> sourceType;
+		private Class<?> targetType;
+		private RelationshipRepository<?, ?, ?, ?> repository;
+
+		public RelationshipRepositoryRegistration(Class<?> sourceType, Class<?> targetType,
+				RelationshipRepository<?, ?, ?, ?> repository) {
+			this.sourceType = sourceType;
+			this.targetType = targetType;
+			this.repository = repository;
+		}
+
+		public Class<?> getSourceType() {
+			return sourceType;
+		}
+
+		public Class<?> getTargetType() {
+			return targetType;
+		}
+
+		public RelationshipRepository<?, ?, ?, ?> getRepository() {
+			return repository;
+		}
+
+	}
+
+	public static class ResourceRepositoryRegistration {
+
+		private Class<?> resourceClass;
+		private ResourceRepository<?, ?> repository;
+
+		public ResourceRepositoryRegistration(Class<?> resourceClass, ResourceRepository<?, ?> repository) {
+			this.resourceClass = resourceClass;
+			this.repository = repository;
+		}
+
+		public Class<?> getResourceClass() {
+			return resourceClass;
+		}
+
+		public ResourceRepository<?, ?> getRepository() {
+			return repository;
+		}
+	}
+
+	public List<ExceptionMapperLookup> getExceptionMapperLookups() {
+		return Collections.unmodifiableList(exceptionMapperLookups);
+	}
+	
+
+	@SuppressWarnings("rawtypes")
+	private static class CollectionExceptionMapperLookup implements ExceptionMapperLookup {
+
+		private Set<JsonApiExceptionMapper> set;
+
+		private CollectionExceptionMapperLookup(Set<JsonApiExceptionMapper> set) {
+			this.set = set;
+		}
+
+		public CollectionExceptionMapperLookup(JsonApiExceptionMapper exceptionMapper) {
+			this(new HashSet<JsonApiExceptionMapper>(Arrays.asList(exceptionMapper)));
+		}
+
+		@Override
+		public Set<JsonApiExceptionMapper> getExceptionMappers() {
+			return set;
+		}
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/AnnotationResourceInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/AnnotationResourceInformationBuilder.java
@@ -51,6 +51,11 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
     public AnnotationResourceInformationBuilder(ResourceFieldNameTransformer resourceFieldNameTransformer) {
         this.resourceFieldNameTransformer = resourceFieldNameTransformer;
     }
+    
+    @Override
+	public boolean accept(Class<?> resourceClass) {
+		return resourceClass.getAnnotation(JsonApiResource.class) != null;
+	}
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public ResourceInformation build(Class<?> resourceClass) {

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformationBuilder.java
@@ -4,7 +4,17 @@ package io.katharsis.resource.information;
  * A builder which creates ResourceInformation instances of a specific class.
  */
 public interface ResourceInformationBuilder {
+	
+	/**
+	 * @param resourceClass
+	 * @return true if this builder can process the provided resource class
+	 */
+	public boolean accept(Class<?> resourceClass);
 
+	/**
+	 * @param resourceClass
+	 * @return ResourceInformation for the provided resource class.
+	 */
     public ResourceInformation build(Class<?> resourceClass);
 
 }

--- a/katharsis-core/src/test/java/io/katharsis/dispatcher/RequestDispatcherTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/dispatcher/RequestDispatcherTest.java
@@ -5,6 +5,7 @@ import io.katharsis.dispatcher.registry.ControllerRegistry;
 import io.katharsis.errorhandling.ErrorResponse;
 import io.katharsis.errorhandling.mapper.ExceptionMapperRegistryTest;
 import io.katharsis.locator.SampleJsonServiceLocator;
+import io.katharsis.module.ModuleRegistry;
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.repository.RepositoryMethodParameterProvider;
 import io.katharsis.request.dto.RequestBody;
@@ -40,6 +41,8 @@ public class RequestDispatcherTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+	private ModuleRegistry moduleRegistry;
+
     @Before
     public void prepare() {
         ResourceInformationBuilder resourceInformationBuilder = new AnnotationResourceInformationBuilder(
@@ -48,8 +51,10 @@ public class RequestDispatcherTest {
             resourceInformationBuilder);
         resourceRegistry = registryBuilder
             .build(ResourceRegistryBuilderTest.TEST_MODELS_PACKAGE, ResourceRegistryTest.TEST_MODELS_URL);
+        
+        moduleRegistry = new ModuleRegistry();
     }
-
+    
     @Test
     public void onGivenPathAndRequestTypeControllerShouldHandleRequest() throws Exception {
         // GIVEN
@@ -60,7 +65,7 @@ public class RequestDispatcherTest {
         ControllerRegistry controllerRegistry = new ControllerRegistry(null);
         CollectionGet collectionGet = mock(CollectionGet.class);
         controllerRegistry.addController(collectionGet);
-        RequestDispatcher sut = new RequestDispatcher(controllerRegistry, null);
+        RequestDispatcher sut = new RequestDispatcher(moduleRegistry, controllerRegistry, null);
 
         // WHEN
         when(collectionGet.isAcceptable(any(JsonPath.class), eq(requestType))).thenCallRealMethod();
@@ -78,7 +83,7 @@ public class RequestDispatcherTest {
         //noinspection unchecked
         when(controllerRegistry.getController(any(JsonPath.class), anyString())).thenThrow(IllegalStateException.class);
 
-        RequestDispatcher requestDispatcher = new RequestDispatcher(controllerRegistry,
+        RequestDispatcher requestDispatcher = new RequestDispatcher(moduleRegistry, controllerRegistry,
             ExceptionMapperRegistryTest.exceptionMapperRegistry);
 
         BaseResponseContext response = requestDispatcher.dispatchRequest(null, null, null, null, null);
@@ -97,7 +102,7 @@ public class RequestDispatcherTest {
         //noinspection unchecked
         when(controllerRegistry.getController(any(JsonPath.class), anyString())).thenThrow(ArithmeticException.class);
 
-        RequestDispatcher requestDispatcher = new RequestDispatcher(controllerRegistry,
+        RequestDispatcher requestDispatcher = new RequestDispatcher(moduleRegistry, controllerRegistry,
             ExceptionMapperRegistryTest.exceptionMapperRegistry);
 
         expectedException.expect(ArithmeticException.class);

--- a/katharsis-core/src/test/java/io/katharsis/dispatcher/filter/FilterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/dispatcher/filter/FilterTest.java
@@ -17,6 +17,8 @@ import io.katharsis.dispatcher.RequestDispatcher;
 import io.katharsis.dispatcher.controller.collection.CollectionGet;
 import io.katharsis.dispatcher.registry.ControllerRegistry;
 import io.katharsis.locator.SampleJsonServiceLocator;
+import io.katharsis.module.ModuleRegistry;
+import io.katharsis.module.SimpleModule;
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.repository.RepositoryMethodParameterProvider;
 import io.katharsis.repository.mock.NewInstanceRepositoryMethodParameterProvider;
@@ -37,12 +39,15 @@ public class FilterTest {
 	private RequestDispatcher dispatcher;
 	private CollectionGet collectionGet;
 	private PathBuilder pathBuilder;
+	private ModuleRegistry moduleRegistry;
 
 	String path = "/tasks/";
 	String requestType = "GET";
 
 	@Before
 	public void prepare() {
+		moduleRegistry = new ModuleRegistry();
+		
 		ResourceInformationBuilder resourceInformationBuilder = new AnnotationResourceInformationBuilder(
 				new ResourceFieldNameTransformer());
 		ResourceRegistryBuilder registryBuilder = new ResourceRegistryBuilder(new SampleJsonServiceLocator(),
@@ -53,14 +58,18 @@ public class FilterTest {
 		ControllerRegistry controllerRegistry = new ControllerRegistry(null);
 		collectionGet = mock(CollectionGet.class);
 		controllerRegistry.addController(collectionGet);
-		dispatcher = new RequestDispatcher(controllerRegistry, null);
+		dispatcher = new RequestDispatcher(moduleRegistry, controllerRegistry, null);
 	}
 
 	@Test
 	public void test() throws Exception {
+		
 		// GIVEN
 		filter = mock(TestFilter.class);
-		dispatcher.addFilter(filter);
+		
+		SimpleModule filterModule = new SimpleModule("filter");
+		filterModule.addFilter(filter);
+		moduleRegistry.addModule(filterModule);
 
 		// WHEN
 		ArgumentCaptor<FilterRequestContext> captor = ArgumentCaptor.forClass(FilterRequestContext.class);

--- a/katharsis-core/src/test/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryTest.java
@@ -1,15 +1,18 @@
 package io.katharsis.errorhandling.mapper;
 
-import io.katharsis.errorhandling.ErrorResponse;
-import io.katharsis.response.HttpStatus;
-import io.katharsis.utils.java.Optional;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.ClosedFileSystemException;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.errorhandling.ErrorResponse;
+import io.katharsis.response.HttpStatus;
+import io.katharsis.utils.java.Optional;
 
 public class ExceptionMapperRegistryTest {
 
@@ -17,56 +20,128 @@ public class ExceptionMapperRegistryTest {
     public static final ExceptionMapperRegistry exceptionMapperRegistry = new ExceptionMapperRegistry(exceptionMapperTypeSet());
 
     @Test
-    public void shouldReturnIntegerMAXForNotRelatedClasses() {
+    public void shouldReturnIntegerMAXForNotRelatedClassesFromException() {
         int distance = exceptionMapperRegistry.getDistanceBetweenExceptions(Exception.class, SomeException.class);
         assertThat(distance).isEqualTo(Integer.MAX_VALUE);
     }
 
     @Test
-    public void shouldReturn0DistanceBetweenSameClass() throws Exception {
+    public void shouldReturn0DistanceBetweenSameClassFromException() throws Exception {
         int distance = exceptionMapperRegistry.getDistanceBetweenExceptions(Exception.class, Exception.class);
         assertThat(distance).isEqualTo(0);
     }
 
     @Test
-    public void shouldReturn1AsADistanceBetweenSameClass() throws Exception {
+    public void shouldReturn1AsADistanceBetweenSameClassFromException() throws Exception {
         int distance = exceptionMapperRegistry.getDistanceBetweenExceptions(SomeException.class, Exception.class);
         assertThat(distance).isEqualTo(1);
     }
 
     @Test
-    public void shouldNotFindMapperIfSuperClassIsNotMapped() throws Exception {
+    public void shouldNotFindMapperIfSuperClassIsNotMappedFromException() throws Exception {
         Optional<JsonApiExceptionMapper> mapper = exceptionMapperRegistry.findMapperFor(RuntimeException.class);
         assertThat(mapper.isPresent()).isFalse();
     }
 
     @Test
-    public void shouldFindDirectExceptionMapper() throws Exception {
+    public void shouldFindDirectExceptionMapperFromException() throws Exception {
         Optional<JsonApiExceptionMapper> mapper = exceptionMapperRegistry.findMapperFor(IllegalStateException.class);
         assertThat(mapper.isPresent()).isTrue();
         assertThat(mapper.get()).isExactlyInstanceOf(IllegalStateExceptionMapper.class);
     }
 
     @Test
-    public void shouldFindDescendantExceptionMapper() throws Exception {
+    public void shouldFindDescendantExceptionMapperFromException() throws Exception {
         Optional<JsonApiExceptionMapper> mapper = exceptionMapperRegistry.findMapperFor(ClosedFileSystemException.class);
         assertThat(mapper.isPresent()).isTrue();
         assertThat(mapper.get()).isExactlyInstanceOf(IllegalStateExceptionMapper.class);
     }
-
+    
+    @Test
+    public void shouldFindDirectExceptionMapperFromError() throws Exception {
+    	ErrorResponse response = ErrorResponse.builder().setStatus(HttpStatus.BAD_REQUEST_400).build();
+        Optional<ExceptionMapper<?>> mapper = exceptionMapperRegistry.findMapperFor(response);
+        assertThat(mapper.isPresent()).isTrue();
+        assertThat(mapper.get()).isExactlyInstanceOf(IllegalStateExceptionMapper.class);
+        Throwable throwable = mapper.get().fromErrorResponse(response);
+        assertThat(throwable).isExactlyInstanceOf(IllegalStateException.class);
+    }
+    
+    @Test
+    public void shouldFindDescendantExceptionMapperFromError() throws Exception {
+    	// two exception mapper will match (IllegalStateException and SomeIllegalStateException)
+    	// subtype should be choosen.
+    	ErrorData errorData = ErrorData.builder().setId("someId").build();
+    	ErrorResponse response = ErrorResponse.builder().setStatus(HttpStatus.BAD_REQUEST_400).setSingleErrorData(errorData).build();
+        Optional<ExceptionMapper<?>> mapper = exceptionMapperRegistry.findMapperFor(response);
+        assertThat(mapper.isPresent()).isTrue();
+        assertThat(mapper.get()).isExactlyInstanceOf(SomeIllegalStateExceptionMapper.class);
+        Throwable throwable = mapper.get().fromErrorResponse(response);
+        assertThat(throwable).isExactlyInstanceOf(SomeIllegalStateException.class);
+    }
+    
+    @Test
+    public void shouldNotFindDescendantExceptionMapperFromError() throws Exception {
+    	ErrorData errorData = ErrorData.builder().setId("someOtherId").build();
+    	ErrorResponse response = ErrorResponse.builder().setStatus(HttpStatus.BAD_REQUEST_400).setSingleErrorData(errorData).build();
+        Optional<ExceptionMapper<?>> mapper = exceptionMapperRegistry.findMapperFor(response);
+        assertThat(mapper.isPresent()).isTrue();
+        assertThat(mapper.get()).isExactlyInstanceOf(IllegalStateExceptionMapper.class);
+    }
+    
     private static class SomeException extends Exception {
+
+    	private static final long serialVersionUID = 1L;
+    }
+    
+    private static class SomeIllegalStateException extends IllegalStateException {
+
+		private static final long serialVersionUID = 1L;
     }
 
     private static Set<ExceptionMapperType> exceptionMapperTypeSet() {
         Set<ExceptionMapperType> types = new HashSet<>();
         types.add(new ExceptionMapperType(IllegalStateException.class, new IllegalStateExceptionMapper()));
+        types.add(new ExceptionMapperType(SomeIllegalStateException.class, new SomeIllegalStateExceptionMapper()));
         return types;
     }
 
-    public static class IllegalStateExceptionMapper implements JsonApiExceptionMapper<IllegalStateException> {
+    public static class IllegalStateExceptionMapper implements ExceptionMapper<IllegalStateException> {
         @Override
         public ErrorResponse toErrorResponse(IllegalStateException exception) {
             return ErrorResponse.builder().setStatus(HttpStatus.BAD_REQUEST_400).build();
         }
+
+		@Override
+		public IllegalStateException fromErrorResponse(ErrorResponse errorResponse) {
+			return new IllegalStateException();
+		}
+
+		@Override
+		public boolean accepts(ErrorResponse errorResponse) {
+			return errorResponse.getHttpStatus() == HttpStatus.BAD_REQUEST_400;
+		}
+    }
+    
+    public static class SomeIllegalStateExceptionMapper implements ExceptionMapper<SomeIllegalStateException> {
+        @Override
+        public ErrorResponse toErrorResponse(SomeIllegalStateException exception) {
+        	ErrorData errorData = ErrorData.builder().setId("someId").build();
+            return ErrorResponse.builder().setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500).setSingleErrorData(errorData).build();
+        }
+
+		@Override
+		public SomeIllegalStateException fromErrorResponse(ErrorResponse errorResponse) {
+			return new SomeIllegalStateException();
+		}
+
+		@Override
+		public boolean accepts(ErrorResponse errorResponse) {
+			if(errorResponse.getHttpStatus() == HttpStatus.BAD_REQUEST_400 && errorResponse.getErrors() != null){
+				Iterator<ErrorData> errors = errorResponse.getErrors().iterator();
+				return errors.hasNext() && "someId".equals(errors.next().getId());
+			}
+			return false;
+		}
     }
 }

--- a/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
@@ -1,0 +1,222 @@
+package io.katharsis.module;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.dispatcher.filter.TestFilter;
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.RelationshipRepository;
+import io.katharsis.resource.annotations.JsonApiId;
+import io.katharsis.resource.annotations.JsonApiResource;
+import io.katharsis.resource.field.ResourceFieldNameTransformer;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.resource.mock.models.ComplexPojo;
+import io.katharsis.resource.mock.models.Document;
+import io.katharsis.resource.mock.models.FancyProject;
+import io.katharsis.resource.mock.models.Project;
+import io.katharsis.resource.mock.models.Task;
+import io.katharsis.resource.mock.models.Thing;
+import io.katharsis.resource.mock.models.User;
+import io.katharsis.resource.mock.repository.DocumentRepository;
+import io.katharsis.resource.mock.repository.PojoRepository;
+import io.katharsis.resource.mock.repository.ProjectRepository;
+import io.katharsis.resource.mock.repository.ResourceWithoutRepositoryToProjectRepository;
+import io.katharsis.resource.mock.repository.TaskToProjectRepository;
+import io.katharsis.resource.mock.repository.TaskWithLookupRepository;
+import io.katharsis.resource.mock.repository.UserRepository;
+import io.katharsis.resource.mock.repository.UserToProjectRepository;
+import io.katharsis.resource.registry.RegistryEntry;
+import io.katharsis.resource.registry.ResourceLookup;
+import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.resource.registry.repository.DirectResponseRelationshipEntry;
+
+public class ModuleTest {
+
+	private ResourceRegistry resourceRegistry;
+	private ModuleRegistry moduleRegistry;
+
+	@Before
+	public void setup() {
+		resourceRegistry = new ResourceRegistry("http://localhost");
+
+		moduleRegistry = new ModuleRegistry();
+		moduleRegistry.addModule(new CoreModule("io.katharsis.module.mock", new ResourceFieldNameTransformer()));
+		moduleRegistry.addModule(new TestModule());
+		moduleRegistry.init(new ObjectMapper(), resourceRegistry);
+	}
+
+	@Test
+	public void testInformationBuilder() throws Exception {
+		ResourceInformationBuilder informationBuilder = moduleRegistry.getResourceInformationBuilder();
+
+		Assert.assertTrue(informationBuilder.accept(ComplexPojo.class));
+		Assert.assertTrue(informationBuilder.accept(Document.class));
+		Assert.assertTrue(informationBuilder.accept(FancyProject.class));
+		Assert.assertTrue(informationBuilder.accept(Project.class));
+		Assert.assertTrue(informationBuilder.accept(Task.class));
+		Assert.assertTrue(informationBuilder.accept(Thing.class));
+		Assert.assertTrue(informationBuilder.accept(User.class));
+		Assert.assertTrue(informationBuilder.accept(TestResource.class));
+
+		Assert.assertFalse(informationBuilder.accept(TestRepository.class));
+		Assert.assertFalse(informationBuilder.accept(DocumentRepository.class));
+		Assert.assertFalse(informationBuilder.accept(PojoRepository.class));
+		Assert.assertFalse(informationBuilder.accept(ProjectRepository.class));
+		Assert.assertFalse(informationBuilder.accept(ResourceWithoutRepositoryToProjectRepository.class));
+		Assert.assertFalse(informationBuilder.accept(TaskToProjectRepository.class));
+		Assert.assertFalse(informationBuilder.accept(TaskWithLookupRepository.class));
+		Assert.assertFalse(informationBuilder.accept(UserRepository.class));
+		Assert.assertFalse(informationBuilder.accept(UserToProjectRepository.class));
+
+		Assert.assertFalse(informationBuilder.accept(Object.class));
+		Assert.assertFalse(informationBuilder.accept(String.class));
+
+		try {
+			informationBuilder.build(Object.class);
+			Assert.fail();
+		} catch (UnsupportedOperationException e) {
+			// ok
+		}
+
+		ResourceInformation userInfo = informationBuilder.build(User.class);
+		Assert.assertEquals("id", userInfo.getIdField().getUnderlyingName());
+
+		ResourceInformation testInfo = informationBuilder.build(TestResource.class);
+		Assert.assertEquals("id", testInfo.getIdField().getUnderlyingName());
+		Assert.assertEquals("testId", testInfo.getIdField().getJsonName());
+	}
+
+	@Test
+	public void testResourceLookup() throws Exception {
+		ResourceLookup resourceLookup = moduleRegistry.getResourceLookup();
+
+		Assert.assertFalse(resourceLookup.getResourceClasses().contains(Object.class));
+		Assert.assertFalse(resourceLookup.getResourceClasses().contains(String.class));
+		Assert.assertTrue(resourceLookup.getResourceClasses().contains(TestResource.class));
+
+		Assert.assertFalse(resourceLookup.getResourceRepositoryClasses().contains(Object.class));
+		Assert.assertFalse(resourceLookup.getResourceRepositoryClasses().contains(String.class));
+		Assert.assertTrue(resourceLookup.getResourceRepositoryClasses().contains(TestRepository.class));
+	}
+
+	@Test
+	public void testJacksonModule() throws Exception {
+		List<com.fasterxml.jackson.databind.Module> jacksonModules = moduleRegistry.getJacksonModules();
+		Assert.assertEquals(1, jacksonModules.size());
+		com.fasterxml.jackson.databind.Module jacksonModule = jacksonModules.get(0);
+		Assert.assertEquals("test", jacksonModule.getModuleName());
+	}
+
+	@Test
+	public void testFilter() throws Exception {
+		List<Filter> filters = moduleRegistry.getFilters();
+		Assert.assertEquals(1, filters.size());
+	}
+
+	@Test
+	public void testRepositoryRegistration() {
+		RegistryEntry<?> entry = resourceRegistry.getEntry(TestResource2.class);
+		ResourceInformation info = entry.getResourceInformation();
+		Assert.assertEquals(TestResource2.class, info.getResourceClass());
+
+		Assert.assertNotNull(entry.getResourceRepository(null));
+		List<?> relationshipEntries = entry.getRelationshipEntries();
+		Assert.assertEquals(1, relationshipEntries.size());
+		DirectResponseRelationshipEntry<?, ?> responseRelationshipEntry = (DirectResponseRelationshipEntry<?, ?>) relationshipEntries
+				.get(0);
+		Assert.assertNotNull(responseRelationshipEntry);
+	}
+
+	class TestModule implements Module {
+
+		@Override
+		public String getModuleName() {
+			return "test";
+		}
+
+		@Override
+		public void setupModule(ModuleContext context) {
+			context.addResourceLookup(new TestResourceLookup());
+			context.addResourceInformationBuilder(new TestResourceInformationBuilder());
+
+			context.addJacksonModule(new com.fasterxml.jackson.databind.module.SimpleModule() {
+				private static final long serialVersionUID = 7829254359521781942L;
+
+				@Override
+				public String getModuleName() {
+					return "test";
+				}
+			});
+
+			context.addFilter(new TestFilter());
+			context.addRepository(TestResource2.class, new TestRepository2());
+			context.addRepository(TestResource2.class, TestResource2.class, new TestRelationshipRepository2());
+
+		}
+	}
+
+	@JsonApiResource(type = "test2")
+	static class TestResource2 {
+
+		@JsonApiId
+		private int id;
+
+		private TestResource2 parent;
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		public TestResource2 getParent() {
+			return parent;
+		}
+
+		public void setParent(TestResource2 parent) {
+			this.parent = parent;
+		}
+	}
+
+	class TestRelationshipRepository2
+			implements RelationshipRepository<TestResource2, Integer, TestResource2, Integer> {
+
+		@Override
+		public void setRelation(TestResource2 source, Integer targetId, String fieldName) {
+		}
+
+		@Override
+		public void setRelations(TestResource2 source, Iterable<Integer> targetIds, String fieldName) {
+		}
+
+		@Override
+		public void addRelations(TestResource2 source, Iterable<Integer> targetIds, String fieldName) {
+		}
+
+		@Override
+		public void removeRelations(TestResource2 source, Iterable<Integer> targetIds, String fieldName) {
+		}
+
+		@Override
+		public TestResource2 findOneTarget(Integer sourceId, String fieldName, QueryParams queryParams) {
+			return null;
+		}
+
+		@Override
+		public Iterable<TestResource2> findManyTargets(Integer sourceId, String fieldName, QueryParams queryParams) {
+			return null;
+		}
+	}
+
+	class TestRepository2 extends TestRepository {
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/SimpleModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/SimpleModuleTest.java
@@ -1,0 +1,209 @@
+package io.katharsis.module;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.Module;
+
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.dispatcher.filter.TestFilter;
+import io.katharsis.errorhandling.mapper.ExceptionMapper;
+import io.katharsis.errorhandling.mapper.ExceptionMapperLookup;
+import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
+import io.katharsis.errorhandling.mapper.KatharsisExceptionMapper;
+import io.katharsis.module.Module.ModuleContext;
+import io.katharsis.repository.RelationshipRepository;
+import io.katharsis.repository.ResourceRepository;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.resource.registry.ResourceLookup;
+import io.katharsis.resource.registry.ResourceRegistry;
+
+public class SimpleModuleTest {
+
+	private TestModuleContext context;
+	private SimpleModule module;
+
+	@Before
+	public void setup() {
+		context = new TestModuleContext();
+		module = new SimpleModule("simple");
+	}
+
+	@Test
+	public void testResourceInformationBuilder() {
+		module.addResourceInformationBuilder(new TestResourceInformationBuilder());
+		Assert.assertEquals(1, module.getResourceInformationBuilders().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(1, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numResourceRepositoreis);
+		Assert.assertEquals(0, context.numRelationshipRepositories);
+	}
+
+	@Test
+	public void testResourceLookup() {
+		module.addResourceLookup(new TestResourceLookup());
+		Assert.assertEquals(1, module.getResourceLookups().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(1, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numResourceRepositoreis);
+		Assert.assertEquals(0, context.numRelationshipRepositories);
+	}
+
+	@Test
+	public void testFilter() {
+		module.addFilter(new TestFilter());
+		Assert.assertEquals(1, module.getFilters().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(1, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numResourceRepositoreis);
+		Assert.assertEquals(0, context.numRelationshipRepositories);
+	}
+
+	@Test
+	public void testJacksonModule() {
+		module.addJacksonModule(new com.fasterxml.jackson.databind.module.SimpleModule() {
+			private static final long serialVersionUID = 7829254359521781942L;
+
+			@Override
+			public String getModuleName() {
+				return "test";
+			}
+		});
+		Assert.assertEquals(1, module.getJacksonModules().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(1, context.numJacksonModules);
+		Assert.assertEquals(0, context.numResourceRepositoreis);
+		Assert.assertEquals(0, context.numRelationshipRepositories);
+	}
+
+	@Test
+	public void testResourceRepository() {
+		module.addRepository(TestResource.class, new TestRepository());
+		Assert.assertEquals(1, module.getResourceRepositoryRegistrations().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(1, context.numResourceRepositoreis);
+		Assert.assertEquals(0, context.numRelationshipRepositories);
+	}
+
+	@Test
+	public void testRelationshipRepository() {
+		module.addRepository(TestResource.class, TestResource.class, new TestRelationshipRepository());
+		Assert.assertEquals(1, module.getRelationshipRepositoryRegistrations().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numResourceRepositoreis);
+		Assert.assertEquals(1, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numExceptionMapperLookup);
+	}
+	
+	@Test
+	public void testExceptionMapperLookup() {
+		module.addExceptionMapperLookup(new TestExceptionMapperLookup());
+		Assert.assertEquals(1, module.getExceptionMapperLookups().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numResourceRepositoreis);
+		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(1, context.numExceptionMapperLookup);
+	}
+	
+	class TestExceptionMapperLookup implements ExceptionMapperLookup	{
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public Set<JsonApiExceptionMapper> getExceptionMappers() {
+			return new HashSet<JsonApiExceptionMapper>( Arrays.asList(new KatharsisExceptionMapper()));
+		}
+	}
+
+	class TestModuleContext implements ModuleContext {
+
+		private int numResourceInformationBuilds = 0;
+		private int numResourceLookups = 0;
+		private int numJacksonModules = 0;
+		private int numResourceRepositoreis = 0;
+		private int numRelationshipRepositories = 0;
+		private int numFilters = 0;
+		private int numExceptionMapperLookup = 0;
+
+		@Override
+		public void addResourceInformationBuilder(ResourceInformationBuilder resourceInformationBuilder) {
+			numResourceInformationBuilds++;
+		}
+
+		@Override
+		public void addResourceLookup(ResourceLookup resourceLookup) {
+			numResourceLookups++;
+		}
+
+		@Override
+		public void addJacksonModule(Module module) {
+			numJacksonModules++;
+		}
+
+		@Override
+		public void addRepository(Class<?> resourceClass, ResourceRepository<?, ?> repository) {
+			numResourceRepositoreis++;
+		}
+
+		@Override
+		public void addRepository(Class<?> sourceResourceClass, Class<?> targetResourceClass,
+				RelationshipRepository<?, ?, ?, ?> repository) {
+			numRelationshipRepositories++;
+		}
+
+		@Override
+		public void addFilter(Filter filter) {
+			numFilters++;
+		}
+
+		@Override
+		public ResourceRegistry getResourceRegistry() {
+			return new ResourceRegistry(null);
+		}
+
+		@Override
+		public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
+			numExceptionMapperLookup++;
+		}
+
+		@Override
+		public void addExceptionMapper(ExceptionMapper<?> exceptionMapper) {
+			numExceptionMapperLookup++;
+		}
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/TestRelationshipRepository.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestRelationshipRepository.java
@@ -1,0 +1,33 @@
+package io.katharsis.module;
+
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.RelationshipRepository;
+
+class TestRelationshipRepository implements RelationshipRepository<TestResource, Integer, TestResource, Integer> {
+
+	@Override
+	public void setRelation(TestResource source, Integer targetId, String fieldName) {
+	}
+
+	@Override
+	public void setRelations(TestResource source, Iterable<Integer> targetIds, String fieldName) {
+	}
+
+	@Override
+	public void addRelations(TestResource source, Iterable<Integer> targetIds, String fieldName) {
+	}
+
+	@Override
+	public void removeRelations(TestResource source, Iterable<Integer> targetIds, String fieldName) {
+	}
+
+	@Override
+	public TestResource findOneTarget(Integer sourceId, String fieldName, QueryParams queryParams) {
+		return null;
+	}
+
+	@Override
+	public Iterable<TestResource> findManyTargets(Integer sourceId, String fieldName, QueryParams queryParams) {
+		return null;
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/TestRepository.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestRepository.java
@@ -1,0 +1,31 @@
+package io.katharsis.module;
+
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.ResourceRepository;
+
+class TestRepository implements ResourceRepository<TestResource, Integer> {
+
+	@Override
+	public TestResource findOne(Integer id, QueryParams queryParams) {
+		return null;
+	}
+
+	@Override
+	public Iterable<TestResource> findAll(QueryParams queryParams) {
+		return null;
+	}
+
+	@Override
+	public Iterable<TestResource> findAll(Iterable<Integer> ids, QueryParams queryParams) {
+		return null;
+	}
+
+	@Override
+	public <S extends TestResource> S save(S entity) {
+		return null;
+	}
+
+	@Override
+	public void delete(Integer id) {
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResource.java
@@ -1,0 +1,14 @@
+package io.katharsis.module;
+
+class TestResource {
+
+	private int id;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResourceInformationBuilder.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResourceInformationBuilder.java
@@ -1,0 +1,28 @@
+package io.katharsis.module;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.katharsis.resource.field.ResourceAttributesBridge;
+import io.katharsis.resource.field.ResourceField;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+
+class TestResourceInformationBuilder implements ResourceInformationBuilder {
+
+	@Override
+	public boolean accept(Class<?> resourceClass) {
+		return resourceClass == TestResource.class;
+	}
+
+	@Override
+	public ResourceInformation build(Class<?> resourceClass) {
+		ResourceField idField = new ResourceField("testId", "id", Integer.class, null);
+		ResourceAttributesBridge<?> attributeFields = null;
+		Set<ResourceField> relationshipFields = new HashSet<ResourceField>();
+		ResourceInformation info = new ResourceInformation(resourceClass, resourceClass.getSimpleName(), idField,
+				attributeFields, relationshipFields);
+		return info;
+	}
+
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResourceLookup.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResourceLookup.java
@@ -1,0 +1,20 @@
+package io.katharsis.module;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.katharsis.resource.registry.ResourceLookup;
+
+class TestResourceLookup implements ResourceLookup {
+
+	@Override
+	public Set<Class<?>> getResourceClasses() {
+		return new HashSet<Class<?>>(Arrays.asList(TestResource.class));
+	}
+
+	@Override
+	public Set<Class<?>> getResourceRepositoryClasses() {
+		return new HashSet<Class<?>>(Arrays.asList(TestRepository.class));
+	}
+}

--- a/katharsis-spring/src/main/java/io/katharsis/spring/boot/KatharsisConfigV2.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/boot/KatharsisConfigV2.java
@@ -34,6 +34,7 @@ import javax.servlet.Filter;
         QueryParamsBuilderConfiguration.class,
     JacksonConfiguration.class,
     JsonLocatorConfiguration.class,
+    ModuleConfiguration.class,
     KatharsisRegistryConfiguration.class})
 @EnableConfigurationProperties(KatharsisSpringBootProperties.class)
 public class KatharsisConfigV2 {

--- a/katharsis-spring/src/main/java/io/katharsis/spring/boot/ModuleConfiguration.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/boot/ModuleConfiguration.java
@@ -1,0 +1,31 @@
+package io.katharsis.spring.boot;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.katharsis.module.CoreModule;
+import io.katharsis.module.ModuleRegistry;
+import io.katharsis.resource.field.ResourceFieldNameTransformer;
+
+@Configuration
+public class ModuleConfiguration {
+
+	@Autowired
+    private KatharsisSpringBootProperties properties;
+	
+	@Autowired
+	private ObjectMapper objectMapper;
+	
+	@Bean
+	public ModuleRegistry moduleRegistry() {
+		ResourceFieldNameTransformer resourceFieldNameTransformer = new ResourceFieldNameTransformer(
+				objectMapper.getSerializationConfig());
+		ModuleRegistry registry = new ModuleRegistry();
+		String resourceSearchPackage = properties.getResourcePackage();
+		registry.addModule(new CoreModule(resourceSearchPackage, resourceFieldNameTransformer));
+		return registry;
+	}
+}

--- a/katharsis-spring/src/main/java/io/katharsis/spring/boot/RequestDispatcherConfiguration.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/boot/RequestDispatcherConfiguration.java
@@ -5,6 +5,7 @@ import io.katharsis.dispatcher.RequestDispatcher;
 import io.katharsis.dispatcher.registry.ControllerRegistry;
 import io.katharsis.dispatcher.registry.ControllerRegistryBuilder;
 import io.katharsis.errorhandling.mapper.ExceptionMapperRegistry;
+import io.katharsis.module.ModuleRegistry;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.utils.parser.TypeParser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,9 @@ public class RequestDispatcherConfiguration {
 
     @Autowired
     private ObjectMapper objectMapper;
+    
+    @Autowired
+    private ModuleRegistry moduleRegistry;
 
     @Autowired
     private ResourceRegistry resourceRegistry;
@@ -30,6 +34,6 @@ public class RequestDispatcherConfiguration {
             new ControllerRegistryBuilder(resourceRegistry, typeParser, objectMapper);
         ControllerRegistry controllerRegistry = controllerRegistryBuilder.build();
 
-        return new RequestDispatcher(controllerRegistry, exceptionMapperRegistry);
+        return new RequestDispatcher(moduleRegistry, controllerRegistry, exceptionMapperRegistry);
     }
 }


### PR DESCRIPTION
- implementation similar to Jackson module implementation
- Module interface that provides hooks into Katharsis
- Currently supports to add:
 - repositories
 - exception mappers
 - filters
 - jackson modules
 - information builders
- CoreModule provides current Katharsis functionality
- initial implementation
 - only a minimal set of classes touched
 - future extensions possible
 - CoreModule might grow a bit
 - the use of internal packages should be considered in the future
within Katharsis-core to declare what API is accessible to modules.
- SimpleModule implementation has a starting point to write own modules
- ModuleRegistry as container to hold all modules
- Spring, Servlet, JAX-RS implementations updated and support new method
"addModule(Module)".