### PR TITLE
Getting Katharsis to adhere to the Json api specification for query parameters (#113)

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/queryParams/DefaultQueryParamsParser.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/DefaultQueryParamsParser.java
@@ -17,65 +17,377 @@
 
 package io.katharsis.queryParams;
 
+import io.katharsis.jackson.exception.ParametersDeserializationException;
+import io.katharsis.queryParams.context.QueryParamsParserContext;
+import io.katharsis.queryParams.include.Inclusion;
+import io.katharsis.queryParams.params.*;
 import io.katharsis.resource.RestrictedQueryParamsMembers;
+import io.katharsis.utils.StringUtils;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+/**
+ * The default QueryParamsParser implementation which parses query parameters with the behavior
+ * specified in the Katharsis documentation.  This parser does NOT adhere to the JSON-API specification,
+ * but it does provide more flexibility.  If you need to adhere to the spec, use {@link JsonApiQueryParamsParser}
+ */
 public class DefaultQueryParamsParser implements QueryParamsParser {
 
-    @Override
-    public Map<String, Set<String>> parseFiltersParameters(final Map<String, Set<String>> queryParams) {
+    /**
+     * <strong>Important!</strong> Katharsis implementation differs form JSON API
+     * <a href="http://jsonapi.org/format/#fetching-filtering">definition of filtering</a>
+     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
+     * <p>
+     * Filter params can be send with following format (Katharsis does not specify or implement any operators): <br>
+     * <strong>filter[ResourceType][property|operator]([property|operator])* = "value"</strong><br>
+     * <p>
+     * Examples of accepted filtering of resources:
+     * <ul>
+     * <li>{@code GET /tasks/?filter[tasks][name]=Super task}</li>
+     * <li>{@code GET /tasks/?filter[tasks][name]=Super task&filter[tasks][dueDate]=2015-10-01}</li>
+     * <li>{@code GET /tasks/?filter[tasks][name][$startWith]=Super task}</li>
+     * <li>{@code GET /tasks/?filter[tasks][name][][$startWith]=Super&filter[tasks][name][][$endWith]=task}</li>
+     * </ul>
+     *
+     * @return {@link TypedParams} Map of filtering params passed to a request grouped by type of resource
+     */
+    protected TypedParams<FilterParams> parseFiltersParameters(final QueryParamsParserContext context) {
         String filterKey = RestrictedQueryParamsMembers.filter.name();
-        return filterQueryParamsByKey(queryParams, filterKey);
+        Map<String, Set<String>> filters = filterQueryParamsByKey(context, filterKey);
+
+        Map<String, Map<String, Set<String>>> temporaryFiltersMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : filters.entrySet()) {
+
+            List<String> propertyList = buildPropertyListFromEntry(entry, filterKey);
+
+            String resourceType = propertyList.get(0);
+            String propertyPath = StringUtils.join(".", propertyList.subList(1, propertyList.size()));
+
+            if (temporaryFiltersMap.containsKey(resourceType)) {
+                Map<String, Set<String>> resourceParams = temporaryFiltersMap.get(resourceType);
+                resourceParams.put(propertyPath, Collections.unmodifiableSet(entry.getValue()));
+            } else {
+                Map<String, Set<String>> resourceParams = new LinkedHashMap<>();
+                temporaryFiltersMap.put(resourceType, resourceParams);
+                resourceParams.put(propertyPath, entry.getValue());
+            }
+        }
+
+        Map<String, FilterParams> decodedFiltersMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Map<String, Set<String>>> resourceTypesMap : temporaryFiltersMap.entrySet()) {
+            Map<String, Set<String>> filtersMap = Collections.unmodifiableMap(resourceTypesMap.getValue());
+            decodedFiltersMap.put(resourceTypesMap.getKey(), new FilterParams(filtersMap));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedFiltersMap));
     }
 
-    @Override
-    public Map<String, Set<String>> parseSortingParameters(final Map<String, Set<String>> queryParams) {
+    /**
+     * <strong>Important!</strong> Katharsis implementation differs form JSON API
+     * <a href="http://jsonapi.org/format/#fetching-sorting">definition of sorting</a>
+     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
+     * <p>
+     * Sort params can be send with following format: <br>
+     * <strong>sort[ResourceType][property]([property])* = "asc|desc"</strong>
+     * <p>
+     * Examples of accepted sorting of resources:
+     * <ul>
+     * <li>{@code GET /tasks/?sort[tasks][name]=asc}</li>
+     * <li>{@code GET /project/?sort[projects][shortName]=desc&sort[users][name][firstName]=asc}</li>
+     * </ul>
+     *
+     * @return {@link TypedParams} Map of sorting params passed to request grouped by type of resource
+     */
+    protected TypedParams<SortingParams> parseSortingParameters(final QueryParamsParserContext context) {
         String sortingKey = RestrictedQueryParamsMembers.sort.name();
-        return filterQueryParamsByKey(queryParams, sortingKey);
+        Map<String, Set<String>> sorting = filterQueryParamsByKey(context, sortingKey);
+
+        Map<String, Map<String, RestrictedSortingValues>> temporarySortingMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : sorting.entrySet()) {
+
+            List<String> propertyList = buildPropertyListFromEntry(entry, sortingKey);
+
+            String resourceType = propertyList.get(0);
+            String propertyPath = StringUtils.join(".", propertyList.subList(1, propertyList.size()));
+
+
+            if (temporarySortingMap.containsKey(resourceType)) {
+                Map<String, RestrictedSortingValues> resourceParams = temporarySortingMap.get(resourceType);
+                resourceParams.put(propertyPath, RestrictedSortingValues.valueOf(entry.getValue()
+                    .iterator()
+                    .next()));
+            } else {
+                Map<String, RestrictedSortingValues> resourceParams = new HashMap<>();
+                temporarySortingMap.put(resourceType, resourceParams);
+                resourceParams.put(propertyPath, RestrictedSortingValues.valueOf(entry.getValue()
+                    .iterator()
+                    .next()));
+            }
+        }
+
+        Map<String, SortingParams> decodedSortingMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Map<String, RestrictedSortingValues>> resourceTypesMap : temporarySortingMap.entrySet()) {
+            Map<String, RestrictedSortingValues> sortingMap = Collections.unmodifiableMap(resourceTypesMap.getValue());
+            decodedSortingMap.put(resourceTypesMap.getKey(), new SortingParams(sortingMap));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedSortingMap));
     }
 
-    @Override
-    public Map<String, Set<String>> parseGroupingParameters(final Map<String, Set<String>> queryParams) {
+    /**
+     * <strong>Important: </strong> Grouping itself is not specified by JSON API itself, but the
+     * keyword and format it reserved for today and future use in Katharsis.
+     * <p>
+     * Group params can be send with following format: <br>
+     * <strong>group[ResourceType] = "property(.property)*"</strong>
+     * <p>
+     * Examples of accepted grouping of resources:
+     * <ul>
+     * <li>{@code GET /tasks/?group[tasks]=name}</li>
+     * <li>{@code GET /project/?group[users]=name.firstName&include[projects]=team}</li>
+     * </ul>
+     *
+     * @return {@link Map} Map of grouping params passed to request grouped by type of resource
+     */
+    protected TypedParams<GroupingParams> parseGroupingParameters(final QueryParamsParserContext context) {
         String groupingKey = RestrictedQueryParamsMembers.group.name();
-        return filterQueryParamsByKey(queryParams, groupingKey);
+        Map<String, Set<String>> grouping =  filterQueryParamsByKey(context, groupingKey);
+
+        Map<String, Set<String>> temporaryGroupingMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : grouping.entrySet()) {
+
+            List<String> propertyList = buildPropertyListFromEntry(entry, groupingKey);
+
+            if (propertyList.size() > 1) {
+                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'group' parameter " +
+                        "(1) eg. group[tasks][name] <-- #2 level and more are not allowed");
+            }
+
+            String resourceType = propertyList.get(0);
+
+            if (temporaryGroupingMap.containsKey(resourceType)) {
+                Set<String> resourceParams = temporaryGroupingMap.get(resourceType);
+                resourceParams.addAll(entry.getValue());
+                temporaryGroupingMap.put(resourceType, resourceParams);
+            } else {
+                Set<String> resourceParams = new LinkedHashSet<>();
+                resourceParams.addAll(entry.getValue());
+                temporaryGroupingMap.put(resourceType, resourceParams);
+            }
+        }
+
+        Map<String, GroupingParams> decodedGroupingMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> resourceTypesMap : temporaryGroupingMap.entrySet()) {
+            Set<String> groupingSet = Collections.unmodifiableSet(resourceTypesMap.getValue());
+            decodedGroupingMap.put(resourceTypesMap.getKey(), new GroupingParams(groupingSet));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedGroupingMap));
     }
 
-    @Override
-    public Map<String, Set<String>> parseIncludedFieldsParameters(final Map<String, Set<String>> queryParams) {
+    /**
+     * <strong>Important!</strong> Katharsis implementation differs form JSON API
+     * <a href="http://jsonapi.org/format/#fetching-sparse-fieldsets">definition of sparse field set</a>
+     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
+     * <p>
+     * Sparse field set params can be send with following format: <br>
+     * <strong>fields[ResourceType] = "property(.property)*"</strong><br>
+     * <p>
+     * Examples of accepted sparse field sets of resources:
+     * <ul>
+     * <li>{@code GET /tasks/?fields[tasks]=name}</li>
+     * <li>{@code GET /tasks/?fields[tasks][]=name&fields[tasks][]=dueDate}</li>
+     * <li>{@code GET /tasks/?fields[users]=name.surname&include[tasks]=author}</li>
+     * </ul>
+     *
+     * @return {@link TypedParams} Map of sparse field set params passed to a request grouped by type of resource
+     */
+    protected TypedParams<IncludedFieldsParams> parseIncludedFieldsParameters(final QueryParamsParserContext context) {
         String sparseKey = RestrictedQueryParamsMembers.fields.name();
-        return filterQueryParamsByKey(queryParams, sparseKey);
+        Map<String, Set<String>> sparse = filterQueryParamsByKey(context, sparseKey);
+
+        Map<String, Set<String>> temporarySparseMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : sparse.entrySet()) {
+            List<String> propertyList = buildPropertyListFromEntry(entry, sparseKey);
+
+            if (propertyList.size() > 1) {
+                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'fields' " +
+                        "parameter (1) eg. fields[tasks][name] <-- #2 level and more are not allowed");
+            }
+
+            String resourceType = propertyList.get(0);
+
+            if (temporarySparseMap.containsKey(resourceType)) {
+                Set<String> resourceParams = temporarySparseMap.get(resourceType);
+                resourceParams.addAll(entry.getValue());
+                temporarySparseMap.put(resourceType, resourceParams);
+            } else {
+                Set<String> resourceParams = new LinkedHashSet<>();
+                resourceParams.addAll(entry.getValue());
+                temporarySparseMap.put(resourceType, resourceParams);
+            }
+        }
+
+        Map<String, IncludedFieldsParams> decodedSparseMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> resourceTypesMap : temporarySparseMap.entrySet()) {
+            Set<String> sparseSet = Collections.unmodifiableSet(resourceTypesMap.getValue());
+            decodedSparseMap.put(resourceTypesMap.getKey(), new IncludedFieldsParams(sparseSet));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedSparseMap));
     }
 
-    @Override
-    public Map<String, Set<String>> parseIncludedRelationsParameters(final Map<String, Set<String>> queryParams) {
+    /**
+     * <strong>Important!</strong> Katharsis implementation differs form JSON API
+     * <a href="http://jsonapi.org/format/#fetching-includes">definition of includes</a>
+     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
+     * <p>
+     * Included field set params can be send with following format: <br>
+     * <strong>include[ResourceType] = "property(.property)*"</strong><br>
+     * <p>
+     * Examples of accepted sparse field sets of resources:
+     * <ul>
+     * <li>{@code GET /tasks/?include[tasks]=author}</li>
+     * <li>{@code GET /tasks/?include[tasks][]=author&include[tasks][]=comments}</li>
+     * <li>{@code GET /projects/?include[projects]=task&include[tasks]=comments}</li>
+     * </ul>
+     *
+     * @return {@link TypedParams} Map of sparse field set params passed to a request grouped by type of resource
+     */
+    protected TypedParams<IncludedRelationsParams> parseIncludedRelationsParameters(QueryParamsParserContext context) {
         String includeKey = RestrictedQueryParamsMembers.include.name();
-        return filterQueryParamsByKey(queryParams, includeKey);
+        Map<String, Set<String>> inclusions =  filterQueryParamsByKey(context, includeKey);
+
+        Map<String, Set<Inclusion>> temporaryInclusionsMap = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : inclusions.entrySet()) {
+            List<String> propertyList = buildPropertyListFromEntry(entry, includeKey);
+
+            if (propertyList.size() > 1) {
+                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'include' " +
+                        "parameter (1)");
+            }
+
+            String resourceType = propertyList.get(0);
+            Set<Inclusion> resourceParams;
+            if (temporaryInclusionsMap.containsKey(resourceType)) {
+                resourceParams = temporaryInclusionsMap.get(resourceType);
+            } else {
+                resourceParams = new LinkedHashSet<>();
+            }
+            for(String path : entry.getValue()) {
+                resourceParams.add(new Inclusion(path));
+            }
+            temporaryInclusionsMap.put(resourceType, resourceParams);
+        }
+
+        Map<String, IncludedRelationsParams> decodedInclusions = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<Inclusion>> resourceTypesMap : temporaryInclusionsMap.entrySet()) {
+            Set<Inclusion> inclusionSet = Collections.unmodifiableSet(resourceTypesMap.getValue());
+            decodedInclusions.put(resourceTypesMap.getKey(), new IncludedRelationsParams(inclusionSet));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedInclusions));
     }
 
-    @Override
-    public Map<String, Set<String>> parsePaginationParameters(final Map<String, Set<String>> queryParams) {
+    /**
+     * <strong>Important!</strong> Katharsis implementation sets on strategy of pagination whereas JSON API
+     * <a href="http://jsonapi.org/format/#fetching-pagination">definition of pagination</a>
+     * is agnostic about pagination strategies.
+     * <p>
+     * Pagination params can be send with following format: <br>
+     * <strong>page[offset|limit] = "value"</strong>, where value is an integer
+     * <p>
+     * Examples of accepted grouping of resources:
+     * <ul>
+     * <li>{@code GET /projects/?page[offset]=0&page[limit]=10}</li>
+     * </ul>
+     *
+     * @return {@link Map} Map of pagination keys passed to request
+     */
+    protected Map<RestrictedPaginationKeys, Integer> parsePaginationParameters(final QueryParamsParserContext context) {
         String pagingKey = RestrictedQueryParamsMembers.page.name();
-        return filterQueryParamsByKey(queryParams, pagingKey);
+        Map<String, Set<String>> pagination = filterQueryParamsByKey(context, pagingKey);
+
+        Map<RestrictedPaginationKeys, Integer> decodedPagination = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : pagination.entrySet()) {
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.page.name());
+
+            if (propertyList.size() > 1) {
+                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'page' parameter " +
+                        "(1) eg. page[offset][minimal] <-- #2 level and more are not allowed");
+            }
+
+            String resourceType = propertyList.get(0);
+
+            decodedPagination.put(RestrictedPaginationKeys.valueOf(resourceType), Integer.parseInt(entry
+                    .getValue()
+                    .iterator()
+                    .next()));
+        }
+
+        return Collections.unmodifiableMap(decodedPagination);
     }
 
     /**
      * Filters provided query params to one starting with provided string key
      *
-     * @param queryParams Request query params
+     * @param context used to inspect the parameters of the current request
      * @param queryKey    Filtering key
      * @return Filtered query params
      */
-    private static Map<String, Set<String>> filterQueryParamsByKey(Map<String, Set<String>> queryParams, String queryKey) {
+    protected Map<String, Set<String>> filterQueryParamsByKey(QueryParamsParserContext context, String queryKey) {
         Map<String, Set<String>> filteredQueryParams = new HashMap<>();
 
-        for (Map.Entry<String, Set<String>> entry : queryParams.entrySet()) {
-            if (entry.getKey().startsWith(queryKey)) {
-                filteredQueryParams.put(entry.getKey(), entry.getValue());
+        for (String paramName : context.getParameterNames()) {
+            if (paramName.startsWith(queryKey)) {
+                filteredQueryParams.put(paramName, context.getParameterValue(paramName));
             }
         }
         return filteredQueryParams;
+    }
+
+    protected static List<String> buildPropertyListFromEntry(Map.Entry<String, Set<String>> entry, String prefix) {
+        String entryKey = entry.getKey()
+                .substring(prefix.length());
+
+        String pattern = "[^\\]\\[]+(?<!\\[)(?=\\])";
+        Pattern regexp = Pattern.compile(pattern);
+        Matcher matcher = regexp.matcher(entryKey);
+        List<String> matchList = new LinkedList<>();
+
+        while (matcher.find()) {
+            matchList.add(matcher.group());
+        }
+
+        if (matchList.isEmpty()) {
+            throw new ParametersDeserializationException("Malformed filter parameter: " + entryKey);
+        }
+
+        return matchList;
+    }
+
+    @Override
+    public QueryParams parse(QueryParamsParserContext context) {
+        QueryParams queryParams = new QueryParams();
+        queryParams.setFilters(parseFiltersParameters(context));
+        queryParams.setSorting(parseSortingParameters(context));
+        queryParams.setGrouping(parseGroupingParameters(context));
+        queryParams.setPagination(parsePaginationParameters(context));
+        queryParams.setIncludedFields(parseIncludedFieldsParameters(context));
+        queryParams.setIncludedRelations(parseIncludedRelationsParameters(context));
+        return queryParams;
     }
 }

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/JsonApiQueryParamsParser.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/JsonApiQueryParamsParser.java
@@ -1,0 +1,97 @@
+package io.katharsis.queryParams;
+
+import io.katharsis.queryParams.context.QueryParamsParserContext;
+import io.katharsis.queryParams.include.Inclusion;
+import io.katharsis.queryParams.params.IncludedRelationsParams;
+import io.katharsis.queryParams.params.SortingParams;
+import io.katharsis.queryParams.params.TypedParams;
+import io.katharsis.resource.RestrictedQueryParamsMembers;
+
+import java.util.*;
+
+/**
+ * A {@link QueryParamsParser} implementation which adheres to the JSON-API standard more strictly
+ * than the DefaultQueryParamsParser, at the expense of having less flexibility.
+ */
+public class JsonApiQueryParamsParser extends DefaultQueryParamsParser {
+
+    private static final String JSON_API_SORT_INDICATOR_DESC = "-";
+    private static final String JSON_API_PARAM_DELIMITER = ",";
+
+    protected TypedParams<SortingParams> parseSortingParameters(final QueryParamsParserContext context) {
+        String sortingKey = RestrictedQueryParamsMembers.sort.name();
+        Set<String> rawSortingQueryParams = parseDelimitedParameters(context.getParameterValue(sortingKey));
+        Map<String, SortingParams> decodedSortingMap = new LinkedHashMap<>();
+
+        if (!rawSortingQueryParams.isEmpty()) {
+            Map<String, RestrictedSortingValues> temporarySortingMap = new LinkedHashMap<>();
+
+            for (String sortParam : rawSortingQueryParams) {
+                if (sortParam.startsWith(JSON_API_SORT_INDICATOR_DESC)) {
+                    temporarySortingMap.put(sortParam.substring(1), RestrictedSortingValues.desc);
+                } else {
+                    temporarySortingMap.put(sortParam, RestrictedSortingValues.asc);
+                }
+            }
+
+            decodedSortingMap.put(context.getRequestedResourceInformation().getResourceType(),
+                    new SortingParams(temporarySortingMap));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedSortingMap));
+    }
+
+    protected TypedParams<IncludedRelationsParams> parseIncludedRelationsParameters(QueryParamsParserContext context) {
+        String includeKey = RestrictedQueryParamsMembers.include.name();
+        Map<String, Set<String>> inclusions = filterQueryParamsByKey(context, includeKey);
+
+        Map<String, IncludedRelationsParams> decodedInclusions = new LinkedHashMap<>();
+
+        if (inclusions.containsKey(RestrictedQueryParamsMembers.include.name())) {
+            Set<Inclusion> inclusionSet = new LinkedHashSet<>();
+            for (String inclusion : inclusions.get(RestrictedQueryParamsMembers.include.name())) {
+                inclusionSet.add(new Inclusion(inclusion));
+            }
+            decodedInclusions.put(context.getRequestedResourceInformation().getResourceType(),
+                    new IncludedRelationsParams(inclusionSet));
+        }
+
+        return new TypedParams<>(Collections.unmodifiableMap(decodedInclusions));
+    }
+
+    /**
+     * Returns a list of all of the strings contained in parametersToParse.  If any of the
+     * strings contained in parametersToParse is a comma-delimited list, that string will be split
+     * into substrings and each substring will be added to the returned set (in place of the
+     * delimited list).
+     */
+    private static Set<String> parseDelimitedParameters(Set<String> parametersToParse) {
+        Set<String> parsedParameters = new LinkedHashSet<>();
+        if (parametersToParse != null && !parametersToParse.isEmpty()) {
+            for (String parameterToParse : parametersToParse) {
+                parsedParameters.addAll(Arrays.asList(parameterToParse.split(JSON_API_PARAM_DELIMITER)));
+            }
+        }
+        return parsedParameters;
+    }
+
+    /**
+     * Filters provided query params to one starting with provided string key.  This override also splits param
+     * values if they are contained in a comma-delimited list.
+     *
+     * @param context used to inspect the parameters of the current request
+     * @param queryKey    Filtering key
+     * @return Filtered query params
+     */
+    @Override
+    protected Map<String, Set<String>> filterQueryParamsByKey(QueryParamsParserContext context, String queryKey) {
+        Map<String, Set<String>> filteredQueryParams = new HashMap<>();
+
+        for (String paramName : context.getParameterNames()) {
+            if (paramName.startsWith(queryKey)) {
+                filteredQueryParams.put(paramName, parseDelimitedParameters(context.getParameterValue(paramName)));
+            }
+        }
+        return filteredQueryParams;
+    }
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/QueryParams.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/QueryParams.java
@@ -1,26 +1,8 @@
 package io.katharsis.queryParams;
 
-import io.katharsis.jackson.exception.ParametersDeserializationException;
-import io.katharsis.queryParams.include.Inclusion;
-import io.katharsis.queryParams.params.FilterParams;
-import io.katharsis.queryParams.params.GroupingParams;
-import io.katharsis.queryParams.params.IncludedFieldsParams;
-import io.katharsis.queryParams.params.IncludedRelationsParams;
-import io.katharsis.queryParams.params.SortingParams;
-import io.katharsis.queryParams.params.TypedParams;
-import io.katharsis.resource.RestrictedQueryParamsMembers;
-import io.katharsis.utils.StringUtils;
+import io.katharsis.queryParams.params.*;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Contains a set of parameters passed along with the request.
@@ -33,342 +15,46 @@ public class QueryParams {
     private TypedParams<IncludedRelationsParams> includedRelations;
     private Map<RestrictedPaginationKeys, Integer> pagination;
 
-
-    /**
-     * <strong>Important!</strong> Katharsis implementation differs form JSON API
-     * <a href="http://jsonapi.org/format/#fetching-filtering">definition of filtering</a>
-     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
-     * <p>
-     * Filter params can be send with following format (Katharsis does not specify or implement any operators): <br>
-     * <strong>filter[ResourceType][property|operator]([property|operator])* = "value"</strong><br>
-     * <p>
-     * Examples of accepted filtering of resources:
-     * <ul>
-     * <li>{@code GET /tasks/?filter[tasks][name]=Super task}</li>
-     * <li>{@code GET /tasks/?filter[tasks][name]=Super task&filter[tasks][dueDate]=2015-10-01}</li>
-     * <li>{@code GET /tasks/?filter[tasks][name][$startWith]=Super task}</li>
-     * <li>{@code GET /tasks/?filter[tasks][name][][$startWith]=Super&filter[tasks][name][][$endWith]=task}</li>
-     * </ul>
-     *
-     * @return {@link TypedParams} Map of filtering params passed to a request grouped by type of resource
-     */
     public TypedParams<FilterParams> getFilters() {
         return filters;
     }
-
-    void setFilters(Map<String, Set<String>> filters) {
-        Map<String, Map<String, Set<String>>> temporaryFiltersMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> entry : filters.entrySet()) {
-
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.filter.name());
-
-            String resourceType = propertyList.get(0);
-            String propertyPath = StringUtils.join(".", propertyList.subList(1, propertyList.size()));
-
-            if (temporaryFiltersMap.containsKey(resourceType)) {
-                Map<String, Set<String>> resourceParams = temporaryFiltersMap.get(resourceType);
-                resourceParams.put(propertyPath, Collections.unmodifiableSet(entry.getValue()));
-            } else {
-                Map<String, Set<String>> resourceParams = new LinkedHashMap<>();
-                temporaryFiltersMap.put(resourceType, resourceParams);
-                resourceParams.put(propertyPath, entry.getValue());
-            }
-        }
-
-        Map<String, FilterParams> decodedFiltersMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Map<String, Set<String>>> resourceTypesMap : temporaryFiltersMap.entrySet()) {
-            Map<String, Set<String>> filtersMap = Collections.unmodifiableMap(resourceTypesMap.getValue());
-            decodedFiltersMap.put(resourceTypesMap.getKey(), new FilterParams(filtersMap));
-        }
-
-        this.filters = new TypedParams<>(Collections.unmodifiableMap(decodedFiltersMap));
+    void setFilters(TypedParams<FilterParams> filters) {
+        this.filters = filters;
     }
 
-    /**
-     * <strong>Important!</strong> Katharsis implementation differs form JSON API
-     * <a href="http://jsonapi.org/format/#fetching-sorting">definition of sorting</a>
-     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
-     * <p>
-     * Sort params can be send with following format: <br>
-     * <strong>sort[ResourceType][property]([property])* = "asc|desc"</strong>
-     * <p>
-     * Examples of accepted sorting of resources:
-     * <ul>
-     * <li>{@code GET /tasks/?sort[tasks][name]=asc}</li>
-     * <li>{@code GET /project/?sort[projects][shortName]=desc&sort[users][name][firstName]=asc}</li>
-     * </ul>
-     *
-     * @return {@link TypedParams} Map of sorting params passed to request grouped by type of resource
-     */
     public TypedParams<SortingParams> getSorting() {
         return sorting;
     }
-
-    void setSorting(Map<String, Set<String>> sorting) {
-        Map<String, Map<String, RestrictedSortingValues>> temporarySortingMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> entry : sorting.entrySet()) {
-
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.sort.name());
-
-            String resourceType = propertyList.get(0);
-            String propertyPath = StringUtils.join(".", propertyList.subList(1, propertyList.size()));
-
-
-            if (temporarySortingMap.containsKey(resourceType)) {
-                Map<String, RestrictedSortingValues> resourceParams = temporarySortingMap.get(resourceType);
-                resourceParams.put(propertyPath, RestrictedSortingValues.valueOf(entry.getValue()
-                    .iterator()
-                    .next()));
-            } else {
-                Map<String, RestrictedSortingValues> resourceParams = new HashMap<>();
-                temporarySortingMap.put(resourceType, resourceParams);
-                resourceParams.put(propertyPath, RestrictedSortingValues.valueOf(entry.getValue()
-                    .iterator()
-                    .next()));
-            }
-        }
-
-        Map<String, SortingParams> decodedSortingMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Map<String, RestrictedSortingValues>> resourceTypesMap : temporarySortingMap.entrySet
-            ()) {
-            Map<String, RestrictedSortingValues> sortingMap = Collections.unmodifiableMap(resourceTypesMap.getValue());
-            decodedSortingMap.put(resourceTypesMap.getKey(), new SortingParams(sortingMap));
-        }
-
-
-        this.sorting = new TypedParams<>(Collections.unmodifiableMap(decodedSortingMap));
-
+    void setSorting(TypedParams<SortingParams> sorting) {
+        this.sorting = sorting;
     }
 
-    /**
-     * <strong>Important: </strong> Grouping itself is not specified by JSON API itself, but the
-     * keyword and format it reserved for today and future use in Katharsis.
-     * <p>
-     * Group params can be send with following format: <br>
-     * <strong>group[ResourceType] = "property(.property)*"</strong>
-     * <p>
-     * Examples of accepted grouping of resources:
-     * <ul>
-     * <li>{@code GET /tasks/?group[tasks]=name}</li>
-     * <li>{@code GET /project/?group[users]=name.firstName&include[projects]=team}</li>
-     * </ul>
-     *
-     * @return {@link Map} Map of grouping params passed to request grouped by type of resource
-     */
     public TypedParams<GroupingParams> getGrouping() {
         return grouping;
     }
-
-    void setGrouping(Map<String, Set<String>> grouping) {
-        Map<String, Set<String>> temporaryGroupingMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> entry : grouping.entrySet()) {
-
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.group.name());
-
-            if (propertyList.size() > 1) {
-                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'group' parameter " +
-                    "(1) eg. group[tasks][name] <-- #2 level and more are not allowed");
-            }
-
-            String resourceType = propertyList.get(0);
-
-            if (temporaryGroupingMap.containsKey(resourceType)) {
-                Set<String> resourceParams = temporaryGroupingMap.get(resourceType);
-                resourceParams.addAll(entry.getValue());
-                temporaryGroupingMap.put(resourceType, resourceParams);
-            } else {
-                Set<String> resourceParams = new LinkedHashSet<>();
-                resourceParams.addAll(entry.getValue());
-                temporaryGroupingMap.put(resourceType, resourceParams);
-            }
-        }
-
-        Map<String, GroupingParams> decodedGroupingMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> resourceTypesMap : temporaryGroupingMap.entrySet()) {
-            Set<String> groupingSet = Collections.unmodifiableSet(resourceTypesMap.getValue());
-            decodedGroupingMap.put(resourceTypesMap.getKey(), new GroupingParams(groupingSet));
-        }
-
-        this.grouping = new TypedParams<>(Collections.unmodifiableMap(decodedGroupingMap));
-
+    void setGrouping(TypedParams<GroupingParams> grouping) {
+        this.grouping = grouping;
     }
 
-    /**
-     * <strong>Important!</strong> Katharsis implementation sets on strategy of pagination whereas JSON API
-     * <a href="http://jsonapi.org/format/#fetching-pagination">definition of pagination</a>
-     * is agnostic about pagination strategies.
-     * <p>
-     * Pagination params can be send with following format: <br>
-     * <strong>page[offset|limit] = "value"</strong>, where value is an integer
-     * <p>
-     * Examples of accepted grouping of resources:
-     * <ul>
-     * <li>{@code GET /projects/?page[offset]=0&page[limit]=10}</li>
-     * </ul>
-     *
-     * @return {@link Map} Map of pagination keys passed to request
-     */
     public Map<RestrictedPaginationKeys, Integer> getPagination() {
         return pagination;
     }
-
-    void setPagination(Map<String, Set<String>> pagination) {
-        Map<RestrictedPaginationKeys, Integer> decodedPagination = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> entry : pagination.entrySet()) {
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.page.name());
-
-            if (propertyList.size() > 1) {
-                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'page' parameter " +
-                    "(1) eg. page[offset][minimal] <-- #2 level and more are not allowed");
-            }
-
-            String resourceType = propertyList.get(0);
-
-            decodedPagination.put(RestrictedPaginationKeys.valueOf(resourceType), Integer.parseInt(entry
-                .getValue()
-                .iterator()
-                .next()));
-        }
-
-        this.pagination = Collections.unmodifiableMap(decodedPagination);
+    void setPagination(Map<RestrictedPaginationKeys, Integer> pagination) {
+        this.pagination = pagination;
     }
 
-    /**
-     * <strong>Important!</strong> Katharsis implementation differs form JSON API
-     * <a href="http://jsonapi.org/format/#fetching-sparse-fieldsets">definition of sparse field set</a>
-     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
-     * <p>
-     * Sparse field set params can be send with following format: <br>
-     * <strong>fields[ResourceType] = "property(.property)*"</strong><br>
-     * <p>
-     * Examples of accepted sparse field sets of resources:
-     * <ul>
-     * <li>{@code GET /tasks/?fields[tasks]=name}</li>
-     * <li>{@code GET /tasks/?fields[tasks][]=name&fields[tasks][]=dueDate}</li>
-     * <li>{@code GET /tasks/?fields[users]=name.surname&include[tasks]=author}</li>
-     * </ul>
-     *
-     * @return {@link TypedParams} Map of sparse field set params passed to a request grouped by type of resource
-     */
     public TypedParams<IncludedFieldsParams> getIncludedFields() {
         return includedFields;
     }
-
-    void setIncludedFields(Map<String, Set<String>> sparse) {
-        Map<String, Set<String>> temporarySparseMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> entry : sparse.entrySet()) {
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.fields.name());
-
-            if (propertyList.size() > 1) {
-                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'fields' " +
-                    "parameter (1) eg. fields[tasks][name] <-- #2 level and more are not allowed");
-            }
-
-            String resourceType = propertyList.get(0);
-
-            if (temporarySparseMap.containsKey(resourceType)) {
-                Set<String> resourceParams = temporarySparseMap.get(resourceType);
-                resourceParams.addAll(entry.getValue());
-                temporarySparseMap.put(resourceType, resourceParams);
-            } else {
-                Set<String> resourceParams = new LinkedHashSet<>();
-                resourceParams.addAll(entry.getValue());
-                temporarySparseMap.put(resourceType, resourceParams);
-            }
-        }
-
-        Map<String, IncludedFieldsParams> decodedSparseMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> resourceTypesMap : temporarySparseMap.entrySet()) {
-            Set<String> sparseSet = Collections.unmodifiableSet(resourceTypesMap.getValue());
-            decodedSparseMap.put(resourceTypesMap.getKey(), new IncludedFieldsParams(sparseSet));
-        }
-
-        this.includedFields = new TypedParams<>(Collections.unmodifiableMap(decodedSparseMap));
+    void setIncludedFields(TypedParams<IncludedFieldsParams> includedFields) {
+        this.includedFields = includedFields;
     }
 
-    /**
-     * <strong>Important!</strong> Katharsis implementation differs form JSON API
-     * <a href="http://jsonapi.org/format/#fetching-includes">definition of includes</a>
-     * in order to fit standard query parameter serializing strategy and maximize effective processing of data.
-     * <p>
-     * Included field set params can be send with following format: <br>
-     * <strong>include[ResourceType] = "property(.property)*"</strong><br>
-     * <p>
-     * Examples of accepted sparse field sets of resources:
-     * <ul>
-     * <li>{@code GET /tasks/?include[tasks]=author}</li>
-     * <li>{@code GET /tasks/?include[tasks][]=author&include[tasks][]=comments}</li>
-     * <li>{@code GET /projects/?include[projects]=task&include[tasks]=comments}</li>
-     * </ul>
-     *
-     * @return {@link TypedParams} Map of sparse field set params passed to a request grouped by type of resource
-     */
     public TypedParams<IncludedRelationsParams> getIncludedRelations() {
         return includedRelations;
     }
-
-    void setIncludedRelations(Map<String, Set<String>> inclusions) {
-        Map<String, Set<Inclusion>> temporaryInclusionsMap = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<String>> entry : inclusions.entrySet()) {
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.include.name());
-
-            if (propertyList.size() > 1) {
-                throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'include' " +
-                    "parameter (1)");
-            }
-
-            String resourceType = propertyList.get(0);
-            Set<Inclusion> resourceParams;
-            if (temporaryInclusionsMap.containsKey(resourceType)) {
-                resourceParams = temporaryInclusionsMap.get(resourceType);
-            } else {
-                resourceParams = new LinkedHashSet<>();
-            }
-            for(String path : entry.getValue()) {
-                resourceParams.add(new Inclusion(path));
-            }
-            temporaryInclusionsMap.put(resourceType, resourceParams);
-        }
-
-        Map<String, IncludedRelationsParams> decodedInclusions = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Set<Inclusion>> resourceTypesMap : temporaryInclusionsMap.entrySet()) {
-            Set<Inclusion> inclusionSet = Collections.unmodifiableSet(resourceTypesMap.getValue());
-            decodedInclusions.put(resourceTypesMap.getKey(), new IncludedRelationsParams(inclusionSet));
-        }
-
-        this.includedRelations = new TypedParams<>(Collections.unmodifiableMap(decodedInclusions));
-    }
-
-    private static List<String> buildPropertyListFromEntry(Map.Entry<String, Set<String>> entry, String prefix) {
-        String entryKey = entry.getKey()
-            .substring(prefix.length());
-
-        String pattern = "[^\\]\\[]+(?<!\\[)(?=\\])";
-        Pattern regexp = Pattern.compile(pattern);
-        Matcher matcher = regexp.matcher(entryKey);
-        List<String> matchList = new LinkedList<>();
-
-        while (matcher.find()) {
-            matchList.add(matcher.group());
-        }
-
-
-        if (matchList.isEmpty()) {
-            throw new ParametersDeserializationException("Malformed filter parameter: " + entryKey);
-        }
-
-        return matchList;
+    void setIncludedRelations(TypedParams<IncludedRelationsParams> includedRelations) {
+        this.includedRelations = includedRelations;
     }
 
     @Override

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/QueryParamsBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/QueryParamsBuilder.java
@@ -2,6 +2,8 @@ package io.katharsis.queryParams;
 
 import io.katharsis.errorhandling.exception.KatharsisException;
 import io.katharsis.jackson.exception.ParametersDeserializationException;
+import io.katharsis.queryParams.context.SimpleQueryParamsParserContext;
+import io.katharsis.queryParams.context.QueryParamsParserContext;
 
 import java.util.Map;
 import java.util.Set;
@@ -26,27 +28,33 @@ public class QueryParamsBuilder {
     public QueryParamsBuilder(final QueryParamsParser queryParamsParser) {
         this.queryParamsParser = queryParamsParser;
     }
+
     /**
-     * Decodes passed query parameters
+     * Decodes passed query parameters using the given raw map.  Mainly intended to be used for testing purposes.
+     * For most cases, use {@link #buildQueryParams(QueryParamsParserContext context) instead.}
      *
      * @param queryParams Map of provided query params
      * @return QueryParams containing filtered query params grouped by JSON:API standard
      * @throws ParametersDeserializationException thrown when unsupported input format is detected
      */
     public QueryParams buildQueryParams(Map<String, Set<String>> queryParams) {
-        QueryParams deserializedQueryParams = new QueryParams();
+        return buildQueryParams(new SimpleQueryParamsParserContext(queryParams));
+    }
+
+    /**
+     * Parses the query parameters of the current request using this builder's QueryParamsParser and the
+     * given context.
+     * @param context - Contains raw information about the query parameters of the current request
+     * @return - QueryParams object which contains the parsed query parameters of the current request
+     * @throws ParametersDeserializationException thrown when unsupported input format is detected
+     */
+    public QueryParams buildQueryParams(QueryParamsParserContext context) {
         try {
-            deserializedQueryParams.setFilters(this.queryParamsParser.parseFiltersParameters(queryParams));
-            deserializedQueryParams.setSorting(this.queryParamsParser.parseSortingParameters(queryParams));
-            deserializedQueryParams.setGrouping(this.queryParamsParser.parseGroupingParameters(queryParams));
-            deserializedQueryParams.setPagination(this.queryParamsParser.parsePaginationParameters(queryParams));
-            deserializedQueryParams.setIncludedFields(this.queryParamsParser.parseIncludedFieldsParameters(queryParams));
-            deserializedQueryParams.setIncludedRelations(this.queryParamsParser.parseIncludedRelationsParameters(queryParams));
+            return queryParamsParser.parse(context);
         } catch (KatharsisException e) {
             throw e;
         } catch (RuntimeException e) {
             throw new ParametersDeserializationException(e.getMessage());
         }
-        return deserializedQueryParams;
     }
 }

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/QueryParamsParser.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/QueryParamsParser.java
@@ -17,16 +17,14 @@
 
 package io.katharsis.queryParams;
 
-import java.util.Map;
-import java.util.Set;
+import io.katharsis.queryParams.context.QueryParamsParserContext;
 
+/**
+ * QueryParamsParser implementations will create QueryParams objects using the given
+ * QueryParamsParserContext.
+ *
+ * Known implementations: {@link DefaultQueryParamsParser} {@link JsonApiQueryParamsParser}
+ */
 public interface QueryParamsParser {
-
-    Map<String, Set<String>> parseFiltersParameters(Map<String, Set<String>> queryParams);
-    Map<String, Set<String>> parseSortingParameters(Map<String, Set<String>> queryParams);
-    Map<String, Set<String>> parseGroupingParameters(Map<String, Set<String>> queryParams);
-    Map<String, Set<String>> parseIncludedFieldsParameters(Map<String, Set<String>> queryParams);
-    Map<String, Set<String>> parseIncludedRelationsParameters(Map<String, Set<String>> queryParams);
-    Map<String, Set<String>> parsePaginationParameters(Map<String, Set<String>> queryParams);
-
+    QueryParams parse(QueryParamsParserContext context);
 }

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/context/AbstractQueryParamsParserContext.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/context/AbstractQueryParamsParserContext.java
@@ -1,0 +1,18 @@
+package io.katharsis.queryParams.context;
+
+
+import io.katharsis.request.path.JsonPath;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.registry.ResourceRegistry;
+
+public abstract class AbstractQueryParamsParserContext implements QueryParamsParserContext {
+
+    private final ResourceInformation resourceInformation;
+
+    protected AbstractQueryParamsParserContext(ResourceRegistry resourceRegistry, JsonPath path) {
+        resourceInformation = resourceRegistry.getEntry(path.getResourceName()).getResourceInformation();
+    }
+
+    @Override
+    public ResourceInformation getRequestedResourceInformation() { return resourceInformation; }
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/context/QueryParamsParserContext.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/context/QueryParamsParserContext.java
@@ -1,0 +1,27 @@
+package io.katharsis.queryParams.context;
+
+import io.katharsis.resource.information.ResourceInformation;
+
+import java.util.Set;
+
+/**
+ * Supplies information about the query parameters of the incoming request.  This information is then
+ * used by QueryParamsParsers to create QueryParams objects.
+ */
+public interface QueryParamsParserContext {
+
+    /**
+     * Returns the set of parameter values that match the given query parameter name of the current request.
+     */
+    Set<String> getParameterValue(String parameterName);
+
+    /**
+     * Returns the set of query parameter names associated to the current request.
+     */
+    Iterable<String> getParameterNames();
+
+    /**
+     * Returns ResourceInformation for the primary resource of the current request.
+     */
+    ResourceInformation getRequestedResourceInformation();
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryParams/context/SimpleQueryParamsParserContext.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryParams/context/SimpleQueryParamsParserContext.java
@@ -1,0 +1,41 @@
+package io.katharsis.queryParams.context;
+
+
+import io.katharsis.resource.information.ResourceInformation;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A QueryParamsParserContext implementation mainly used for testing purposes.
+ * This implementation is a simple wrapper over a map of query parameters and their values.
+ */
+public class SimpleQueryParamsParserContext implements QueryParamsParserContext {
+
+    private final Map<String, Set<String>> paramMap;
+    private final ResourceInformation resourceInformation;
+
+    public SimpleQueryParamsParserContext(Map<String, Set<String>> paramMap) {
+        this(paramMap, null);
+    }
+
+    public SimpleQueryParamsParserContext(Map<String, Set<String>> paramMap, ResourceInformation resourceInformation) {
+        this.paramMap = paramMap;
+        this.resourceInformation = resourceInformation;
+    }
+
+    @Override
+    public Set<String> getParameterValue(String parameterName) {
+        return paramMap.get(parameterName);
+    }
+
+    @Override
+    public Iterable<String> getParameterNames() {
+        return paramMap.keySet();
+    }
+
+    @Override
+    public ResourceInformation getRequestedResourceInformation() {
+        return resourceInformation;
+    }
+}

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResource.java
@@ -1,6 +1,6 @@
 package io.katharsis.module;
 
-class TestResource {
+public class TestResource {
 
 	private int id;
 

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResourceInformationBuilder.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResourceInformationBuilder.java
@@ -8,7 +8,7 @@ import io.katharsis.resource.field.ResourceField;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 
-class TestResourceInformationBuilder implements ResourceInformationBuilder {
+public class TestResourceInformationBuilder implements ResourceInformationBuilder {
 
 	@Override
 	public boolean accept(Class<?> resourceClass) {
@@ -19,7 +19,7 @@ class TestResourceInformationBuilder implements ResourceInformationBuilder {
 	public ResourceInformation build(Class<?> resourceClass) {
 		ResourceField idField = new ResourceField("testId", "id", Integer.class, null);
 		ResourceAttributesBridge<?> attributeFields = null;
-		Set<ResourceField> relationshipFields = new HashSet<ResourceField>();
+		Set<ResourceField> relationshipFields = new HashSet<>();
 		ResourceInformation info = new ResourceInformation(resourceClass, resourceClass.getSimpleName(), idField,
 				attributeFields, relationshipFields);
 		return info;

--- a/katharsis-core/src/test/java/io/katharsis/queryParams/JsonApiQueryParamsParserTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryParams/JsonApiQueryParamsParserTest.java
@@ -1,0 +1,77 @@
+package io.katharsis.queryParams;
+
+
+import io.katharsis.module.TestResource;
+import io.katharsis.module.TestResourceInformationBuilder;
+import io.katharsis.queryParams.context.SimpleQueryParamsParserContext;
+import io.katharsis.queryParams.include.Inclusion;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonApiQueryParamsParserTest {
+
+    private Map<String, Set<String>> queryParams;
+    private QueryParamsParser parser = new JsonApiQueryParamsParser();
+
+    @Before
+    public void prepare() {
+        queryParams = new HashMap<>();
+    }
+
+    @Test
+    public void onGivenSortingParserShouldReturnOnlyRequestParamsWithSorting() {
+        // GIVEN
+        queryParams.put("sort", Collections.singleton("name,-id"));
+        queryParams.put("random", Collections.singleton("name,-id"));
+
+        // WHEN
+        QueryParams result = parseQueryParams();
+
+        // THEN
+        assertThat(result.getSorting().getParams()).containsOnlyKeys(TestResource.class.getSimpleName());
+        assertThat(result.getSorting().getParams().get(TestResource.class.getSimpleName()).getParams().size()).isEqualTo(2);
+        assertThat(result.getSorting().getParams().get(TestResource.class.getSimpleName()).getParams().get("name")).isEqualTo(RestrictedSortingValues.asc);
+        assertThat(result.getSorting().getParams().get(TestResource.class.getSimpleName()).getParams().get("id")).isEqualTo(RestrictedSortingValues.desc);
+    }
+
+    @Test
+    public void onGivenIncludedFieldsParserShouldReturnOnlyRequestParamsWithIncludedFields() {
+        // GIVEN
+        queryParams.put("fields[users]", Collections.singleton("name,id"));
+        queryParams.put("random[users]", Collections.singleton("surname"));
+
+        // WHEN
+        QueryParams result = parseQueryParams();
+
+        // THEN
+        assertThat(result.getIncludedFields().getParams().size()).isEqualTo(1);
+        assertThat(result.getIncludedFields().getParams().get("users").getParams()).containsOnly("name", "id");
+    }
+
+    @Test
+    public void onGivenIncludedRelationsParserShouldReturnOnlyRequestParamsWithIncludedRelations() {
+        // GIVEN
+        queryParams.put("include", Collections.singleton("author,comments.author"));
+        queryParams.put("random", Collections.singleton("author"));
+
+        // WHEN
+        QueryParams result = parseQueryParams();
+
+        // THEN
+        assertThat(result.getIncludedRelations().getParams().size()).isEqualTo(1);
+        assertThat(result.getIncludedRelations().getParams().get(TestResource.class.getSimpleName()).
+                getParams()).containsOnly(new Inclusion("author"), new Inclusion("comments.author"));
+    }
+
+    private QueryParams parseQueryParams() {
+        return parser.parse(new SimpleQueryParamsParserContext(queryParams,
+                new TestResourceInformationBuilder().build(TestResource.class)));
+    }
+}

--- a/katharsis-core/src/test/java/io/katharsis/queryParams/QueryParamsBuilderTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryParams/QueryParamsBuilderTest.java
@@ -170,4 +170,10 @@ public class QueryParamsBuilderTest {
             .get("special-users")
             .getParams()).containsExactly(new Inclusion("friends"), new Inclusion("foes"));
     }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void onGivenInvalidQueryParamsBuilderShouldThrowParametersDeserializationException() {
+        queryParams.put("include[missing_bracket", new LinkedHashSet<>(Arrays.asList("bad","request")));
+        sut.buildQueryParams(queryParams);
+    }
 }

--- a/katharsis-rs/src/main/java/io/katharsis/rs/JaxRsQueryParamsParserContext.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/JaxRsQueryParamsParserContext.java
@@ -1,0 +1,41 @@
+package io.katharsis.rs;
+
+import io.katharsis.queryParams.context.AbstractQueryParamsParserContext;
+import io.katharsis.request.path.JsonPath;
+import io.katharsis.resource.registry.ResourceRegistry;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.util.*;
+
+
+public class JaxRsQueryParamsParserContext extends AbstractQueryParamsParserContext {
+
+    private final Map<String, Set<String>> queryParameters = new HashMap<>();
+
+    JaxRsQueryParamsParserContext(UriInfo uriInfo, ResourceRegistry resourceRegistry, JsonPath path) {
+        super(resourceRegistry, path);
+        initParameterMap(uriInfo);
+    }
+
+    @Override
+    public Set<String> getParameterValue(String parameterName) {
+        if (queryParameters.containsKey(parameterName)) {
+            return queryParameters.get(parameterName);
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Iterable<String> getParameterNames() {
+        return queryParameters.keySet();
+    }
+
+    private void initParameterMap(UriInfo uriInfo) {
+        MultivaluedMap<String, String> queryParametersMultiMap = uriInfo.getQueryParameters();
+
+        for (Map.Entry<String, List<String>> queryEntry : queryParametersMultiMap.entrySet()) {
+            queryParameters.put(queryEntry.getKey(), new LinkedHashSet<>(queryEntry.getValue()));
+        }
+    }
+}

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -116,7 +116,7 @@ public class KatharsisFilter implements ContainerRequestFilter {
             ResourceRegistry newRegistry = new ResourceRegistry(resourceRegistry.getResources(), new UriInfoServiceUrlProvider(uriInfo));
             JsonPath jsonPath = new PathBuilder(newRegistry).buildPath(path);
 
-            QueryParams requestParams = createQueryParams(uriInfo);
+            QueryParams requestParams = createQueryParams(uriInfo, jsonPath);
 
             String method = requestContext.getMethod();
             RequestBody requestBody = inputStreamToBody(requestContext.getEntityStream());
@@ -161,15 +161,8 @@ public class KatharsisFilter implements ContainerRequestFilter {
         requestContext.abortWith(response);
     }
 
-    private QueryParams createQueryParams(UriInfo uriInfo) {
-        MultivaluedMap<String, String> queryParametersMultiMap = uriInfo.getQueryParameters();
-        Map<String, Set<String>> queryParameters = new HashMap<>();
-
-        for (Map.Entry<String, List<String>> queryEntry : queryParametersMultiMap.entrySet()) {
-            queryParameters.put(queryEntry.getKey(), new LinkedHashSet<>(queryEntry.getValue()));
-        }
-
-        return queryParamsBuilder.buildQueryParams(queryParameters);
+    private QueryParams createQueryParams(UriInfo uriInfo, JsonPath path) {
+        return queryParamsBuilder.buildQueryParams(new JaxRsQueryParamsParserContext(uriInfo, resourceRegistry, path));
     }
 
     public RequestBody inputStreamToBody(InputStream is) throws IOException {

--- a/katharsis-servlet/src/main/java/io/katharsis/invoker/KatharsisInvoker.java
+++ b/katharsis-servlet/src/main/java/io/katharsis/invoker/KatharsisInvoker.java
@@ -31,15 +31,13 @@ import io.katharsis.request.path.JsonPath;
 import io.katharsis.request.path.PathBuilder;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.response.BaseResponseContext;
-import io.katharsis.servlet.util.QueryStringUtils;
+import io.katharsis.servlet.ServletQueryParamsParserContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
-import java.util.Map;
 import java.util.Scanner;
-import java.util.Set;
 
 /**
  * Katharsis dispatcher invoker.
@@ -85,7 +83,7 @@ public class KatharsisInvoker {
         try {
             JsonPath jsonPath = new PathBuilder(resourceRegistry).buildPath(invokerContext.getRequestPath());
 
-            QueryParams queryParams = createQueryParams(invokerContext);
+            QueryParams queryParams = createQueryParams(invokerContext, jsonPath);
 
             in = invokerContext.getRequestEntityStream();
             RequestBody requestBody = inputStreamToBody(in);
@@ -150,10 +148,9 @@ public class KatharsisInvoker {
         return false;
     }
 
-    private QueryParams createQueryParams(KatharsisInvokerContext invokerContext) {
-        Map<String, Set<String>> queryParameters =
-            QueryStringUtils.parseQueryStringAsSingleValueMap(invokerContext);
-        return this.queryParamsBuilder.buildQueryParams(queryParameters);
+    private QueryParams createQueryParams(KatharsisInvokerContext invokerContext, JsonPath path) {
+        return queryParamsBuilder.buildQueryParams(new ServletQueryParamsParserContext(invokerContext,
+                resourceRegistry, path));
     }
 
     private RequestBody inputStreamToBody(InputStream is) throws IOException {

--- a/katharsis-servlet/src/main/java/io/katharsis/servlet/ServletQueryParamsParserContext.java
+++ b/katharsis-servlet/src/main/java/io/katharsis/servlet/ServletQueryParamsParserContext.java
@@ -1,0 +1,38 @@
+package io.katharsis.servlet;
+
+import io.katharsis.invoker.KatharsisInvokerContext;
+import io.katharsis.queryParams.context.AbstractQueryParamsParserContext;
+import io.katharsis.queryParams.context.QueryParamsParserContext;
+import io.katharsis.request.path.JsonPath;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.servlet.util.QueryStringUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class ServletQueryParamsParserContext extends AbstractQueryParamsParserContext {
+
+    private final Map<String, Set<String>> queryParameters;
+
+    public ServletQueryParamsParserContext(KatharsisInvokerContext invokerContext, ResourceRegistry resourceRegistry,
+                                           JsonPath path) {
+        super(resourceRegistry, path);
+        queryParameters = QueryStringUtils.parseQueryStringAsSingleValueMap(invokerContext);
+    }
+
+    @Override
+    public Set<String> getParameterValue(String parameterName) {
+        if (queryParameters.containsKey(parameterName)) {
+            return queryParameters.get(parameterName);
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Iterable<String> getParameterNames() {
+        return queryParameters.keySet();
+    }
+}

--- a/katharsis-spring/src/main/java/io/katharsis/spring/KatharsisFilterV2.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/KatharsisFilterV2.java
@@ -113,7 +113,7 @@ public class KatharsisFilterV2 implements Filter, BeanFactoryAware {
         try {
             JsonPath jsonPath = new PathBuilder(resourceRegistry).buildPath(getRequestPath(request));
 
-            QueryParams queryParams = createQueryParams(request);
+            QueryParams queryParams = createQueryParams(request, jsonPath);
 
             in = request.getInputStream();
             RequestBody requestBody = inputStreamToBody(in);
@@ -210,16 +210,11 @@ public class KatharsisFilterV2 implements Filter, BeanFactoryAware {
      * body parameters, but we don't expect to receive such body.
      *
      * @param request request body
+     * @path
      * @return query parameters
      */
-    private QueryParams createQueryParams(HttpServletRequest request) {
-        Map<String, String[]> params = request.getParameterMap();
-
-        Map<String, Set<String>> queryParameters = new HashMap<>(params.size());
-        for (Map.Entry<String, String[]> entry : params.entrySet()) {
-            queryParameters.put(entry.getKey(), new HashSet<>(Arrays.asList(entry.getValue())));
-        }
-        return queryParamsBuilder.buildQueryParams(queryParameters);
+    private QueryParams createQueryParams(HttpServletRequest request, JsonPath path) {
+        return queryParamsBuilder.buildQueryParams(new SpringQueryParamsParserContext(request, resourceRegistry, path));
     }
 
     private RequestBody inputStreamToBody(InputStream is) {

--- a/katharsis-spring/src/main/java/io/katharsis/spring/SpringQueryParamsParserContext.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/SpringQueryParamsParserContext.java
@@ -1,0 +1,40 @@
+package io.katharsis.spring;
+
+import io.katharsis.queryParams.context.AbstractQueryParamsParserContext;
+import io.katharsis.queryParams.context.QueryParamsParserContext;
+import io.katharsis.request.path.JsonPath;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.registry.ResourceRegistry;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.*;
+
+public class SpringQueryParamsParserContext extends AbstractQueryParamsParserContext {
+
+    private final Map<String, Set<String>> queryParameters = new HashMap<>();
+
+    SpringQueryParamsParserContext(HttpServletRequest request, ResourceRegistry resourceRegistry, JsonPath path) {
+        super(resourceRegistry, path);
+        initParameterMap(request);
+    }
+
+    @Override
+    public Set<String> getParameterValue(String parameterName) {
+        if (queryParameters.containsKey(parameterName)) {
+            return queryParameters.get(parameterName);
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Iterable<String> getParameterNames() {
+        return queryParameters.keySet();
+    }
+
+    private void initParameterMap(HttpServletRequest request) {
+        Map<String, String[]> params = request.getParameterMap();
+        for (Map.Entry<String, String[]> entry : params.entrySet()) {
+            queryParameters.put(entry.getKey(), new HashSet<>(Arrays.asList(entry.getValue())));
+        }
+    }
+}


### PR DESCRIPTION
Simplify/enhance the QueryParamsParser interface by utilizing a context object
to supply the parser with the raw query parameter information from the request, as
well as a reference to the ResourceInformation of the requested resource.

Implement a new QueryParamsParser which adheres to the JSON-API standard more strictly.

#113 