### PR TITLE
Fix to-many relationships in JPAModule

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/responseRepository/RelationshipRepositoryAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/responseRepository/RelationshipRepositoryAdapter.java
@@ -82,7 +82,9 @@ public class RelationshipRepositoryAdapter<T, T_ID extends Serializable, D, D_ID
             resource = ((AnnotatedRelationshipRepositoryAdapter) relationshipRepository)
                 .findOneTarget(sourceId, fieldName, toQueryParams(queryAdapter));
         } else if(relationshipRepository instanceof QuerySpecRelationshipRepository){
-        	resource = ((QuerySpecRelationshipRepository)relationshipRepository).findOneTarget(sourceId, fieldName, toQuerySpec(queryAdapter));
+        	QuerySpecRelationshipRepository querySpecRepository = (QuerySpecRelationshipRepository) relationshipRepository;
+        	Class<?> targetResourceClass = querySpecRepository.getTargetResourceClass();
+        	resource = querySpecRepository.findOneTarget(sourceId, fieldName, toQuerySpec(queryAdapter, targetResourceClass));
         } else {
             resource = ((RelationshipRepository) relationshipRepository)
                 .findOneTarget(sourceId, fieldName, toQueryParams(queryAdapter));
@@ -96,7 +98,9 @@ public class RelationshipRepositoryAdapter<T, T_ID extends Serializable, D, D_ID
             resources = ((AnnotatedRelationshipRepositoryAdapter) relationshipRepository)
                 .findManyTargets(sourceId, fieldName, toQueryParams(queryAdapter));
         }else if(relationshipRepository instanceof QuerySpecRelationshipRepository){
-            	resources = ((QuerySpecRelationshipRepository)relationshipRepository).findManyTargets(sourceId, fieldName, toQuerySpec(queryAdapter));
+        	QuerySpecRelationshipRepository querySpecRepository = (QuerySpecRelationshipRepository) relationshipRepository;
+        	Class<?> targetResourceClass = querySpecRepository.getTargetResourceClass();
+            	resources = querySpecRepository.findManyTargets(sourceId, fieldName, toQuerySpec(queryAdapter, targetResourceClass));
         } else {
             resources = ((RelationshipRepository) relationshipRepository)
                 .findManyTargets(sourceId, fieldName, toQueryParams(queryAdapter));

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/responseRepository/ResourceRepositoryAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/responseRepository/ResourceRepositoryAdapter.java
@@ -35,7 +35,7 @@ public class ResourceRepositoryAdapter<T, ID extends Serializable> extends Respo
 			resource = ((AnnotatedResourceRepositoryAdapter) resourceRepository).findOne(id, toQueryParams(queryAdapter));
 		}
 		else if (resourceRepository instanceof QuerySpecResourceRepository) {
-			resource = ((QuerySpecResourceRepository) resourceRepository).findOne(id, toQuerySpec(queryAdapter));
+			resource = ((QuerySpecResourceRepository) resourceRepository).findOne(id, toQuerySpec(queryAdapter, resourceInformation.getResourceClass()));
 		}
 		else {
 			resource = ((ResourceRepository) resourceRepository).findOne(id, toQueryParams(queryAdapter));
@@ -49,7 +49,7 @@ public class ResourceRepositoryAdapter<T, ID extends Serializable> extends Respo
 			resources = ((AnnotatedResourceRepositoryAdapter) resourceRepository).findAll(toQueryParams(queryAdapter));
 		}
 		else if (resourceRepository instanceof QuerySpecResourceRepository) {
-			resources = ((QuerySpecResourceRepository) resourceRepository).findAll(toQuerySpec(queryAdapter));
+			resources = ((QuerySpecResourceRepository) resourceRepository).findAll(toQuerySpec(queryAdapter, resourceInformation.getResourceClass()));
 		}
 		else {
 			resources = ((ResourceRepository) resourceRepository).findAll(toQueryParams(queryAdapter));
@@ -63,7 +63,7 @@ public class ResourceRepositoryAdapter<T, ID extends Serializable> extends Respo
 			resources = ((AnnotatedResourceRepositoryAdapter) resourceRepository).findAll(ids, toQueryParams(queryAdapter));
 		}
 		else if (resourceRepository instanceof QuerySpecResourceRepository) {
-			resources = ((QuerySpecResourceRepository) resourceRepository).findAll(ids, toQuerySpec(queryAdapter));
+			resources = ((QuerySpecResourceRepository) resourceRepository).findAll(ids, toQuerySpec(queryAdapter, resourceInformation.getResourceClass()));
 		}
 		else {
 			resources = ((ResourceRepository) resourceRepository).findAll(ids, toQueryParams(queryAdapter));

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/responseRepository/ResponseRepository.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/responseRepository/ResponseRepository.java
@@ -83,7 +83,7 @@ public abstract class ResponseRepository {
         return null;
     }
     
-	protected QuerySpec toQuerySpec(QueryAdapter queryAdapter) {
+	protected QuerySpec toQuerySpec(QueryAdapter queryAdapter, Class<?> targetResourceClass) {
 	 	if(queryAdapter == null)
     		return null;
 		if(queryAdapter instanceof QuerySpecAdapter){
@@ -98,8 +98,7 @@ public abstract class ResponseRepository {
     	
     	DefaultQuerySpecConverter converter = new DefaultQuerySpecConverter(resourceRegistry, operatorRegistry);
     	
-    	Class<?> resourceClass = resourceInformation.getResourceClass();
-    	return converter.fromParams(resourceClass, queryParams);
+    	return converter.fromParams(targetResourceClass, queryParams);
 	}
 	
 	protected abstract FilterOperator getDefaultOperator() ;

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaModule.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaModule.java
@@ -263,8 +263,13 @@ public class JpaModule implements Module {
 		Set<Class<?>> relatedResourceClasses = new HashSet<>();
 		for (MetaAttribute attr : metaEntity.getAttributes()) {
 			if (attr.isAssociation()) {
-				Class<?> relType = attr.getType().getImplementationClass();
-
+				Class<?> relType = null;
+				if(attr.getType().isCollection()) {
+					relType = attr.getType().getElementType().getImplementationClass();
+				}
+				else {
+					relType = attr.getType().getImplementationClass();
+				}
 				// only include relations that are exposed as repositories
 				if (entityClasses.contains(relType)) {
 					relatedResourceClasses.add(relType);

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaRelationshipRepository.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaRelationshipRepository.java
@@ -182,8 +182,7 @@ public class JpaRelationshipRepository<T, I extends Serializable, D, J extends S
 
 	@Override
 	public Class<T> getSourceResourceClass() {
-		// TODO Auto-generated method stub
-		return null;
+		return entityClass;
 	}
 
 	@Override

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/AbstractJpaQueryImpl.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/AbstractJpaQueryImpl.java
@@ -71,7 +71,12 @@ public abstract class AbstractJpaQueryImpl<T, B extends JpaQueryBackend<?, ?, ?,
 
 		MetaDataObject parentMeta = metaLookup.getMeta(entityClass).asDataObject();
 		MetaAttribute attrMeta = parentMeta.getAttribute(attrName);
-		this.meta = attrMeta.getType().asEntity();
+		if(attrMeta.getType().isCollection()) {
+			this.meta = attrMeta.getType().asCollection().getElementType().asEntity();
+		}
+		else {
+			this.meta = attrMeta.getType().asEntity();
+		}
 		this.clazz = (Class<T>) meta.getImplementationClass();
 
 		this.parentEntityClass = entityClass;

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/JoinRegistry.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/JoinRegistry.java
@@ -45,10 +45,11 @@ public class JoinRegistry<F, E> {
 				criteriaPath = joinMap(currentCriteriaPath, pathElement);
 			} else {
 				// we may need to downcast if attribute is defined on a subtype
-				Class<?> entityType = pathElement.getParent().asDataObject().getImplementationClass();
-				boolean isSubType = !entityType.isAssignableFrom(backend.getJavaType(currentCriteriaPath));
+				Class<?> pathType = pathElement.getParent().asDataObject().getImplementationClass();
+				Class<?> currentType = backend.getJavaElementType(currentCriteriaPath);
+				boolean isSubType = !pathType.isAssignableFrom(currentType);
 				if (isSubType) {
-					currentCriteriaPath = backend.joinSubType(currentCriteriaPath, entityType);
+					currentCriteriaPath = backend.joinSubType(currentCriteriaPath, pathType);
 				}
 				criteriaPath = backend.getAttribute(currentCriteriaPath, pathElement);
 			}

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/JpaQueryBackend.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/JpaQueryBackend.java
@@ -43,7 +43,7 @@ public interface JpaQueryBackend<F, O, P, E> {
 
 	public P or(List<P> predicates);
 
-	public Class<?> getJavaType(E currentCriteriaPath);
+	public Class<?> getJavaElementType(E currentCriteriaPath);
 
 	public E getAttribute(E currentCriteriaPath, MetaAttribute pathElement);
 

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/criteria/JpaCriteriaQueryBackend.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/criteria/JpaCriteriaQueryBackend.java
@@ -281,7 +281,7 @@ public class JpaCriteriaQueryBackend<T> implements JpaQueryBackend<From<?, ?>, O
 	}
 
 	@Override
-	public Class<?> getJavaType(Expression<?> currentCriteriaPath) {
+	public Class<?> getJavaElementType(Expression<?> currentCriteriaPath) {
 		return currentCriteriaPath.getJavaType();
 	}
 

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/querydsl/QuerydslUtils.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/querydsl/QuerydslUtils.java
@@ -23,32 +23,34 @@ class QuerydslUtils {
 			String fieldName = firstToLower(entityClass.getSimpleName());
 			Field field = queryClass.getField(fieldName);
 			return (EntityPath<T>) field.get(entityClass);
-		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+		}
+		catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 			throw new IllegalStateException("failed to access query class " + queryClass.getName(), e);
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T> Expression<T> get(Expression<?> entityPath, String name) {
+	public static <T> Expression<T> get(Expression<?> path, String name) {
 		try {
-			Class<?> clazz = entityPath.getClass();
+			Class<?> clazz = path.getClass();
 			Field field = clazz.getField(name);
-			return (Expression<T>) field.get(entityPath);
-		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-			throw new IllegalStateException("failed get field " + entityPath + "." + name, e);
+			return (Expression<T>) field.get(path);
+		}
+		catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+			throw new IllegalStateException("failed get field " + path + "." + name, e);
 		}
 	}
 
 	public static com.querydsl.core.JoinType convertJoinType(JoinType joinType) {
 		switch (joinType) {
-		case INNER:
-			return com.querydsl.core.JoinType.JOIN;
-		case LEFT:
-			return com.querydsl.core.JoinType.LEFTJOIN;
-		case RIGHT:
-			return com.querydsl.core.JoinType.RIGHTJOIN;
-		default:
-			throw new IllegalStateException(joinType.toString() + " unknown");
+			case INNER:
+				return com.querydsl.core.JoinType.JOIN;
+			case LEFT:
+				return com.querydsl.core.JoinType.LEFTJOIN;
+			case RIGHT:
+				return com.querydsl.core.JoinType.RIGHTJOIN;
+			default:
+				throw new IllegalStateException(joinType.toString() + " unknown");
 		}
 	}
 
@@ -70,7 +72,8 @@ class QuerydslUtils {
 		String queryClassName = entityClass.getPackage().getName() + ".Q" + entityClass.getSimpleName();
 		try {
 			return entityClass.getClassLoader().loadClass(queryClassName);
-		} catch (ClassNotFoundException | SecurityException | IllegalArgumentException e) {
+		}
+		catch (ClassNotFoundException | SecurityException | IllegalArgumentException e) {
 			throw new IllegalStateException("unable to find query class " + queryClassName, e);
 		}
 	}

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/AbstractJpaJerseyTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/AbstractJpaJerseyTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.katharsis.client.KatharsisClient;
 import io.katharsis.jpa.model.TestEntity;
 import io.katharsis.jpa.query.AbstractJpaTest;
+import io.katharsis.jpa.query.querydsl.QuerydslQueryFactory;
 import io.katharsis.jpa.util.EntityManagerProducer;
 import io.katharsis.jpa.util.SpringTransactionRunner;
 import io.katharsis.jpa.util.TestConfig;
@@ -95,6 +96,7 @@ public abstract class AbstractJpaJerseyTest extends JerseyTest {
 					new QueryParamsBuilder(new DefaultQueryParamsParser()), new SampleJsonServiceLocator());
 
 			JpaModule module = new JpaModule(emFactory, em, transactionRunner);
+			module.setQueryFactory(QuerydslQueryFactory.newInstance(module.getMetaLookup(), em));
 			setupModule(module);
 			feature.addModule(module);
 

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaRelationshipRepositoryTestBase.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaRelationshipRepositoryTestBase.java
@@ -6,10 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.hamcrest.core.Is;
-import org.hamcrest.core.IsInstanceOf;
-import org.hamcrest.core.IsNot;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +15,6 @@ import io.katharsis.jpa.JpaRelationshipRepository;
 import io.katharsis.jpa.model.RelatedEntity;
 import io.katharsis.jpa.model.TestEntity;
 import io.katharsis.jpa.query.AbstractJpaTest;
-import io.katharsis.jpa.query.querydsl.QuerydslQueryFactory;
 import io.katharsis.queryspec.FilterOperator;
 import io.katharsis.queryspec.FilterSpec;
 import io.katharsis.queryspec.QuerySpec;
@@ -156,9 +152,6 @@ public abstract class JpaRelationshipRepositoryTestBase extends AbstractJpaTest 
 
 	@Test
 	public void testGetManyRelation() {
-		//TODO fix for QueryDSL
-		Assume.assumeThat("QueryDSL still breaks on this, so ignore it for now",
-				queryFactory, IsNot.not(IsInstanceOf.instanceOf(QuerydslQueryFactory.class)));
 		TestEntity test = em.find(TestEntity.class, 1L);
 		Assert.assertThat(test.getManyRelatedValues().size(), Is.is(0));
 

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaRelationshipRepositoryTestBase.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaRelationshipRepositoryTestBase.java
@@ -1,9 +1,15 @@
 package io.katharsis.jpa.repository;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsInstanceOf;
+import org.hamcrest.core.IsNot;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +18,7 @@ import io.katharsis.jpa.JpaRelationshipRepository;
 import io.katharsis.jpa.model.RelatedEntity;
 import io.katharsis.jpa.model.TestEntity;
 import io.katharsis.jpa.query.AbstractJpaTest;
+import io.katharsis.jpa.query.querydsl.QuerydslQueryFactory;
 import io.katharsis.queryspec.FilterOperator;
 import io.katharsis.queryspec.FilterSpec;
 import io.katharsis.queryspec.QuerySpec;
@@ -145,5 +152,30 @@ public abstract class JpaRelationshipRepositoryTestBase extends AbstractJpaTest 
 		Assert.assertEquals(0, test.getManyRelatedValues().size());
 		related = em.find(RelatedEntity.class, 101L);
 		Assert.assertNull(related.getTestEntity());
+	}
+
+	@Test
+	public void testGetManyRelation() {
+		//TODO fix for QueryDSL
+		Assume.assumeThat("QueryDSL still breaks on this, so ignore it for now",
+				queryFactory, IsNot.not(IsInstanceOf.instanceOf(QuerydslQueryFactory.class)));
+		TestEntity test = em.find(TestEntity.class, 1L);
+		Assert.assertThat(test.getManyRelatedValues().size(), Is.is(0));
+
+		repo.addRelations(test, Arrays.asList(101L,102L), TestEntity.ATTR_manyRelatedValues);
+		em.flush();
+		em.clear();
+		test = em.find(TestEntity.class, 1L);
+		Assert.assertThat(test.getManyRelatedValues().size(), Is.is(2));
+
+		QuerySpec querySpec = new QuerySpec(RelatedEntity.class);
+		Iterable<RelatedEntity> targets = repo.findManyTargets(1L, TestEntity.ATTR_manyRelatedValues, querySpec);
+		List<RelatedEntity> res = new ArrayList<>();
+		for (RelatedEntity relatedEntity : targets) {
+			res.add(relatedEntity);
+		}
+		Assert.assertThat(res.size(), Is.is(2));
+		Assert.assertThat(res.get(0).getId(), Is.is(101L));
+		Assert.assertThat(res.get(1).getId(), Is.is(102L));
 	}
 }


### PR DESCRIPTION
When you tried to query a to-many relation it didn't produce a proper result.

Reproduction of the issue is found in JpaRelationshipRepositoryTestBase class.

I had to disable the QueryDSL tests because the QueryFactory for QueryDsl still
cannot handle to-many type of queries properly.