### PR TITLE
remove deploy lifecycle binding from parent pom

### DIFF
--- a/katharsis-parent/pom.xml
+++ b/katharsis-parent/pom.xml
@@ -174,15 +174,6 @@
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>deploy</id>
-                            <phase>deploy</phase>
-                            <goals>
-                                <goal>deploy</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.github.danielflower.mavenplugins</groupId>


### PR DESCRIPTION
From the maven docs for deploy:deploy:
Binds by default to the lifecycle phase: deploy.

Because of this binding the deploy target ran twice because it got
registered a second time. After removing the extra binding declaration
the deploy ran once for each module, just as it should.