### PR TITLE
#140 UriInfoServiceUrlProvider not working

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
@@ -1,15 +1,16 @@
 package io.katharsis.resource.registry;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.exception.init.ResourceNotFoundInitializationException;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.utils.java.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 
 public class ResourceRegistry {
@@ -149,7 +150,7 @@ public class ResourceRegistry {
         return Optional.empty();
     }
 
-    public String getResourceUrl(Class clazz) {
+    public String getResourceUrl(Class<?> clazz) {
         return serviceUrlProvider.getUrl() + "/" + getResourceType(clazz);
     }
 
@@ -157,6 +158,10 @@ public class ResourceRegistry {
         return serviceUrlProvider.getUrl();
     }
 
+    public ServiceUrlProvider getServiceUrlProvider(){
+    	return serviceUrlProvider;
+    }
+    
     /**
      * Get a list of all registered resources by Katharsis.
      *

--- a/katharsis-core/src/test/java/io/katharsis/resource/registry/ResourceRegistryTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/registry/ResourceRegistryTest.java
@@ -36,6 +36,10 @@ public class ResourceRegistryTest {
         assertThat(tasksEntry).isNotNull();
     }
 
+    @Test
+    public void testGetSeriveUrlProvider(){
+    	assertThat(resourceRegistry.getServiceUrlProvider().getUrl()).isEqualTo(TEST_MODELS_URL);
+    }
 
     @Test
     public void testSecondaryConstructor() {

--- a/katharsis-rs/src/main/java/io/katharsis/resource/registry/UriInfoServiceUrlProvider.java
+++ b/katharsis-rs/src/main/java/io/katharsis/resource/registry/UriInfoServiceUrlProvider.java
@@ -4,7 +4,6 @@ import javax.ws.rs.core.UriInfo;
 
 public class UriInfoServiceUrlProvider implements ServiceUrlProvider {
 
-	@Deprecated
 	private UriInfo globalUrlInfo;
 
 	private ThreadLocal<UriInfo> threadLocal = new ThreadLocal<>();
@@ -13,6 +12,9 @@ public class UriInfoServiceUrlProvider implements ServiceUrlProvider {
 		// make use of thread local and started/finish events to get uriInfo
 	}
 
+	/**
+	 * @deprecated Make use of the default constructor instead.
+	 */
 	@Deprecated
 	public UriInfoServiceUrlProvider(UriInfo info) {
 		this.globalUrlInfo = info;

--- a/katharsis-rs/src/main/java/io/katharsis/resource/registry/UriInfoServiceUrlProvider.java
+++ b/katharsis-rs/src/main/java/io/katharsis/resource/registry/UriInfoServiceUrlProvider.java
@@ -2,17 +2,44 @@ package io.katharsis.resource.registry;
 
 import javax.ws.rs.core.UriInfo;
 
-
 public class UriInfoServiceUrlProvider implements ServiceUrlProvider {
 
-    private UriInfo info;
+	@Deprecated
+	private UriInfo globalUrlInfo;
 
-    public UriInfoServiceUrlProvider(UriInfo info) {
-        this.info = info;
-    }
+	private ThreadLocal<UriInfo> threadLocal = new ThreadLocal<>();
 
-    @Override
-    public String getUrl() {
-        return info.getBaseUri().toString();
-    }
+	public UriInfoServiceUrlProvider() {
+		// make use of thread local and started/finish events to get uriInfo
+	}
+
+	@Deprecated
+	public UriInfoServiceUrlProvider(UriInfo info) {
+		this.globalUrlInfo = info;
+	}
+
+	@Override
+	public String getUrl() {
+		UriInfo urlInfo = globalUrlInfo;
+		if (urlInfo == null) {
+			urlInfo = threadLocal.get();
+			if (urlInfo == null) {
+				throw new IllegalStateException("uriInfo not available, make sure to call onRequestStarted in advance");
+			}
+		}
+		String url = urlInfo.getBaseUri().toString();
+		if(url.endsWith("/")){
+			return url.substring(0, url.length() - 1);
+		}else{
+			return url;
+		}
+	}
+
+	public void onRequestStarted(UriInfo uriInfo) {
+		threadLocal.set(uriInfo);
+	}
+
+	public void onRequestFinished() {
+		threadLocal.remove();
+	}
 }


### PR DESCRIPTION
fixed mixup of UriInfoServiceUrlProvider and ConstantServiceUrlProvider.
Switched to a thread-local solution for now since the actual URL is only
available at request-time.

With Katharsis 3.0 there is a potential to clean this up further by
mothing the url handling out of the serialization stack.