### PR TITLE
Refactor QuerySpec paging implementation

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/queryspec/DefaultPageParamDeserializer.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/DefaultPageParamDeserializer.java
@@ -1,0 +1,72 @@
+package io.katharsis.queryspec;
+
+import io.katharsis.jackson.exception.ParametersDeserializationException;
+import io.katharsis.queryParams.RestrictedPaginationKeys;
+
+/**
+ * Default deserializer for the pagination types supported by {@link RestrictedPaginationKeys}
+ * <p>
+ * It favors limit/offset params over page number/size.
+ * This means if a limit/offset param is encountered, the resulting {@link PagingSpec} will be offset/limit based,
+ * regardless if a pageNumber/Size is also encountered.
+ * <p>
+ * Mixing offset/limit and number/size isn't something that makes sense anyways.
+ */
+public class DefaultPageParamDeserializer {
+
+    private static final String OFFSET_PARAMETER = RestrictedPaginationKeys.offset.name();
+
+    private static final String LIMIT_PARAMETER = RestrictedPaginationKeys.limit.name();
+
+    private static final String NUMBER_PARAMETER = RestrictedPaginationKeys.number.name();
+
+    private static final String SIZE_PARAMETER = RestrictedPaginationKeys.size.name();
+
+    private Long pageNumber = null;
+    private Long pageSize = null;
+    private Long limit = null;
+    private Long offset = null;
+
+    /**
+     * Parse a single parameter
+     *
+     * @param parameter
+     */
+    public void collectPageParam(DefaultQuerySpecDeserializer.Parameter parameter) {
+        if (!parameter.name.startsWith("[") || !parameter.name.endsWith("]")) {
+            throw new ParametersDeserializationException(parameter.toString());
+        }
+        String name = parameter.name.substring(1, parameter.name.length() - 1);
+        if (OFFSET_PARAMETER.equalsIgnoreCase(name)) {
+            offset = parameter.getLongValue();
+        } else if (LIMIT_PARAMETER.equalsIgnoreCase(name)) {
+            limit = parameter.getLongValue();
+        } else if (SIZE_PARAMETER.equalsIgnoreCase(name)) {
+            pageSize = parameter.getLongValue();
+        } else if (NUMBER_PARAMETER.equalsIgnoreCase(name)) {
+            pageNumber = parameter.getLongValue();
+        } else {
+            throw new ParametersDeserializationException(parameter.toString());
+        }
+    }
+
+    /**
+     * Deserializes the collected parameters into an appropriate {@link PagingSpec}
+     *
+     * @return the PagingSpec represented by the parsed parameters
+     */
+    public PagingSpec deserialize() {
+        PagingSpec pagingSpec = null;
+        if (limit != null) {
+            if (offset == null)
+                offset = 0L;
+            pagingSpec = new OffsetBasedPagingSpec(offset, limit, OFFSET_PARAMETER, LIMIT_PARAMETER);
+        }
+        if (pagingSpec == null && pageSize != null) {
+            if (pageNumber == null)
+                pageNumber = 0L;
+            pagingSpec = new PageBasedPagingSpec(pageNumber, pageSize, NUMBER_PARAMETER, SIZE_PARAMETER);
+        }
+        return pagingSpec;
+    }
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/DefaultQuerySpecSerializer.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/DefaultQuerySpecSerializer.java
@@ -1,18 +1,12 @@
 package io.katharsis.queryspec;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import io.katharsis.repository.exception.RepositoryNotFoundException;
 import io.katharsis.resource.RestrictedQueryParamsMembers;
 import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.utils.StringUtils;
+
+import java.util.*;
 
 public class DefaultQuerySpecSerializer implements QuerySpecSerializer {
 
@@ -119,11 +113,15 @@ public class DefaultQuerySpecSerializer implements QuerySpecSerializer {
 	}
 
 	public void serializePagination(QuerySpec querySpec, String resourceType, Map<String, Set<String>> map) {
-		if (querySpec.getOffset() != 0) {
-			put(map, "page[offset]", Long.toString(querySpec.getOffset()));
-		}
-		if (querySpec.getLimit() != null) {
-			put(map, "page[limit]", Long.toString(querySpec.getLimit()));
+		PagingSpec pagingSpec = querySpec.getPagingSpec();
+		if (pagingSpec == null) return;
+
+		Map<String, String> nameValues = pagingSpec.getSerializationNameValues();
+		if (nameValues == null) return;
+
+		for (Map.Entry<String, String> nameValue : nameValues.entrySet()) {
+			String name = String.format("page[%s]", nameValue.getKey());
+			put(map, name, nameValue.getValue());
 		}
 	}
 

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/InMemoryEvaluator.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/InMemoryEvaluator.java
@@ -1,17 +1,15 @@
 package io.katharsis.queryspec;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-
 import io.katharsis.response.paging.PagedResultList;
 import io.katharsis.utils.PropertyUtils;
+
+import java.util.*;
 
 /**
  * Applies the given QuerySpec to the provided list in memory. Result available
  * with getResult(). Use QuerySpec.apply to make use of this class.
+ *
+ * Pagination prefers limit/offset over page number/size when both are set.
  */
 public class InMemoryEvaluator {
 
@@ -46,14 +44,10 @@ public class InMemoryEvaluator {
 	}
 
 	private <T> List<T> applyPaging(List<T> results, QuerySpec querySpec) {
-		int offset = (int) Math.min(querySpec.getOffset(), Integer.MAX_VALUE);
-		int limit = (int) Math.min(Integer.MAX_VALUE,
-				querySpec.getLimit() != null ? querySpec.getLimit() : Integer.MAX_VALUE);
-		limit = Math.min(results.size() - offset, limit);
-		if (offset > 0 || limit < results.size()) {
-			return results.subList(offset, offset + limit);
-		}
-		return results;
+		PagingSpec pagingSpec = querySpec.getPagingSpec();
+		if (pagingSpec == null)
+			return results;
+		return pagingSpec.applyPaging(results);
 	}
 
 	private <T> void applyFilter(List<T> results, FilterSpec filterSpec) {

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/OffsetBasedPagingSpec.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/OffsetBasedPagingSpec.java
@@ -1,0 +1,173 @@
+package io.katharsis.queryspec;
+
+import io.katharsis.utils.CompareUtils;
+import io.katharsis.utils.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Offset+Limit based paging implementation where offset and limit (here called limit) are the primary
+ * paging inputs.
+ * <p>
+ * Looking for page number and size based paging? See {@link PageBasedPagingSpec}.
+ */
+public class OffsetBasedPagingSpec implements PagingSpec {
+    private final long offset;
+    private final long limit;
+
+
+    private String offsetName = "offset";
+    private String limitName = "limit";
+
+    /**
+     * Construct an offset based paging spec with default serialization names.
+     *
+     * @param offset
+     * @param limit
+     */
+    public OffsetBasedPagingSpec(long offset, long limit) {
+        this.offset = offset;
+        this.limit = limit;
+    }
+
+    /**
+     * Construct an offset based paging spec with customized serialization names.
+     *
+     * @param offset
+     * @param limit
+     * @param offsetName
+     * @param limitName
+     */
+    public OffsetBasedPagingSpec(long offset, long limit, String offsetName, String limitName) {
+        this.offset = offset;
+        this.limit = limit;
+        this.offsetName = offsetName;
+        this.limitName = limitName;
+    }
+
+    @Override
+    public <T> List<T> applyPaging(List<T> results) {
+        int actualOffset = (int) Math.min(getOffset(), Integer.MAX_VALUE);
+        int actualLimit = (int) Math.min(getLimit(), Integer.MAX_VALUE);
+
+        return OffsetBasedPagingSpec.applyPaging(actualLimit, actualOffset, results);
+    }
+
+    public static <T> List<T> applyPaging(int limit, int offset, List<T> results) {
+        limit = Math.min(results.size() - offset, limit);
+        if (offset > 0 || limit < results.size()) {
+            return results.subList(offset, offset + limit);
+        }
+        return results;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public long getLimit() {
+        return limit;
+    }
+
+    /**
+     * The serialized name of the offset, defaults to "offset"
+     *
+     * @return
+     */
+    public String getOffsetName() {
+        return offsetName;
+    }
+
+    public void setOffsetName(String offsetName) {
+        if (StringUtils.isBlank(offsetName))
+            throw new IllegalArgumentException("Offset name should not be null or empty.");
+        this.offsetName = offsetName;
+    }
+
+
+    /**
+     * The serialized name of the limit, defaults to "limit"
+     *
+     * @return
+     */
+    public String getLimitName() {
+        return limitName;
+    }
+
+    public void setLimitName(String limitName) {
+        if (StringUtils.isBlank(limitName))
+            throw new IllegalArgumentException("Limit name should not be null or empty.");
+        this.limitName = limitName;
+    }
+
+    /**
+     * A map containing:
+     * offsetName : offset
+     * limitName  : limit
+     *
+     * @return
+     */
+    @Override
+    public Map<String, String> getSerializationNameValues() {
+        Map<String, String> map = new HashMap<>();
+        map.put(offsetName, Long.toString(getOffset()));
+        map.put(limitName, Long.toString(getLimit()));
+        return map;
+    }
+
+    @Override
+    public PagingSpec duplicate() {
+        return new OffsetBasedPagingSpec(offset, limit, offsetName, limitName);
+    }
+
+    @Override
+    public PagingSpec first() {
+        return new OffsetBasedPagingSpec(0, limit, offsetName, limitName);
+    }
+
+    @Override
+    public PagingSpec next(long totalCount, long totalPages) {
+        return new OffsetBasedPagingSpec(Math.min(totalCount, offset + limit), limit, offsetName, limitName);
+    }
+
+    @Override
+    public PagingSpec prev(long totalCount, long totalPages) {
+        return new OffsetBasedPagingSpec(Math.max(0, offset - limit), limit, offsetName, limitName);
+    }
+
+    @Override
+    public PagingSpec last(long totalCount, long totalPages) {
+        return new OffsetBasedPagingSpec((totalPages - 1) * limit, limit, offsetName, limitName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        OffsetBasedPagingSpec that = (OffsetBasedPagingSpec) o;
+
+        return CompareUtils.isEquals(offset, that.offset)
+                && CompareUtils.isEquals(limit, that.limit)
+                && CompareUtils.isEquals(limitName, that.limitName)
+                && CompareUtils.isEquals(offsetName, that.offsetName);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Long.valueOf(offset).hashCode();
+        result = prime * result + Long.valueOf(limit).hashCode();
+        result = prime * result + limitName.hashCode();
+        result = prime * result + offsetName.hashCode();
+        return result;
+    }
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/PageBasedPagingSpec.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/PageBasedPagingSpec.java
@@ -1,0 +1,185 @@
+package io.katharsis.queryspec;
+
+import io.katharsis.utils.CompareUtils;
+import io.katharsis.utils.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Paging implementation that uses page number and page size
+ * as the paging inputs.
+ * <p>
+ * Looking for offset+limit based paging? See {@link PageBasedPagingSpec}.
+ */
+public class PageBasedPagingSpec implements PagingSpec {
+    private final long pageNumber;
+    private final long pageSize;
+
+    private String pageNumberName = "number";
+    private String pageSizeName = "size";
+
+    /**
+     * Create a page based paging spec with the specified page number and page size
+     *
+     * @param pageNumber
+     * @param pageSize
+     */
+    public PageBasedPagingSpec(long pageNumber, long pageSize) {
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+    }
+
+    /**
+     * Create a page based paging spec with the specified page number and page size
+     *
+     * @param pageNumber
+     * @param pageSize
+     * @param pageNumberName the serialized name of the page number, defaults to "number"
+     * @param pageSizeName   the serialized name of the page size, defaults to "size"
+     */
+    public PageBasedPagingSpec(long pageNumber, long pageSize, String pageNumberName, String pageSizeName) {
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        this.pageNumberName = pageNumberName;
+        this.pageSizeName = pageSizeName;
+    }
+
+    @Override
+    public <T> List<T> applyPaging(List<T> results) {
+        long calculatedOffset = getOffset();
+        int actualOffset = (int) Math.min(calculatedOffset, Integer.MAX_VALUE);
+        int actualLimit = (int) Math.min(getLimit(), Integer.MAX_VALUE);
+
+        return OffsetBasedPagingSpec.applyPaging(actualLimit, actualOffset, results);
+    }
+
+    @Override
+    /**
+     * Returns the offset according to the underlying page and page size.
+     *
+     * @return the calculated offset
+     */
+    public long getOffset() {
+        return pageNumber * pageSize;
+    }
+
+    /**
+     * The page represented
+     *
+     * @return
+     */
+    public long getPageNumber() {
+        return pageNumber;
+    }
+
+
+    /**
+     * The number of items to be returned
+     *
+     * @return number of items in the page
+     */
+    @Override
+    public long getLimit() {
+        return pageSize;
+    }
+
+    /**
+     * A map containing:
+     * pageNumberName : pageNumber
+     * pageSizeName   : pageSize
+     *
+     * @return
+     */
+    @Override
+    public Map<String, String> getSerializationNameValues() {
+        Map<String, String> map = new HashMap<>();
+        map.put(pageNumberName, Long.toString(getPageNumber()));
+        map.put(pageSizeName, Long.toString(getLimit()));
+        return map;
+    }
+
+    /**
+     * The serialized name of the page number, defaults to "number"
+     *
+     * @return
+     */
+    public String getPageNumberName() {
+        return pageNumberName;
+    }
+
+    public void setPageNumberName(String pageNumberName) {
+        if (StringUtils.isBlank(pageNumberName))
+            throw new IllegalArgumentException("Page number name should not be null or empty.");
+        this.pageNumberName = pageNumberName;
+    }
+
+    /**
+     * The serialized name of the page number, defaults to "size"
+     *
+     * @return
+     */
+    public String getPageSizeName() {
+        return pageSizeName;
+    }
+
+    public void setPageSizeName(String pageSizeName) {
+        if (StringUtils.isBlank(pageSizeName))
+            throw new IllegalArgumentException("Page size name should not be null or empty.");
+        this.pageSizeName = pageSizeName;
+    }
+
+    @Override
+    public PagingSpec duplicate() {
+        return new PageBasedPagingSpec(getPageNumber(), getLimit(), pageNumberName, pageSizeName);
+    }
+
+    @Override
+    public PagingSpec first() {
+        return new PageBasedPagingSpec(0, getLimit(), pageNumberName, pageSizeName);
+    }
+
+    @Override
+    public PagingSpec next(long totalCount, long totalPages) {
+        return new PageBasedPagingSpec(getPageNumber() + 1, getLimit(), pageNumberName, pageSizeName);
+    }
+
+    @Override
+    public PagingSpec prev(long totalCount, long totalPages) {
+        return getPageNumber() == 0 ? this : new PageBasedPagingSpec(getPageNumber() - 1, getLimit());
+    }
+
+    @Override
+    public PagingSpec last(long totalCount, long totalPages) {
+        return new PageBasedPagingSpec(totalPages - 1, getLimit(), pageNumberName, pageSizeName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        PageBasedPagingSpec that = (PageBasedPagingSpec) o;
+
+        return CompareUtils.isEquals(pageNumber, that.pageNumber)
+                && CompareUtils.isEquals(pageSize, that.pageSize)
+                && CompareUtils.isEquals(pageSizeName, that.pageSizeName)
+                && CompareUtils.isEquals(pageNumberName, that.pageNumberName);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Long.valueOf(pageNumber).hashCode();
+        result = prime * result + Long.valueOf(pageSize).hashCode();
+        result = prime * result + pageSizeName.hashCode();
+        result = prime * result + pageNumberName.hashCode();
+        return result;
+    }
+
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/PagingSpec.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/PagingSpec.java
@@ -1,0 +1,88 @@
+package io.katharsis.queryspec;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An abstract interface for paging implementations.
+ * <p>
+ * See one of the default implementations:
+ * <p>
+ * {@link PageBasedPagingSpec} or
+ * {@link OffsetBasedPagingSpec}
+ */
+public interface PagingSpec extends Serializable {
+
+    /**
+     * Applies the paging parameters to the supplied list and returns the appropriate page.
+     *
+     * @param results
+     * @param <T>
+     * @return the sub list matching the paging spec
+     */
+    <T> List<T> applyPaging(List<T> results);
+
+    /**
+     * Returns the offset to be taken according to the underlying page and page size.
+     *
+     * @return the offset to be take
+     */
+    long getOffset();
+
+    /**
+     * Returns the number of items to be returned from the page.
+     *
+     * @return the number of items of the page
+     */
+    long getLimit();
+
+    /**
+     * A map of the paging parameters and value. It is used to serialize the paging spec to query parameters.
+     * <p>
+     * See the {@link PageBasedPagingSpec#getSerializationNameValues()} or
+     * {@link OffsetBasedPagingSpec#getSerializationNameValues()} for examples.
+     *
+     * @return
+     */
+    Map<String, String> getSerializationNameValues();
+
+    /**
+     * Return a clone of this instance
+     */
+    PagingSpec duplicate();
+
+    /**
+     * Get the PagingSpec for the first page
+     *
+     * @return
+     */
+    PagingSpec first();
+
+    /**
+     * Get the PagingSpec for the next page, given a total count and pages
+     *
+     * @param totalCount
+     * @param totalPages
+     * @return
+     */
+    PagingSpec next(long totalCount, long totalPages);
+
+    /**
+     * Get the PagingSpec for the previous page, given a total count and pages
+     *
+     * @param totalCount
+     * @param totalPages
+     * @return
+     */
+    PagingSpec prev(long totalCount, long totalPages);
+
+    /**
+     * Get the PagingSpec for the last page, given a total count and pages
+     *
+     * @param totalCount
+     * @param totalPages
+     * @return
+     */
+    PagingSpec last(long totalCount, long totalPages);
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpec.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpec.java
@@ -2,20 +2,14 @@ package io.katharsis.queryspec;
 
 import io.katharsis.utils.CompareUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 public class QuerySpec {
 
 	private Class<?> resourceClass;
 
-	private Long limit = null;
-
-	private long offset = 0;
+	private PagingSpec pagingSpec;
 
 	private List<FilterSpec> filters = new ArrayList<>();
 
@@ -29,6 +23,11 @@ public class QuerySpec {
 
 	public QuerySpec(Class<?> resourceClass) {
 		this.resourceClass = resourceClass;
+	}
+
+	public QuerySpec(Class<?> resourceClass, PagingSpec pagingSpec) {
+		this.resourceClass = resourceClass;
+		this.pagingSpec = pagingSpec;
 	}
 
 	public Class<?> getResourceClass() {
@@ -57,8 +56,7 @@ public class QuerySpec {
 		result = prime * result + ((filters == null) ? 0 : filters.hashCode());
 		result = prime * result + ((includedFields == null) ? 0 : includedFields.hashCode());
 		result = prime * result + ((includedRelations == null) ? 0 : includedRelations.hashCode());
-		result = prime * result + ((limit == null) ? 0 : limit.hashCode());
-		result = prime * result + Long.valueOf(offset).hashCode();
+		result = prime * result + ((pagingSpec == null) ? 0 : pagingSpec.hashCode());
 		result = prime * result + ((relatedSpecs == null) ? 0 : relatedSpecs.hashCode());
 		result = prime * result + ((sort == null) ? 0 : sort.hashCode());
 		return result;
@@ -73,25 +71,17 @@ public class QuerySpec {
 		QuerySpec other = (QuerySpec) obj;
 		return CompareUtils.isEquals(filters, other.filters) // NOSONAR
 				&& CompareUtils.isEquals(includedFields, other.includedFields)
-				&& CompareUtils.isEquals(includedRelations, other.includedRelations) && CompareUtils.isEquals(limit, other.limit)
-				&& CompareUtils.isEquals(offset, other.offset) && CompareUtils.isEquals(relatedSpecs, other.relatedSpecs)
+				&& CompareUtils.isEquals(includedRelations, other.includedRelations)
+				&& CompareUtils.isEquals(pagingSpec, other.pagingSpec) && CompareUtils.isEquals(relatedSpecs, other.relatedSpecs)
 				&& CompareUtils.isEquals(sort, other.sort);
 	}
 
-	public Long getLimit() {
-		return limit;
+	public PagingSpec getPagingSpec() {
+		return pagingSpec;
 	}
 
-	public void setLimit(Long limit) {
-		this.limit = limit;
-	}
-
-	public long getOffset() {
-		return offset;
-	}
-
-	public void setOffset(long offset) {
-		this.offset = offset;
+	public void setPagingSpec(PagingSpec pagingSpec) {
+		this.pagingSpec = pagingSpec;
 	}
 
 	public List<FilterSpec> getFilters() {
@@ -179,8 +169,7 @@ public class QuerySpec {
 
 	public QuerySpec duplicate() {
 		QuerySpec copy = new QuerySpec(resourceClass);
-		copy.limit = limit;
-		copy.offset = offset;
+		copy.pagingSpec = pagingSpec;
 		copy.includedFields.addAll(includedFields);
 		copy.includedRelations.addAll(includedRelations);
 		copy.sort.addAll(sort);

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/internal/PageQueryAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/internal/PageQueryAdapter.java
@@ -1,0 +1,83 @@
+package io.katharsis.queryspec.internal;
+
+public interface PageQueryAdapter {
+
+    /**
+     * The total number of pages for the query.
+     *
+     * @return
+     */
+    long getTotalPages();
+
+    /**
+     * The total number of items across all pages in the query.
+     *
+     * @return
+     */
+    long getTotalCount();
+
+    void setTotalPages(long totalPages);
+
+    void setTotalCount(long totalCount);
+
+    /**
+     * The current offset for this page
+     *
+     * @return
+     */
+    long getOffset();
+
+    /**
+     * The current limit for this page
+     *
+     * @return
+     */
+    long getLimit();
+
+    /**
+     * Get the PagingSpec for the first page
+     *
+     * @return
+     */
+    PageQueryAdapter first();
+
+    /**
+     * Returns whether there is a next page that can be accessed from the current page
+     *
+     * @return
+     */
+    boolean hasNext();
+
+    /**
+     * Get the PagingSpec for the next page
+     *
+     * @return
+     */
+    PageQueryAdapter next();
+
+    /**
+     * Returns whether there is a previous page that can be accessed from the current page
+     *
+     * @return
+     */
+    boolean hasPrev();
+
+    /**
+     * Get the PagingSpec for the previous page
+     *
+     * @return
+     */
+    PageQueryAdapter prev();
+
+    /**
+     * Get the PagingSpec for the last page
+     *
+     * @return
+     */
+    PageQueryAdapter last();
+
+    /**
+     * @return clone of this instance
+     */
+    PageQueryAdapter duplicate();
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/internal/PageQuerySpecAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/internal/PageQuerySpecAdapter.java
@@ -1,0 +1,113 @@
+package io.katharsis.queryspec.internal;
+
+import io.katharsis.queryspec.PagingSpec;
+
+public class PageQuerySpecAdapter implements PageQueryAdapter {
+    private final PagingSpec pagingSpec;
+    private long totalCount;
+    private long totalPages;
+
+    public PageQuerySpecAdapter(PagingSpec pagingSpec) {
+        this.pagingSpec = pagingSpec;
+    }
+
+
+    public PageQuerySpecAdapter(PagingSpec pagingSpec, long totalCount, long totalPages) {
+        this.pagingSpec = pagingSpec;
+        this.totalCount = totalCount;
+        this.totalPages = totalPages;
+    }
+
+    public PagingSpec getPagingSpec() {
+        return pagingSpec;
+    }
+
+    @Override
+    public long getTotalPages() {
+        return totalPages;
+    }
+
+    @Override
+    public long getTotalCount() {
+        return totalCount;
+    }
+
+    @Override
+    public void setTotalPages(long totalPages) {
+        this.totalPages = totalPages;
+    }
+
+    @Override
+    public void setTotalCount(long totalCount) {
+        this.totalCount = totalCount;
+
+    }
+
+    @Override
+    public long getOffset() {
+        return pagingSpec.getOffset();
+    }
+
+    @Override
+    public long getLimit() {
+        return pagingSpec.getLimit();
+    }
+
+    @Override
+    public PageQueryAdapter first() {
+        return new PageQuerySpecAdapter(pagingSpec.first(), totalCount, totalPages);
+    }
+
+    @Override
+    public boolean hasNext() {
+        long currentPage = getOffset() / getLimit();
+        return currentPage + 1 < getTotalPages();
+    }
+
+    @Override
+    public PageQueryAdapter next() {
+        return new PageQuerySpecAdapter(pagingSpec.next(totalCount, totalPages), totalCount, totalPages);
+    }
+
+    @Override
+    public boolean hasPrev() {
+        long currentPage = getOffset() / getLimit();
+        return currentPage > 0;
+    }
+
+    @Override
+    public PageQueryAdapter prev() {
+        return new PageQuerySpecAdapter(pagingSpec.prev(totalCount, totalPages), totalCount, totalPages);
+    }
+
+    @Override
+    public PageQueryAdapter last() {
+        return new PageQuerySpecAdapter(pagingSpec.last(totalCount, totalPages), totalCount, totalPages);
+    }
+
+    @Override
+    public PageQueryAdapter duplicate() {
+        return new PageQuerySpecAdapter(pagingSpec.duplicate(), totalCount, totalPages);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PageQuerySpecAdapter that = (PageQuerySpecAdapter) o;
+
+        if (totalCount != that.totalCount) return false;
+        if (totalPages != that.totalPages) return false;
+        return pagingSpec.equals(that.pagingSpec);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pagingSpec.hashCode();
+        result = 31 * result + (int) (totalCount ^ (totalCount >>> 32));
+        result = 31 * result + (int) (totalPages ^ (totalPages >>> 32));
+        return result;
+    }
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/internal/QueryAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/internal/QueryAdapter.java
@@ -6,31 +6,20 @@ import io.katharsis.queryParams.params.TypedParams;
 
 public interface QueryAdapter {
 
-	boolean hasIncludedRelations();
+    boolean hasIncludedRelations();
 
-	TypedParams<IncludedRelationsParams> getIncludedRelations();
+    TypedParams<IncludedRelationsParams> getIncludedRelations();
 
-	TypedParams<IncludedFieldsParams> getIncludedFields();
+    TypedParams<IncludedFieldsParams> getIncludedFields();
 
-	Class<?> getResourceClass();
+    Class<?> getResourceClass();
 
-	/**
-	 * @return maximum number of resources to return or null for unbounded
-	 */
-	Long getLimit();
+    PageQueryAdapter getPageAdapter();
+    void setPageAdapter(PageQueryAdapter adapter);
 
-	/**
-	 * @return maximum number of resources to skip in the response.
-	 */
-	public long getOffset();
-
-	/**
-	 * @return clone of this instance
-	 */
-	QueryAdapter duplicate();
-
-	void setLimit(Long limit);
-
-	void setOffset(long offset);
+    /**
+     * @return clone of this instance
+     */
+    QueryAdapter duplicate();
 
 }

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/internal/QueryParamsAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/internal/QueryParamsAdapter.java
@@ -59,27 +59,17 @@ public class QueryParamsAdapter implements QueryAdapter {
 	}
 
 	@Override
-	public Long getLimit() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public long getOffset() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public QueryAdapter duplicate() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void setLimit(Long limit) {
+	public PageQueryAdapter getPageAdapter() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void setOffset(long offset) {
+	public void setPageAdapter(PageQueryAdapter adapter) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/internal/QuerySpecAdapter.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/internal/QuerySpecAdapter.java
@@ -1,10 +1,5 @@
 package io.katharsis.queryspec.internal;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import io.katharsis.queryParams.include.Inclusion;
 import io.katharsis.queryParams.params.IncludedFieldsParams;
 import io.katharsis.queryParams.params.IncludedRelationsParams;
@@ -17,15 +12,29 @@ import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.utils.StringUtils;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 public class QuerySpecAdapter implements QueryAdapter {
 
 	private QuerySpec querySpec;
 
 	private ResourceRegistry resourceRegistry;
 
+	private PageQueryAdapter pageQuerySpecAdapter;
+
 	public QuerySpecAdapter(QuerySpec querySpec, ResourceRegistry resourceRegistry) {
 		this.querySpec = querySpec;
 		this.resourceRegistry = resourceRegistry;
+		this.pageQuerySpecAdapter = new PageQuerySpecAdapter(querySpec.getPagingSpec());
+	}
+
+	public QuerySpecAdapter(QuerySpec querySpec, ResourceRegistry resourceRegistry, PageQuerySpecAdapter pageQuerySpecAdapter) {
+		this.querySpec = querySpec;
+		this.resourceRegistry = resourceRegistry;
+		this.pageQuerySpecAdapter = pageQuerySpecAdapter;
 	}
 
 	public QuerySpec getQuerySpec() {
@@ -97,27 +106,21 @@ public class QuerySpecAdapter implements QueryAdapter {
 	}
 
 	@Override
-	public Long getLimit() {
-		return querySpec.getLimit();
-	}
-
-	@Override
-	public long getOffset() {
-		return querySpec.getOffset();
-	}
-
-	@Override
 	public QueryAdapter duplicate() {
-		return new QuerySpecAdapter(querySpec.duplicate(), resourceRegistry);
+		return new QuerySpecAdapter(querySpec.duplicate(), resourceRegistry, (PageQuerySpecAdapter) pageQuerySpecAdapter.duplicate());
 	}
 
 	@Override
-	public void setLimit(Long limit) {
-		querySpec.setLimit(limit);
+	public PageQueryAdapter getPageAdapter() {
+		return this.pageQuerySpecAdapter;
 	}
 
 	@Override
-	public void setOffset(long offset) {
-		querySpec.setOffset(offset);
+	public void setPageAdapter(PageQueryAdapter adapter) {
+		if (!(adapter instanceof PageQuerySpecAdapter))
+			throw new UnsupportedOperationException("QuerySpecAdapter only supports PageQuerySpecAdapters and derivative types");
+		this.pageQuerySpecAdapter = adapter;
+		PageQuerySpecAdapter pageAdapter = (PageQuerySpecAdapter) adapter;
+		querySpec.setPagingSpec(pageAdapter.getPagingSpec());
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/queryParams/QueryParamsAdapterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryParams/QueryParamsAdapterTest.java
@@ -1,12 +1,11 @@
 package io.katharsis.queryParams;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.katharsis.queryspec.internal.QueryParamsAdapter;
 import io.katharsis.resource.mock.models.Task;
 import io.katharsis.resource.registry.ConstantServiceUrlProvider;
 import io.katharsis.resource.registry.ResourceRegistry;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class QueryParamsAdapterTest {
 
@@ -41,30 +40,16 @@ public class QueryParamsAdapterTest {
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
-	public void testGetLimit() {
+	public void testGetPageAdapter() {
 		QueryParams params = new QueryParams();
 		QueryParamsAdapter adapter = new QueryParamsAdapter(params);
-		adapter.getLimit();
+        adapter.getPageAdapter();
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
-	public void testGetOffset() {
+	public void testSetPageAdapter() {
 		QueryParams params = new QueryParams();
 		QueryParamsAdapter adapter = new QueryParamsAdapter(params);
-		adapter.getOffset();
-	}
-
-	@Test(expected = UnsupportedOperationException.class)
-	public void testSetLimit() {
-		QueryParams params = new QueryParams();
-		QueryParamsAdapter adapter = new QueryParamsAdapter(params);
-		adapter.setLimit(0L);
-	}
-
-	@Test(expected = UnsupportedOperationException.class)
-	public void testSetOffset() {
-		QueryParams params = new QueryParams();
-		QueryParamsAdapter adapter = new QueryParamsAdapter(params);
-		adapter.setOffset(0L);
+		adapter.setPageAdapter(null);
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/DefaultQuerySpecConverterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/DefaultQuerySpecConverterTest.java
@@ -1,17 +1,12 @@
 package io.katharsis.queryspec;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.resource.mock.models.Project;
 import io.katharsis.resource.mock.models.Task;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
 
 public class DefaultQuerySpecConverterTest extends AbstractQuerySpecTest {
 
@@ -163,8 +158,8 @@ public class DefaultQuerySpecConverterTest extends AbstractQuerySpecTest {
 		QueryParams queryParams = queryParamsBuilder.buildQueryParams(params);
 
 		QuerySpec spec = parser.fromParams(Task.class, queryParams);
-		Assert.assertEquals(1L, spec.getOffset());
-		Assert.assertEquals(Long.valueOf(2L), spec.getLimit());
+		Assert.assertEquals(1L, spec.getPagingSpec().getOffset());
+		Assert.assertEquals(2L, spec.getPagingSpec().getLimit());
 	}
 
 	@Test

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/DefaultQuerySpecSerializerTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/DefaultQuerySpecSerializerTest.java
@@ -1,13 +1,5 @@
 package io.katharsis.queryspec;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.katharsis.locator.JsonServiceLocator;
 import io.katharsis.locator.SampleJsonServiceLocator;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
@@ -19,6 +11,13 @@ import io.katharsis.resource.registry.DefaultResourceLookup;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.ResourceRegistryBuilder;
 import io.katharsis.utils.JsonApiUrlBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 public class DefaultQuerySpecSerializerTest {
 
@@ -122,17 +121,15 @@ public class DefaultQuerySpecSerializerTest {
 	@Test
 	public void testPaging() throws InstantiationException, IllegalAccessException {
 		QuerySpec querySpec = new QuerySpec(Task.class);
-		querySpec.setLimit(2L);
-		querySpec.setOffset(1L);
+		querySpec.setPagingSpec(new OffsetBasedPagingSpec(1, 2));
 		check("http://127.0.0.1/tasks/?page[limit]=2&page[offset]=1", null, querySpec);
 	}
 
 	@Test
 	public void testPagingOnRelation() throws InstantiationException, IllegalAccessException {
 		QuerySpec querySpec = new QuerySpec(Task.class);
-		querySpec.setLimit(2L);
-		querySpec.setOffset(1L);
-		
+		querySpec.setPagingSpec(new OffsetBasedPagingSpec(1, 2));
+
 		String actualUrl = urlBuilder.buildUrl(Task.class, 1L, querySpec, "projects");
 		assertEquals("http://127.0.0.1/tasks/1/relationships/projects/?page[limit]=2&page[offset]=1", actualUrl);
 	}

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/InMemoryEvaluatorTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/InMemoryEvaluatorTest.java
@@ -1,14 +1,13 @@
 package io.katharsis.queryspec;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
+import io.katharsis.resource.mock.models.Task;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.katharsis.resource.mock.models.Task;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class InMemoryEvaluatorTest {
 
@@ -33,24 +32,15 @@ public class InMemoryEvaluatorTest {
 	}
 
 	@Test
-	public void setLimit() {
+	public void setPageSpec() {
 		QuerySpec spec = new QuerySpec(Task.class);
-		spec.setLimit(2L);
+        spec.setPagingSpec(new OffsetBasedPagingSpec(3, 2));
 		Assert.assertEquals(2, spec.apply(tasks).size());
-	}
 
-	@Test
-	public void setOffset() {
-		QuerySpec spec = new QuerySpec(Task.class);
-		spec.setOffset(2L);
-		Assert.assertEquals(3, spec.apply(tasks).size());
-	}
+        spec.setPagingSpec(new PageBasedPagingSpec(0, 2));
+		Assert.assertEquals(2, spec.apply(tasks).size());
 
-	@Test
-	public void setOffsetLimit() {
-		QuerySpec spec = new QuerySpec(Task.class);
-		spec.setOffset(2L);
-		spec.setLimit(1L);
+		spec.setPagingSpec(new OffsetBasedPagingSpec(2, 1));
 		List<Task> results = spec.apply(tasks);
 		Assert.assertEquals(1, results.size());
 		Assert.assertEquals(Long.valueOf(2L), results.get(0).getId());

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/OffsetBasedPagingSpecTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/OffsetBasedPagingSpecTest.java
@@ -1,0 +1,93 @@
+package io.katharsis.queryspec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+class OffsetBasedPagingSpecTest {
+    @Test
+    public void applyPaging() throws Exception {
+        List<String> list = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(0, 1);
+
+        List<String> result = spec.applyPaging(list);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("1", result.get(0));
+
+        spec = new OffsetBasedPagingSpec(2, 4);
+        result = spec.applyPaging(list);
+
+        Assert.assertEquals(4, result.size());
+        Assert.assertEquals(list.subList(2, 6), result);
+    }
+
+    @Test
+    public void getSerializationNameValues() throws Exception {
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(5, 10, "foo", "bar");
+
+        Map<String, String> serializationNameValues = spec.getSerializationNameValues();
+        Assert.assertEquals("5", serializationNameValues.get("foo"));
+        Assert.assertEquals("10", serializationNameValues.get("bar"));
+    }
+
+    @Test
+    public void testDuplicateEqualsAndHashCode() throws Exception {
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(5, 10, "foo", "bar");
+        OffsetBasedPagingSpec duplicate = (OffsetBasedPagingSpec) spec.duplicate();
+
+        Assert.assertEquals(spec.getLimit(), duplicate.getLimit());
+        Assert.assertEquals(spec.getOffset(), duplicate.getOffset());
+        Assert.assertEquals(spec.getOffsetName(), duplicate.getOffsetName());
+        Assert.assertEquals(spec.getLimitName(), duplicate.getLimitName());
+
+        Assert.assertTrue(spec.equals(duplicate));
+        Assert.assertEquals(spec.hashCode(), duplicate.hashCode());
+
+        Assert.assertNotEquals(spec, "someOtherType");
+    }
+
+    @Test
+    public void first() throws Exception {
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(5, 10);
+        PagingSpec first = spec.first();
+        Assert.assertEquals(spec.getLimit(), first.getLimit());
+        Assert.assertEquals(0L, first.getOffset());
+
+        OffsetBasedPagingSpec firstClone = new OffsetBasedPagingSpec(0, 10);
+        Assert.assertTrue(first.equals(firstClone));
+    }
+
+    @Test
+    public void next() throws Exception {
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(0, 10);
+        PagingSpec next = spec.next(30, 3);
+        Assert.assertEquals(spec.getLimit(), next.getLimit());
+        Assert.assertEquals(10, next.getOffset());
+    }
+
+    @Test
+    public void prev() throws Exception {
+        // when prev() called on the first page, must result in the same page
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(0, 10);
+        PagingSpec prev = spec.prev(30, 3);
+        Assert.assertEquals(spec, prev);
+
+        spec = new OffsetBasedPagingSpec(10, 5);
+        prev = spec.prev(5 * 4, 4);
+        Assert.assertEquals(spec.getLimit(), prev.getLimit());
+        Assert.assertEquals(5, prev.getOffset());
+    }
+
+    @Test
+    public void last() throws Exception {
+        OffsetBasedPagingSpec spec = new OffsetBasedPagingSpec(0, 10);
+        PagingSpec last = spec.last(30, 3);
+        Assert.assertEquals(spec.getLimit(), last.getLimit());
+        Assert.assertEquals(20, last.getOffset());
+    }
+
+}

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/PageBasedPagingSpecTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/PageBasedPagingSpecTest.java
@@ -1,0 +1,95 @@
+package io.katharsis.queryspec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class PageBasedPagingSpecTest {
+    @Test
+    public void applyPaging() throws Exception {
+        List<String> list = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(0, 1);
+
+        List<String> result = spec.applyPaging(list);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("1", result.get(0));
+
+        spec = new PageBasedPagingSpec(2, 4);
+        result = spec.applyPaging(list);
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals(list.subList(8, 10), result);
+    }
+
+    @Test
+    public void getSerializationNameValues() throws Exception {
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(5, 10, "foo", "bar");
+
+        Map<String, String> serializationNameValues = spec.getSerializationNameValues();
+        Assert.assertEquals("5", serializationNameValues.get("foo"));
+        Assert.assertEquals("10", serializationNameValues.get("bar"));
+    }
+
+    @Test
+    public void testDuplicateEqualsAndHashCode() throws Exception {
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(5, 10, "foo", "bar");
+        PageBasedPagingSpec duplicate = (PageBasedPagingSpec) spec.duplicate();
+
+        Assert.assertEquals(spec.getLimit(), duplicate.getLimit());
+        Assert.assertEquals(spec.getOffset(), duplicate.getOffset());
+        Assert.assertEquals(spec.getPageNumber(), duplicate.getPageNumber());
+
+        Assert.assertTrue(spec.equals(duplicate));
+        Assert.assertEquals(spec.hashCode(), duplicate.hashCode());
+
+        Assert.assertNotEquals(spec, "someOtherType");
+    }
+
+    @Test
+    public void first() throws Exception {
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(5, 10);
+        PageBasedPagingSpec first = (PageBasedPagingSpec) spec.first();
+        Assert.assertEquals(spec.getLimit(), first.getLimit());
+        Assert.assertEquals(0L, first.getOffset());
+        Assert.assertEquals(0L, first.getPageNumber());
+
+        PageBasedPagingSpec firstClone = new PageBasedPagingSpec(0, 10);
+        Assert.assertTrue(first.equals(firstClone));
+    }
+
+    @Test
+    public void next() throws Exception {
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(0, 10);
+        PageBasedPagingSpec next = (PageBasedPagingSpec) spec.next(30, 3);
+        Assert.assertEquals(spec.getLimit(), next.getLimit());
+        Assert.assertEquals(10, next.getOffset());
+        Assert.assertEquals(1, next.getPageNumber());
+    }
+
+    @Test
+    public void prev() throws Exception {
+        // when prev() called on the first page, must result in the same page
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(0, 10);
+        PageBasedPagingSpec prev = (PageBasedPagingSpec) spec.prev(30, 3);
+        Assert.assertEquals(spec, prev);
+
+        spec = new PageBasedPagingSpec(10, 5);
+        prev = (PageBasedPagingSpec) spec.prev(10 * 5, 10);
+        Assert.assertEquals(spec.getLimit(), prev.getLimit());
+        Assert.assertEquals(9, prev.getPageNumber());
+    }
+
+    @Test
+    public void last() throws Exception {
+        PageBasedPagingSpec spec = new PageBasedPagingSpec(0, 10);
+        PageBasedPagingSpec last = (PageBasedPagingSpec) spec.last(30, 3);
+        Assert.assertEquals(spec.getLimit(), last.getLimit());
+        Assert.assertEquals(20, last.getOffset());
+        Assert.assertEquals(2, last.getPageNumber());
+    }
+
+}

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/QuerySpecTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/QuerySpecTest.java
@@ -1,14 +1,13 @@
 package io.katharsis.queryspec;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-
+import io.katharsis.resource.mock.models.Project;
+import io.katharsis.resource.mock.models.Task;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.katharsis.resource.mock.models.Project;
-import io.katharsis.resource.mock.models.Task;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 
 public class QuerySpecTest {
 
@@ -48,8 +47,8 @@ public class QuerySpecTest {
 		spec.addSort(new SortSpec(Arrays.asList("sortAttr"), Direction.ASC));
 		spec.includeField(Arrays.asList("includedField"));
 		spec.includeRelation(Arrays.asList("includedRelation"));
-		spec.setLimit(2L);
-		spec.setOffset(1L);
+
+		spec.setPagingSpec(new OffsetBasedPagingSpec(1, 2));
 
 		QuerySpec duplicate = spec.duplicate();
 		Assert.assertNotSame(spec, duplicate);
@@ -107,16 +106,10 @@ public class QuerySpecTest {
 		spec2.addSort(new SortSpec(Arrays.asList("sortAttr"), Direction.ASC));
 		Assert.assertEquals(spec1, spec2);
 
-		spec2.setOffset(2);
+        spec1.setPagingSpec(new OffsetBasedPagingSpec(2, 10));
 		Assert.assertNotEquals(spec1, spec2);
-		spec2.setOffset(0);
+        spec2.setPagingSpec(new OffsetBasedPagingSpec(2, 10));
 		Assert.assertEquals(spec1, spec2);
-
-		spec2.setLimit(2L);
-		Assert.assertNotEquals(spec1, spec2);
-		spec2.setLimit(null);
-		Assert.assertEquals(spec1, spec2);
-
 		Assert.assertNotEquals(spec1, "someOtherType");
 	}
 

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/internal/PageQuerySpecAdapterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/internal/PageQuerySpecAdapterTest.java
@@ -1,0 +1,67 @@
+package io.katharsis.queryspec.internal;
+
+import io.katharsis.queryspec.PageBasedPagingSpec;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PageQuerySpecAdapterTest {
+    PageBasedPagingSpec firstPage;
+    PageBasedPagingSpec middlePage;
+    PageBasedPagingSpec lastPage;
+    PageQuerySpecAdapter firstPageAdapter;
+    PageQuerySpecAdapter middlePageAdapter;
+    PageQuerySpecAdapter lastPageAdapter;
+
+    @Before
+    public void setup() {
+        firstPage = new PageBasedPagingSpec(0, 10);
+        middlePage = new PageBasedPagingSpec(5, 10);
+        lastPage = new PageBasedPagingSpec(10, 10);
+        firstPageAdapter = new PageQuerySpecAdapter(firstPage, 100, 10);
+        middlePageAdapter = new PageQuerySpecAdapter(middlePage, 100, 10);
+        lastPageAdapter = new PageQuerySpecAdapter(lastPage, 100, 10);
+    }
+
+    @Test
+    public void testDelegation() throws Exception {
+        Assert.assertEquals(firstPage.getLimit(), firstPageAdapter.getLimit());
+        Assert.assertEquals(firstPage.getOffset(), firstPageAdapter.getOffset());
+        Assert.assertEquals(firstPage.next(firstPageAdapter.getTotalCount(), firstPageAdapter.getTotalPages()),
+                ((PageQuerySpecAdapter) firstPageAdapter.next()).getPagingSpec());
+        Assert.assertEquals(firstPage.prev(firstPageAdapter.getTotalCount(), firstPageAdapter.getTotalPages()),
+                ((PageQuerySpecAdapter) firstPageAdapter.prev()).getPagingSpec());
+        Assert.assertEquals(firstPage.last(firstPageAdapter.getTotalCount(), firstPageAdapter.getTotalPages()),
+                ((PageQuerySpecAdapter) firstPageAdapter.last()).getPagingSpec());
+        Assert.assertEquals(firstPage.first(), ((PageQuerySpecAdapter) firstPageAdapter.first()).getPagingSpec());
+    }
+
+    @Test
+    public void hasNext() throws Exception {
+        Assert.assertTrue(firstPageAdapter.hasNext());
+        Assert.assertTrue(middlePageAdapter.hasNext());
+        Assert.assertFalse(lastPageAdapter.hasNext());
+    }
+
+    @Test
+    public void hasPrev() throws Exception {
+        Assert.assertFalse(firstPageAdapter.hasPrev());
+        Assert.assertTrue(middlePageAdapter.hasPrev());
+        Assert.assertTrue(lastPageAdapter.hasPrev());
+    }
+
+    @Test
+    public void testDuplicateEqualsAndHashCode() throws Exception {
+
+        PageQuerySpecAdapter duplicate = (PageQuerySpecAdapter) firstPageAdapter.duplicate();
+        Assert.assertEquals(firstPageAdapter.getLimit(), duplicate.getLimit());
+        Assert.assertEquals(firstPageAdapter.getOffset(), duplicate.getOffset());
+        Assert.assertEquals(firstPageAdapter.getTotalPages(), duplicate.getTotalPages());
+        Assert.assertEquals(firstPageAdapter.getTotalCount(), duplicate.getTotalCount());
+        Assert.assertEquals(firstPageAdapter.getPagingSpec(), duplicate.getPagingSpec());
+        Assert.assertEquals(firstPageAdapter, duplicate);
+
+        Assert.assertNotEquals(firstPageAdapter, "someOtherType");
+    }
+
+}

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/repository/DefaultQuerySpecDeserializerTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/repository/DefaultQuerySpecDeserializerTest.java
@@ -1,26 +1,14 @@
 package io.katharsis.queryspec.repository;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import io.katharsis.queryspec.*;
+import io.katharsis.resource.mock.models.Project;
+import io.katharsis.resource.mock.models.Task;
+import io.katharsis.resource.registry.ResourceRegistry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.katharsis.queryspec.AbstractQuerySpecTest;
-import io.katharsis.queryspec.DefaultQuerySpecDeserializer;
-import io.katharsis.queryspec.Direction;
-import io.katharsis.queryspec.FilterOperator;
-import io.katharsis.queryspec.FilterSpec;
-import io.katharsis.queryspec.QuerySpec;
-import io.katharsis.queryspec.QuerySpecDeserializerContext;
-import io.katharsis.queryspec.SortSpec;
-import io.katharsis.resource.mock.models.Project;
-import io.katharsis.resource.mock.models.Task;
-import io.katharsis.resource.registry.ResourceRegistry;
+import java.util.*;
 
 public class DefaultQuerySpecDeserializerTest extends AbstractQuerySpecTest {
 
@@ -57,31 +45,23 @@ public class DefaultQuerySpecDeserializerTest extends AbstractQuerySpecTest {
 		Assert.assertEquals(expectedSpec, actualSpec);
 	}
 
-
     @Test
     public void defaultPaginationOnRoot(){
     	Map<String, Set<String>> params = new HashMap<>();
-    	deserializer.setDefaultLimit(12L);
-    	deserializer.setDefaultOffset(1L);
 		QuerySpec actualSpec = deserializer.deserialize(Task.class, params);
-		Assert.assertEquals(1L, actualSpec.getOffset());
-		Assert.assertEquals(12L, actualSpec.getLimit().longValue());
-    }
-    
+		Assert.assertNull(actualSpec.getPagingSpec());
+	}
+
     @Test
     public void defaultPaginationOnRelation(){
     	Map<String, Set<String>> params = new HashMap<>();
     	add(params, "sort[projects]", "name");
-    	deserializer.setDefaultLimit(12L);
-    	deserializer.setDefaultOffset(1L);
 		QuerySpec actualSpec = deserializer.deserialize(Task.class, params);
-		Assert.assertEquals(1L, actualSpec.getOffset());
-		Assert.assertEquals(12L, actualSpec.getLimit().longValue());
+		Assert.assertNull(actualSpec.getPagingSpec());
 		QuerySpec projectQuerySpec = actualSpec.getQuerySpec(Project.class);
 		Assert.assertNotNull(projectQuerySpec);
-		Assert.assertEquals(1L, projectQuerySpec.getOffset());
-		Assert.assertEquals(12L, projectQuerySpec.getLimit().longValue());
-    }
+		Assert.assertNull(projectQuerySpec.getPagingSpec());
+	}
 	
 	@Test
 	public void testFindAllOrderByAsc() throws InstantiationException, IllegalAccessException {
@@ -171,14 +151,14 @@ public class DefaultQuerySpecDeserializerTest extends AbstractQuerySpecTest {
 	@Test
 	public void testPaging() throws InstantiationException, IllegalAccessException {
 		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.setLimit(2L);
-		expectedSpec.setOffset(1L);
+		expectedSpec.setPagingSpec(new OffsetBasedPagingSpec(1, 2));
 
 		Map<String, Set<String>> params = new HashMap<>();
 		add(params, "page[offset]", "1");
 		add(params, "page[limit]", "2");
 
 		QuerySpec actualSpec = deserializer.deserialize(Task.class, params);
+		actualSpec.setPagingSpec(new OffsetBasedPagingSpec(1, 2));
 		Assert.assertEquals(expectedSpec, actualSpec);
 	}
 

--- a/katharsis-core/src/test/java/io/katharsis/response/paging/PagedLinksInformationQuerySpecTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/response/paging/PagedLinksInformationQuerySpecTest.java
@@ -1,17 +1,18 @@
 package io.katharsis.response.paging;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import io.katharsis.queryspec.AbstractQuerySpecTest;
+import io.katharsis.queryspec.OffsetBasedPagingSpec;
+import io.katharsis.queryspec.PageBasedPagingSpec;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.queryspec.internal.QueryAdapter;
 import io.katharsis.queryspec.internal.QuerySpecAdapter;
 import io.katharsis.resource.mock.models.Task;
 import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.responseRepository.ResourceRepositoryAdapter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class PagedLinksInformationQuerySpecTest extends AbstractQuerySpecTest {
 
@@ -43,40 +44,44 @@ public class PagedLinksInformationQuerySpecTest extends AbstractQuerySpecTest {
 
 	@Test
 	public void testPaging() throws InstantiationException, IllegalAccessException {
-		QuerySpecAdapter querySpec = new QuerySpecAdapter(new QuerySpec(Task.class), resourceRegistry);
-		querySpec.setOffset(2L);
-		querySpec.setLimit(2L);
+		QuerySpec querySpec = new QuerySpec(Task.class, new OffsetBasedPagingSpec(2, 2));
+		QuerySpecAdapter specAdapter = new QuerySpecAdapter(querySpec, resourceRegistry);
 
-		PagedLinksInformation linksInformation = (PagedLinksInformation) adapter.findAll(querySpec).getLinksInformation();
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=2", linksInformation.getFirst());
+		PagedLinksInformation linksInformation = (PagedLinksInformation) adapter.findAll(specAdapter).getLinksInformation();
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=2&page[offset]=0", linksInformation.getFirst());
 		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=2&page[offset]=4", linksInformation.getLast());
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=2", linksInformation.getPrev());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=2&page[offset]=0", linksInformation.getPrev());
 		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=2&page[offset]=4", linksInformation.getNext());
+
+		querySpec = new QuerySpec(Task.class, new PageBasedPagingSpec(1, 2));
+		specAdapter = new QuerySpecAdapter(querySpec, resourceRegistry);
+
+		linksInformation = (PagedLinksInformation) adapter.findAll(specAdapter).getLinksInformation();
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=0&page[size]=2", linksInformation.getFirst());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=2&page[size]=2", linksInformation.getLast());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=0&page[size]=2", linksInformation.getPrev());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=2&page[size]=2", linksInformation.getNext());
 	}
 
 	@Test
 	public void testPagingFirst() throws InstantiationException, IllegalAccessException {
-		QuerySpecAdapter querySpec = new QuerySpecAdapter(new QuerySpec(Task.class), resourceRegistry);
-		querySpec.setOffset(0L);
-		querySpec.setLimit(3L);
+		QuerySpecAdapter querySpec = new QuerySpecAdapter(new QuerySpec(Task.class, new PageBasedPagingSpec(0, 3)), resourceRegistry);
 
 		PagedLinksInformation linksInformation = (PagedLinksInformation) adapter.findAll(querySpec).getLinksInformation();
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=3", linksInformation.getFirst());
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=3&page[offset]=3", linksInformation.getLast());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=0&page[size]=3", linksInformation.getFirst());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=1&page[size]=3", linksInformation.getLast());
 		Assert.assertNull(linksInformation.getPrev());
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=3&page[offset]=3", linksInformation.getNext());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[number]=1&page[size]=3", linksInformation.getNext());
 	}
 
 	@Test
 	public void testPagingLast() throws InstantiationException, IllegalAccessException {
-		QuerySpecAdapter querySpec = new QuerySpecAdapter(new QuerySpec(Task.class), resourceRegistry);
-		querySpec.setOffset(4L);
-		querySpec.setLimit(4L);
+		QuerySpecAdapter querySpec = new QuerySpecAdapter(new QuerySpec(Task.class, new OffsetBasedPagingSpec(4, 4)), resourceRegistry);
 
 		PagedLinksInformation linksInformation = (PagedLinksInformation) adapter.findAll(querySpec).getLinksInformation();
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=4", linksInformation.getFirst());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=4&page[offset]=0", linksInformation.getFirst());
 		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=4&page[offset]=4", linksInformation.getLast());
-		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=4", linksInformation.getFirst());
+		Assert.assertEquals("http://127.0.0.1/tasks/?page[limit]=4&page[offset]=0", linksInformation.getPrev());
 		Assert.assertNull(linksInformation.getNext());
 	}
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaEntityRepository.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaEntityRepository.java
@@ -1,29 +1,24 @@
 package io.katharsis.jpa;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
-import javax.persistence.EntityManager;
-
 import io.katharsis.jpa.internal.JpaRepositoryBase;
 import io.katharsis.jpa.internal.JpaRepositoryUtils;
 import io.katharsis.jpa.internal.meta.MetaAttribute;
 import io.katharsis.jpa.internal.meta.MetaEntity;
 import io.katharsis.jpa.internal.paging.DefaultPagedMetaInformation;
 import io.katharsis.jpa.internal.paging.PagedMetaInformation;
-import io.katharsis.jpa.query.ComputedAttributeRegistry;
-import io.katharsis.jpa.query.JpaQuery;
-import io.katharsis.jpa.query.JpaQueryExecutor;
-import io.katharsis.jpa.query.JpaQueryFactory;
-import io.katharsis.jpa.query.Tuple;
+import io.katharsis.jpa.query.*;
 import io.katharsis.queryspec.FilterOperator;
 import io.katharsis.queryspec.FilterSpec;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.queryspec.QuerySpecResourceRepository;
 import io.katharsis.response.paging.PagedResultList;
 import io.katharsis.utils.PropertyUtils;
+
+import javax.persistence.EntityManager;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Exposes a JPA entity as ResourceRepository.
@@ -80,7 +75,7 @@ public class JpaEntityRepository<T, I extends Serializable> extends JpaRepositor
 		tuples = filterTuples(filteredQuerySpec, tuples);
 		List<T> resources = map(tuples);
 		resources = filterResults(filteredQuerySpec, resources);
-		if (filteredQuerySpec.getLimit() != null) {
+		if (filteredQuerySpec.getPagingSpec() != null) {
 			long totalRowCount = executor.getTotalRowCount();
 			return new PagedResultList<>(resources, totalRowCount);
 		}

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaRelationshipRepository.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaRelationshipRepository.java
@@ -1,18 +1,5 @@
 package io.katharsis.jpa;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.persistence.EntityManager;
-
 import io.katharsis.jpa.internal.JpaRepositoryBase;
 import io.katharsis.jpa.internal.JpaRepositoryUtils;
 import io.katharsis.jpa.internal.meta.MetaAttribute;
@@ -23,14 +10,14 @@ import io.katharsis.jpa.internal.paging.PagedMetaInformation;
 import io.katharsis.jpa.mapping.IdentityMapper;
 import io.katharsis.jpa.mapping.JpaMapper;
 import io.katharsis.jpa.mapping.JpaMapping;
-import io.katharsis.jpa.query.ComputedAttributeRegistry;
-import io.katharsis.jpa.query.JpaQuery;
-import io.katharsis.jpa.query.JpaQueryExecutor;
-import io.katharsis.jpa.query.JpaQueryFactory;
-import io.katharsis.jpa.query.Tuple;
+import io.katharsis.jpa.query.*;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.queryspec.QuerySpecBulkRelationshipRepository;
 import io.katharsis.response.paging.PagedResultList;
+
+import javax.persistence.EntityManager;
+import java.io.Serializable;
+import java.util.*;
 
 public class JpaRelationshipRepository<S, I extends Serializable, T, J extends Serializable> extends JpaRepositoryBase<T>
 		implements QuerySpecBulkRelationshipRepository<S, I, T, J> {
@@ -221,7 +208,7 @@ public class JpaRelationshipRepository<S, I extends Serializable, T, J extends S
 			sourceIdLists.add(sourceId);
 		}
 
-		if (querySpec.getLimit() != null && sourceIdLists.size() > 1) {
+		if (querySpec.getPagingSpec() != null && sourceIdLists.size() > 1) {
 			throw new UnsupportedOperationException("page limit not supported for bulk inclusions");
 		}
 
@@ -250,7 +237,7 @@ public class JpaRelationshipRepository<S, I extends Serializable, T, J extends S
 		Map<I, Iterable<T>> map = mapTuples(tuples);
 
 		// support paging for non-bulk requests
-		if (sourceIdLists.size() == 1 && querySpec.getLimit() != null) {
+		if (sourceIdLists.size() == 1 && querySpec.getPagingSpec() != null) {
 			long totalRowCount = executor.getTotalRowCount();
 			I sourceId = sourceIdLists.get(0);
 			Iterable<T> iterable = map.get(sourceId);

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaRepositoryUtils.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaRepositoryUtils.java
@@ -1,8 +1,5 @@
 package io.katharsis.jpa.internal;
 
-import java.util.Arrays;
-import java.util.Set;
-
 import io.katharsis.jpa.internal.meta.MetaAttribute;
 import io.katharsis.jpa.internal.meta.MetaEntity;
 import io.katharsis.jpa.internal.meta.MetaKey;
@@ -10,9 +7,13 @@ import io.katharsis.jpa.query.JpaQuery;
 import io.katharsis.jpa.query.JpaQueryExecutor;
 import io.katharsis.queryspec.FilterSpec;
 import io.katharsis.queryspec.IncludeSpec;
+import io.katharsis.queryspec.PagingSpec;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.queryspec.SortSpec;
 import io.katharsis.utils.PreconditionUtil;
+
+import java.util.Arrays;
+import java.util.Set;
 
 public class JpaRepositoryUtils {
 
@@ -53,15 +54,16 @@ public class JpaRepositoryUtils {
 				executor.fetch(included.getAttributePath());
 			}
 		}
-		executor.setOffset((int) querySpec.getOffset());
-		if (querySpec.getOffset() > Integer.MAX_VALUE) {
+		if (querySpec.getPagingSpec() == null)
+			return;
+		PagingSpec pagingSpec = querySpec.getPagingSpec();
+		if (pagingSpec.getOffset() > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException("offset cannot be larger than Integer.MAX_VALUE");
 		}
-		if (querySpec.getLimit() != null) {
-			if (querySpec.getLimit() > Integer.MAX_VALUE) {
-				throw new IllegalArgumentException("limit cannot be larger than Integer.MAX_VALUE");
-			}
-			executor.setLimit((int) querySpec.getLimit().longValue());
+		executor.setOffset((int) pagingSpec.getOffset());
+		if (pagingSpec.getLimit() > Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("limit cannot be larger than Integer.MAX_VALUE");
 		}
+		executor.setLimit((int) pagingSpec.getLimit());
 	}
 }

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/JpaQuerySpecEndToEndTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/JpaQuerySpecEndToEndTest.java
@@ -1,31 +1,22 @@
 package io.katharsis.jpa;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.persistence.OptimisticLockException;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import io.katharsis.client.QuerySpecRelationshipRepositoryStub;
 import io.katharsis.client.QuerySpecResourceRepositoryStub;
 import io.katharsis.client.ResourceRepositoryStub;
 import io.katharsis.client.response.JsonLinksInformation;
 import io.katharsis.client.response.JsonMetaInformation;
 import io.katharsis.client.response.ResourceList;
-import io.katharsis.jpa.model.OtherRelatedEntity;
-import io.katharsis.jpa.model.RelatedEntity;
-import io.katharsis.jpa.model.TestEmbeddedIdEntity;
-import io.katharsis.jpa.model.TestEntity;
-import io.katharsis.jpa.model.TestIdEmbeddable;
-import io.katharsis.jpa.model.VersionedEntity;
-import io.katharsis.queryspec.FilterOperator;
-import io.katharsis.queryspec.FilterSpec;
-import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.jpa.model.*;
+import io.katharsis.queryspec.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.persistence.OptimisticLockException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 
 public class JpaQuerySpecEndToEndTest extends AbstractJpaJerseyTest {
 
@@ -264,9 +255,7 @@ public class JpaQuerySpecEndToEndTest extends AbstractJpaJerseyTest {
 			testRepo.save(task);
 		}
 
-		QuerySpec querySpec = new QuerySpec(TestEntity.class);
-		querySpec.setOffset(2L);
-		querySpec.setLimit(2L);
+		QuerySpec querySpec = new QuerySpec(TestEntity.class, new OffsetBasedPagingSpec(2, 2));
 
 		ResourceList<TestEntity> list = testRepo.findAll(querySpec);
 		Assert.assertEquals(2, list.size());
@@ -279,9 +268,9 @@ public class JpaQuerySpecEndToEndTest extends AbstractJpaJerseyTest {
 		Assert.assertNotNull(links);
 
 		String baseUri = getBaseUri().toString();
-		Assert.assertEquals(baseUri + "test/?page[limit]=2", links.asJsonNode().get("first").asText());
+		Assert.assertEquals(baseUri + "test/?page[limit]=2&page[offset]=0", links.asJsonNode().get("first").asText());
 		Assert.assertEquals(baseUri + "test/?page[limit]=2&page[offset]=4", links.asJsonNode().get("last").asText());
-		Assert.assertEquals(baseUri + "test/?page[limit]=2", links.asJsonNode().get("prev").asText());
+		Assert.assertEquals(baseUri + "test/?page[limit]=2&page[offset]=0", links.asJsonNode().get("prev").asText());
 		Assert.assertEquals(baseUri + "test/?page[limit]=2&page[offset]=4", links.asJsonNode().get("next").asText());
 	}
 
@@ -304,9 +293,7 @@ public class JpaQuerySpecEndToEndTest extends AbstractJpaJerseyTest {
 			relRepo.addRelations(test, Arrays.asList(i), TestEntity.ATTR_manyRelatedValues);
 		}
 
-		QuerySpec querySpec = new QuerySpec(RelatedEntity.class);
-		querySpec.setOffset(2L);
-		querySpec.setLimit(2L);
+		QuerySpec querySpec = new QuerySpec(RelatedEntity.class, new PageBasedPagingSpec(1, 2));
 
 		ResourceList<RelatedEntity> list = relRepo.findManyTargets(test.getId(), TestEntity.ATTR_manyRelatedValues, querySpec);
 		Assert.assertEquals(2, list.size());
@@ -319,13 +306,13 @@ public class JpaQuerySpecEndToEndTest extends AbstractJpaJerseyTest {
 		Assert.assertNotNull(links);
 
 		String baseUri = getBaseUri().toString();
-		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[limit]=2",
+		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[number]=0&page[size]=2",
 				links.asJsonNode().get("first").asText());
-		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[limit]=2&page[offset]=4",
+		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[number]=2&page[size]=2",
 				links.asJsonNode().get("last").asText());
-		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[limit]=2",
+		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[number]=0&page[size]=2",
 				links.asJsonNode().get("prev").asText());
-		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[limit]=2&page[offset]=4",
+		Assert.assertEquals(baseUri + "test/1/relationships/manyRelatedValues/?page[number]=2&page[size]=2",
 				links.asJsonNode().get("next").asText());
 	}
 

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaEntityRepositoryTestBase.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaEntityRepositoryTestBase.java
@@ -1,24 +1,19 @@
 package io.katharsis.jpa.repository;
 
-import java.util.Arrays;
-import java.util.List;
-
+import io.katharsis.jpa.JpaEntityRepository;
+import io.katharsis.jpa.internal.paging.PagedMetaInformation;
+import io.katharsis.jpa.model.RelatedEntity;
+import io.katharsis.jpa.model.TestEntity;
+import io.katharsis.jpa.query.AbstractJpaTest;
+import io.katharsis.queryspec.*;
 import org.hibernate.Hibernate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.katharsis.jpa.JpaEntityRepository;
-import io.katharsis.jpa.internal.paging.PagedMetaInformation;
-import io.katharsis.jpa.model.RelatedEntity;
-import io.katharsis.jpa.model.TestEntity;
-import io.katharsis.jpa.query.AbstractJpaTest;
-import io.katharsis.queryspec.Direction;
-import io.katharsis.queryspec.FilterOperator;
-import io.katharsis.queryspec.FilterSpec;
-import io.katharsis.queryspec.QuerySpec;
-import io.katharsis.queryspec.SortSpec;
+import java.util.Arrays;
+import java.util.List;
 
 @Transactional
 public abstract class JpaEntityRepositoryTestBase extends AbstractJpaTest {
@@ -202,9 +197,7 @@ public abstract class JpaEntityRepositoryTestBase extends AbstractJpaTest {
 
 	@Test
 	public void testPaging() throws InstantiationException, IllegalAccessException {
-		QuerySpec querySpec = new QuerySpec(TestEntity.class);
-		querySpec.setOffset(2L);
-		querySpec.setLimit(2L);
+		QuerySpec querySpec = new QuerySpec(TestEntity.class, new OffsetBasedPagingSpec(2, 2));
 
 		List<TestEntity> list = repo.findAll(querySpec);
 		Assert.assertEquals(2, list.size());
@@ -217,9 +210,7 @@ public abstract class JpaEntityRepositoryTestBase extends AbstractJpaTest {
 
 	@Test
 	public void testPagingFirst() throws InstantiationException, IllegalAccessException {
-		QuerySpec querySpec = new QuerySpec(TestEntity.class);
-		querySpec.setOffset(0L);
-		querySpec.setLimit(3L);
+		QuerySpec querySpec = new QuerySpec(TestEntity.class, new OffsetBasedPagingSpec(0, 3));
 
 		List<TestEntity> list = repo.findAll(querySpec);
 		Assert.assertEquals(3, list.size());
@@ -233,9 +224,7 @@ public abstract class JpaEntityRepositoryTestBase extends AbstractJpaTest {
 
 	@Test
 	public void testPagingLast() throws InstantiationException, IllegalAccessException {
-		QuerySpec querySpec = new QuerySpec(TestEntity.class);
-		querySpec.setOffset(4L);
-		querySpec.setLimit(4L);
+		QuerySpec querySpec = new QuerySpec(TestEntity.class, new OffsetBasedPagingSpec(4, 4));
 
 		List<TestEntity> list = repo.findAll(querySpec);
 		Assert.assertEquals(1, list.size());

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaRelationshipRepositoryTestBase.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaRelationshipRepositoryTestBase.java
@@ -1,16 +1,5 @@
 package io.katharsis.jpa.repository;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
-import org.hamcrest.core.Is;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.transaction.annotation.Transactional;
-
 import io.katharsis.jpa.JpaRelationshipRepository;
 import io.katharsis.jpa.internal.paging.PagedMetaInformation;
 import io.katharsis.jpa.model.RelatedEntity;
@@ -18,7 +7,18 @@ import io.katharsis.jpa.model.TestEntity;
 import io.katharsis.jpa.query.AbstractJpaTest;
 import io.katharsis.queryspec.FilterOperator;
 import io.katharsis.queryspec.FilterSpec;
+import io.katharsis.queryspec.OffsetBasedPagingSpec;
 import io.katharsis.queryspec.QuerySpec;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 @Transactional
 public abstract class JpaRelationshipRepositoryTestBase extends AbstractJpaTest {
@@ -170,9 +170,7 @@ public abstract class JpaRelationshipRepositoryTestBase extends AbstractJpaTest 
 	public void testGetManyRelationWithPaging() throws InstantiationException, IllegalAccessException {
 		TestEntity test = setupManyRelation(Arrays.asList(100L, 101L, 102L, 103L, 104L));
 
-		QuerySpec querySpec = new QuerySpec(TestEntity.class);
-		querySpec.setOffset(2L);
-		querySpec.setLimit(2L);
+		QuerySpec querySpec = new QuerySpec(TestEntity.class, new OffsetBasedPagingSpec(2, 2));
 
 		List<RelatedEntity> list = repo.findManyTargets(test.getId(), TestEntity.ATTR_manyRelatedValues, querySpec);
 		Assert.assertEquals(2, list.size());


### PR DESCRIPTION
As discussed in the gitter chat, QuerySpec is awesome, but there is a real life use case for supporting multiple paging strategies.
1. Some domains use page/number across the board, even down the DAO layer. Constantly converting between limit/offset and page number is confusing
2. Limiting page/number to the deserializer will not work for using QuerySpec on the client side to talk to a Katharsis api that expects number/size.

This implementation takes inspiration from the spring-data-jpa [`Pageable`](https://github.com/spring-projects/spring-data-commons/blob/master/src/main/java/org/springframework/data/domain/Pageable.java) and [`Page`](https://github.com/spring-projects/spring-data-commons/blob/master/src/main/java/org/springframework/data/domain/Page.java) classes, while remaining flexible and extendable (supporting cursor pagination, #25, will be possible!)

It includes
- Support for different paging strategies
- Full LinksInformation serialization for all paging types
- Two default strategies offset/limit based and page number/size based
- Works with `spring-jpa`
## Usage

On the client:

``` java
// page/number based paging, requesting page 0, with page size 20
QuerySpec querySpec = new QuerySpec(Task.class, new PageBasedPagingSpec(0, 20));

// offset/limit based paging, offset=0, limit=10
QuerySpec querySpec = new QuerySpec(Task.class, new OffsetBasedPagingSpec(0, 10));
```

On the server:

``` java
Iterable<Task> findAll(QuerySpec querySpec) {
    if( querySpec.getPagingSpec() != null ) {
        long limit = querySpec.getPagingSpec().getLimit()
        long offset = querySpec.getPagingSpec().getOffset()
        return tasksDao.findAll(limit,offset);
    }
}
```
## TODO

**This PR should not be merged yet**
- [ ] **Default Paging** I temporarily removed support for "default" paging (#137)
    I'd like to get some feedback on this PR before implementing the default pagination. But I'd like the user to opt-in to this default behavior. Not sure how to do this yet. ideas?
- [ ] I'd like to add a `querySpec.hasPaging()` to avoid ugly
      `if( querySpec.getPagingSpec() == null )`
