### PR TITLE
#174 Make katharsis-client customizable with modules

### DIFF
--- a/katharsis-client/pom.xml
+++ b/katharsis-client/pom.xml
@@ -38,7 +38,7 @@
 	</developers>
 
 	<properties>
-		<okhttp.version>2.7.5</okhttp.version>
+		<okhttp.version>3.4.1</okhttp.version>
 		<jersey.version>2.17</jersey.version>
 	</properties>
 
@@ -97,7 +97,7 @@
         </dependency>
 
 		<dependency>
-			<groupId>com.squareup.okhttp</groupId>
+			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<version>${okhttp.version}</version>
 		</dependency>

--- a/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapter.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapter.java
@@ -1,0 +1,5 @@
+package io.katharsis.client.http;
+
+public interface HttpAdapter {
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpAdapter.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpAdapter.java
@@ -1,0 +1,40 @@
+package io.katharsis.client.http.okhttp;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.katharsis.client.http.HttpAdapter;
+import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClient.Builder;
+
+public class OkHttpAdapter implements HttpAdapter {
+
+	private OkHttpClient impl;
+
+	private CopyOnWriteArrayList<OkHttpAdapterListener> listeners = new CopyOnWriteArrayList<>();
+
+	public void addListener(OkHttpAdapterListener listener) {
+		if (impl != null) {
+			throw new IllegalStateException("already initialized");
+		}
+		listeners.add(listener);
+	}
+
+	public OkHttpClient getImplementation() {
+		if (impl == null) {
+			initImpl();
+		}
+		return impl;
+	}
+
+	private void initImpl() {
+		synchronized (this) {
+			if (impl == null) {
+				Builder builder = new OkHttpClient.Builder();
+				for (OkHttpAdapterListener listener : listeners) {
+					listener.onBuild(builder);
+				}
+				impl = builder.build();
+			}
+		}
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpAdapterListener.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpAdapterListener.java
@@ -1,0 +1,9 @@
+package io.katharsis.client.http.okhttp;
+
+import okhttp3.OkHttpClient.Builder;
+
+public interface OkHttpAdapterListener {
+
+	void onBuild(Builder builder);
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpAdapterListenerBase.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpAdapterListenerBase.java
@@ -1,0 +1,11 @@
+package io.katharsis.client.http.okhttp;
+
+import okhttp3.OkHttpClient.Builder;
+
+public class OkHttpAdapterListenerBase implements OkHttpAdapterListener {
+
+	@Override
+	public void onBuild(Builder builder) {
+		// nothing to do
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/AbstractStub.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/AbstractStub.java
@@ -1,10 +1,6 @@
 package io.katharsis.client.internal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Request.Builder;
-import com.squareup.okhttp.Response;
 import io.katharsis.client.ClientException;
 import io.katharsis.client.KatharsisClient;
 import io.katharsis.client.response.ResourceList;
@@ -18,6 +14,10 @@ import io.katharsis.response.LinksInformation;
 import io.katharsis.response.MetaInformation;
 import io.katharsis.utils.JsonApiUrlBuilder;
 import io.katharsis.utils.java.Optional;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import okhttp3.Response;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/RelationshipRepositoryStubImpl.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/RelationshipRepositoryStubImpl.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Request.Builder;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import okhttp3.RequestBody;
 
 import io.katharsis.client.KatharsisClient;
 import io.katharsis.client.QuerySpecRelationshipRepositoryStub;

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/ResourceRepositoryStubImpl.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/ResourceRepositoryStubImpl.java
@@ -5,10 +5,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Request.Builder;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import okhttp3.RequestBody;
 
 import io.katharsis.client.KatharsisClient;
 import io.katharsis.client.QuerySpecResourceRepositoryStub;

--- a/katharsis-client/src/main/java/io/katharsis/client/module/HttpAdapterAware.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/module/HttpAdapterAware.java
@@ -1,0 +1,11 @@
+package io.katharsis.client.module;
+
+import io.katharsis.client.http.HttpAdapter;
+
+/**
+ * Can be implemented by modules to get access to the HttpAdapter implementation. 
+ */
+public interface HttpAdapterAware {
+
+	public void setHttpAdapter(HttpAdapter client);
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
@@ -1,7 +1,6 @@
 package io.katharsis.client;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.MultivaluedMap;
@@ -26,7 +25,9 @@ import io.katharsis.rs.KatharsisProperties;
 public abstract class AbstractClientTest extends JerseyTest {
 
 	protected KatharsisClient client;
+
 	protected TestApplication testApplication;
+
 	protected QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
 
 	@Before
@@ -37,8 +38,6 @@ public abstract class AbstractClientTest extends JerseyTest {
 		TaskRepository.clear();
 		ProjectRepository.clear();
 		TaskToProjectRepository.clear();
-
-		client.getHttpClient().setReadTimeout(1000000, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
@@ -46,7 +45,7 @@ public abstract class AbstractClientTest extends JerseyTest {
 		if (testApplication == null) {
 			testApplication = new TestApplication(false);
 		}
-		
+
 		return testApplication;
 	}
 
@@ -60,16 +59,12 @@ public abstract class AbstractClientTest extends JerseyTest {
 			property(KatharsisProperties.RESOURCE_DEFAULT_DOMAIN, "http://test.local");
 
 			if (!querySpec) {
-				feature = new KatharsisTestFeature(
-					new ObjectMapper(), 
-					new QueryParamsBuilder(new DefaultQueryParamsParser()),
-					new SampleJsonServiceLocator());
+				feature = new KatharsisTestFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()),
+						new SampleJsonServiceLocator());
 			}
 			else {
-				feature = new KatharsisTestFeature(
-					new ObjectMapper(), 
-					new DefaultQuerySpecDeserializer(),
-					new SampleJsonServiceLocator());
+				feature = new KatharsisTestFeature(new ObjectMapper(), new DefaultQuerySpecDeserializer(),
+						new SampleJsonServiceLocator());
 			}
 
 			feature.addModule(new TestModule());
@@ -91,10 +86,10 @@ public abstract class AbstractClientTest extends JerseyTest {
 	protected void assertHasHeaderValue(String name, String value) {
 		MultivaluedMap<String, String> headers = getLastReceivedHeaders();
 		Assert.assertNotNull(headers);
-		
+
 		List<String> values = headers.get(name);
 		Assert.assertNotNull(values);
-		
+
 		Assert.assertTrue(values.contains(value));
 	}
 

--- a/katharsis-client/src/test/java/io/katharsis/client/ModuleTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ModuleTest.java
@@ -1,0 +1,83 @@
+package io.katharsis.client;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.katharsis.client.http.HttpAdapter;
+import io.katharsis.client.http.okhttp.OkHttpAdapter;
+import io.katharsis.client.http.okhttp.OkHttpAdapterListener;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.client.module.HttpAdapterAware;
+import io.katharsis.module.Module;
+import io.katharsis.module.Module.ModuleContext;
+import io.katharsis.queryspec.QuerySpec;
+import okhttp3.OkHttpClient.Builder;
+
+public class ModuleTest extends AbstractClientTest {
+
+	protected QuerySpecResourceRepositoryStub<Task, Long> taskRepo;
+
+	private TestOkHttpAdapterListener adapterListener = Mockito.spy(new TestOkHttpAdapterListener());
+
+	private OkHttpTestModule testModule = Mockito.spy(new OkHttpTestModule());
+
+	@Before
+	public void setup() {
+		super.setup();
+		client.addModule(testModule);
+		taskRepo = client.getQuerySpecRepository(Task.class);
+	}
+
+	@Override
+	protected TestApplication configure() {
+		return new TestApplication(true);
+	}
+
+	@Test
+	public void test() {
+		Task task = new Task();
+		task.setId(1L);
+		task.setName("task");
+		taskRepo.save(task);
+
+		List<Task> tasks = taskRepo.findAll(new QuerySpec(Task.class));
+		Assert.assertEquals(1, tasks.size());
+
+		Mockito.verify(testModule, Mockito.times(1)).setupModule(Mockito.any(ModuleContext.class));
+		Mockito.verify(testModule, Mockito.times(1)).setHttpAdapter(Mockito.eq(client.getHttpAdapter()));
+		Mockito.verify(adapterListener, Mockito.times(1)).onBuild(Mockito.any(Builder.class));
+	}
+
+	class TestOkHttpAdapterListener implements OkHttpAdapterListener {
+
+		@Override
+		public void onBuild(Builder builder) {
+			builder.connectTimeout(10000, TimeUnit.MILLISECONDS);
+		}
+	}
+
+	class OkHttpTestModule implements Module, HttpAdapterAware {
+
+		@Override
+		public String getModuleName() {
+			return "okhttp-test";
+		}
+
+		@Override
+		public void setupModule(ModuleContext context) {
+			// nothing to do
+		}
+
+		@Override
+		public void setHttpAdapter(HttpAdapter adapter) {
+			((OkHttpAdapter) adapter).addListener(adapterListener);
+		}
+
+	}
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
@@ -16,7 +16,6 @@ import io.katharsis.module.SimpleModule.RelationshipRepositoryRegistration;
 import io.katharsis.module.SimpleModule.ResourceRepositoryRegistration;
 import io.katharsis.queryspec.QuerySpecRelationshipRepository;
 import io.katharsis.queryspec.QuerySpecResourceRepository;
-import io.katharsis.repository.RelationshipRepository;
 import io.katharsis.repository.RepositoryInstanceBuilder;
 import io.katharsis.repository.ResourceRepository;
 import io.katharsis.resource.information.ResourceInformation;
@@ -27,7 +26,6 @@ import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.repository.DirectResponseRelationshipEntry;
 import io.katharsis.resource.registry.repository.DirectResponseResourceEntry;
 import io.katharsis.resource.registry.repository.ResponseRelationshipEntry;
-import net.jodah.typetools.TypeResolver;
 
 /**
  * Container for setting up and holding {@link Module} instances;
@@ -35,15 +33,14 @@ import net.jodah.typetools.TypeResolver;
 public class ModuleRegistry {
 
 	private ObjectMapper objectMapper;
+
 	private ResourceRegistry resourceRegistry;
 
 	private List<Module> modules = new ArrayList<Module>();
 
 	private SimpleModule aggregatedModule = new SimpleModule(null);
-	private volatile boolean initialized;
 
-	public ModuleRegistry() {
-	}
+	private volatile boolean initialized;
 
 	/**
 	 * Register an new module to this registry and setup the module.
@@ -94,19 +91,19 @@ public class ModuleRegistry {
 		@Override
 		public void addFilter(Filter filter) {
 			checkNotInitialized();
-			aggregatedModule.addFilter(filter);			
+			aggregatedModule.addFilter(filter);
 		}
 
 		@Override
 		public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
 			checkNotInitialized();
-			aggregatedModule.addExceptionMapperLookup(exceptionMapperLookup);			
+			aggregatedModule.addExceptionMapperLookup(exceptionMapperLookup);
 		}
 
 		@Override
 		public void addExceptionMapper(ExceptionMapper<?> exceptionMapper) {
 			checkNotInitialized();
-			aggregatedModule.addExceptionMapper(exceptionMapper);			
+			aggregatedModule.addExceptionMapper(exceptionMapper);
 		}
 
 		@Override
@@ -119,7 +116,7 @@ public class ModuleRegistry {
 		public void addRepository(Class<?> sourceType, Class<?> targetType,
 				QuerySpecRelationshipRepository<?, ?, ?, ?> repository) {
 			checkNotInitialized();
-			aggregatedModule.addRepository(sourceType, targetType, repository);			
+			aggregatedModule.addRepository(sourceType, targetType, repository);
 		}
 	}
 
@@ -194,7 +191,6 @@ public class ModuleRegistry {
 		}
 	}
 
-	
 	/**
 	 * Combines all {@link ExceptionMapperLookup} instances provided by the registered
 	 * {@link Module}.
@@ -209,9 +205,9 @@ public class ModuleRegistry {
 
 		@SuppressWarnings("rawtypes")
 		@Override
-		public  Set<JsonApiExceptionMapper> getExceptionMappers() {
+		public Set<JsonApiExceptionMapper> getExceptionMappers() {
 			Set<JsonApiExceptionMapper> set = new HashSet<JsonApiExceptionMapper>();
-			for(ExceptionMapperLookup lookup : lookups){
+			for (ExceptionMapperLookup lookup : lookups) {
 				set.addAll(lookup.getExceptionMappers());
 			}
 			return set;
@@ -277,8 +273,9 @@ public class ModuleRegistry {
 		// TODO this needs to be merged with ResourceRegistryBuilder
 		for (final ResourceRepositoryRegistration resourceRepositoryRegistration : resourceRepositoryRegistrations) {
 			Class<?> resourceClass = resourceRepositoryRegistration.getResourceClass();
-			RepositoryInstanceBuilder<ResourceRepository<?, ?>> repositoryInstanceBuilder = new RepositoryInstanceBuilder(
-					null, null) {
+			RepositoryInstanceBuilder<ResourceRepository<?, ?>> repositoryInstanceBuilder = new RepositoryInstanceBuilder(null,
+					null) {
+
 				public Object buildRepository() {
 					return resourceRepositoryRegistration.getRepository();
 				}
@@ -290,21 +287,23 @@ public class ModuleRegistry {
 				if (relationshipRepositoryRegistration.getSourceType() == resourceClass) {
 					RepositoryInstanceBuilder<QuerySpecRelationshipRepository> relationshipInstanceBuilder = new RepositoryInstanceBuilder<QuerySpecRelationshipRepository>(
 							null, null) {
+
 						public QuerySpecRelationshipRepository buildRepository() {
 							return relationshipRepositoryRegistration.getRepository();
 						}
-						
+
 						@Override
-					    public Class getRepositoryClass() {
-					        return relationshipRepositoryRegistration.getRepository().getClass();
-					    }
+						public Class getRepositoryClass() {
+							return relationshipRepositoryRegistration.getRepository().getClass();
+						}
 					};
 					ResponseRelationshipEntry relationshipEntry = new DirectResponseRelationshipEntry(
-							relationshipInstanceBuilder){
+							relationshipInstanceBuilder) {
+
 						@Override
-					    public Class<?> getTargetAffiliation() {
+						public Class<?> getTargetAffiliation() {
 							return relationshipRepositoryRegistration.getTargetType();
-					    }
+						}
 					};
 					relationshipEntries.add(relationshipEntry);
 				}
@@ -328,5 +327,8 @@ public class ModuleRegistry {
 	public ExceptionMapperLookup getExceptionMapperLookup() {
 		return new CombinedExceptionMapperLookup(aggregatedModule.getExceptionMapperLookups());
 	}
-	
+
+	public List<Module> getModules() {
+		return modules;
+	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
@@ -65,6 +65,11 @@ public class ModuleTest {
 		Assert.assertEquals(resourceRegistry, moduleRegistry.getResourceRegistry());
 	}
 
+	@Test
+	public void getModules() {
+		Assert.assertEquals(2, moduleRegistry.getModules().size());
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void testNotInitialized() {
 		moduleRegistry = new ModuleRegistry();

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/AbstractJpaJerseyTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/AbstractJpaJerseyTest.java
@@ -1,7 +1,6 @@
 package io.katharsis.jpa;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -38,7 +37,7 @@ public abstract class AbstractJpaJerseyTest extends JerseyTest {
 	protected QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
 
 	protected AnnotationConfigApplicationContext context;
-	
+
 	private boolean useQuerySpec = true;
 
 	@Before
@@ -48,8 +47,6 @@ public abstract class AbstractJpaJerseyTest extends JerseyTest {
 		JpaModule module = JpaModule.newClientModule(TestEntity.class.getPackage().getName());
 		setupModule(module, false);
 		client.addModule(module);
-
-		client.getHttpClient().setReadTimeout(1000000, TimeUnit.MILLISECONDS);
 	}
 
 	protected void setupModule(JpaModule module, boolean server) {
@@ -95,11 +92,13 @@ public abstract class AbstractJpaJerseyTest extends JerseyTest {
 			SpringTransactionRunner transactionRunner = context.getBean(SpringTransactionRunner.class);
 
 			KatharsisFeature feature;
-			if(useQuerySpec){
-				feature = new KatharsisFeature(new ObjectMapper(),
-					new QueryParamsBuilder(new DefaultQueryParamsParser()), new SampleJsonServiceLocator());
-			}else{
-				feature = new KatharsisFeature(new ObjectMapper(), new DefaultQuerySpecDeserializer(), new SampleJsonServiceLocator());
+			if (useQuerySpec) {
+				feature = new KatharsisFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()),
+						new SampleJsonServiceLocator());
+			}
+			else {
+				feature = new KatharsisFeature(new ObjectMapper(), new DefaultQuerySpecDeserializer(),
+						new SampleJsonServiceLocator());
 			}
 
 			JpaModule module = JpaModule.newServerModule(emFactory, em, transactionRunner);

--- a/katharsis-validation/src/test/java/io/katharsis/validation/AbstractValidationTest.java
+++ b/katharsis-validation/src/test/java/io/katharsis/validation/AbstractValidationTest.java
@@ -27,8 +27,11 @@ import io.katharsis.validation.mock.repository.TaskRepository;
 public abstract class AbstractValidationTest extends JerseyTest {
 
 	protected KatharsisClient client;
+
 	protected ResourceRepositoryStub<Task, Long> taskRepo;
+
 	protected ResourceRepositoryStub<Project, Long> projectRepo;
+
 	protected RelationshipRepositoryStub<Task, Long, Project, Long> relRepo;
 
 	protected QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
@@ -41,8 +44,6 @@ public abstract class AbstractValidationTest extends JerseyTest {
 		projectRepo = client.getRepository(Project.class);
 		relRepo = client.getRepository(Task.class, Project.class);
 		TaskRepository.map.clear();
-
-		client.getHttpClient().setReadTimeout(1000000, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
@@ -52,11 +53,13 @@ public abstract class AbstractValidationTest extends JerseyTest {
 
 	@ApplicationPath("/")
 	private static class TestApplication extends ResourceConfig {
+
 		public TestApplication() {
 			property(KatharsisProperties.RESOURCE_SEARCH_PACKAGE, getClass().getPackage().getName());
 			property(KatharsisProperties.RESOURCE_DEFAULT_DOMAIN, "http://test.local");
 
-			KatharsisFeature feature = new KatharsisFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()), new SampleJsonServiceLocator());
+			KatharsisFeature feature = new KatharsisFeature(new ObjectMapper(),
+					new QueryParamsBuilder(new DefaultQueryParamsParser()), new SampleJsonServiceLocator());
 			feature.addModule(new ValidationModule());
 			register(feature);
 


### PR DESCRIPTION
partial refactoring of http handling:

- HttpAdapter interface introduced to support implementations other than OkHttp in the future
- HttpAdapterAware interface implemented to let modules customize the http adapter
- OkHttpClient updated to current version
- OkHttpClient.Builder used to create OkHttpClient
- OkHttpAdapterListener to let modules modify okhttp during build process