### PR TITLE
#177 Properly support patch/post semantic in katharsis-client

### DIFF
--- a/katharsis-client/src/main/java/io/katharsis/client/QuerySpecResourceRepositoryStub.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/QuerySpecResourceRepositoryStub.java
@@ -39,4 +39,25 @@ public interface QuerySpecResourceRepositoryStub<T, I extends Serializable> exte
 	 * @return persisted resource
 	 */
 	public <S extends T> S save(S entity, QuerySpec querySpec);
+	
+	
+	/**
+	 * Creates the given entity without any of its relationships.
+	 *
+	 * @param entity resource to be saved
+	 * @param <S> resource type
+	 * @return persisted resource
+	 */
+	public <S extends T> S create(S entity);
+
+	/**
+	 * Creates the given entity. {@link QueryParams} allows to specify which
+	 * relationships should be saved as well (just the relation, not the related resource).
+	 *
+	 * @param entity resource to be saved
+	 * @param querySpec querySpec
+	 * @param <S> resource type
+	 * @return persisted resource
+	 */
+	public <S extends T> S create(S entity, QuerySpec querySpec);
 }

--- a/katharsis-client/src/main/java/io/katharsis/client/ResourceRepositoryStub.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/ResourceRepositoryStub.java
@@ -37,4 +37,25 @@ public interface ResourceRepositoryStub<T, ID extends Serializable> extends Reso
 	 * @return persisted resource
 	 */
 	public <S extends T> S save(S entity, QueryParams queryParams);
+	
+
+	/**
+	 * Saves the given entity without any of its relationships.
+	 *
+	 * @param entity resource to be saved
+	 * @param <S> resource type
+	 * @return persisted resource
+	 */
+	public <S extends T> S create(S entity);
+
+	/**
+	 * Saves the given entity. {@link QueryParams} allows to specify which
+	 * relationships should be saved as well.
+	 *
+	 * @param entity resource to be saved
+	 * @param queryParams query params
+	 * @param <S> resource type
+	 * @return persisted resource
+	 */
+	public <S extends T> S create(S entity, QueryParams queryParams);
 }

--- a/katharsis-client/src/test/java/io/katharsis/client/ExceptionTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ExceptionTest.java
@@ -23,7 +23,7 @@ public class ExceptionTest extends AbstractClientTest {
 		task.setId(10000L);
 		task.setName("test");
 		try {
-			taskRepo.save(task);
+			taskRepo.create(task);
 			Assert.fail();
 		}
 		catch (TestException e) {

--- a/katharsis-client/src/test/java/io/katharsis/client/ModuleTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ModuleTest.java
@@ -43,7 +43,7 @@ public class ModuleTest extends AbstractClientTest {
 		Task task = new Task();
 		task.setId(1L);
 		task.setName("task");
-		taskRepo.save(task);
+		taskRepo.create(task);
 
 		List<Task> tasks = taskRepo.findAll(new QuerySpec(Task.class));
 		Assert.assertEquals(1, tasks.size());

--- a/katharsis-client/src/test/java/io/katharsis/client/QueryParamsClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/QueryParamsClientTest.java
@@ -55,7 +55,7 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		Task task = new Task();
 		task.setId(1L);
 		task.setName("test");
-		taskRepo.save(task);
+		taskRepo.create(task);
 
 		// check retrievable with findAll
 		List<Task> tasks = taskRepo.findAll(new QueryParams());
@@ -82,7 +82,7 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		Task task = new Task();
 		task.setId(null);
 		task.setName("test");
-		Task savedTask = taskRepo.save(task);
+		Task savedTask = taskRepo.create(task);
 		Assert.assertNotNull(savedTask.getId());
 	}
 
@@ -91,7 +91,7 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		Task task = new Task();
 		task.setId(1L);
 		task.setName("test");
-		taskRepo.save(task);
+		taskRepo.create(task);
 
 		taskRepo.delete(1L);
 
@@ -129,12 +129,12 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		Project project = new Project();
 		project.setId(1L);
 		project.setName("project");
-		projectRepo.save(project);
+		projectRepo.create(project);
 
 		Task task = new Task();
 		task.setId(2L);
 		task.setName("test");
-		taskRepo.save(task);
+		taskRepo.create(task);
 
 		relRepo.setRelation(task, project.getId(), "project");
 
@@ -148,17 +148,17 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		Project project0 = new Project();
 		project0.setId(1L);
 		project0.setName("project0");
-		projectRepo.save(project0);
+		projectRepo.create(project0);
 
 		Project project1 = new Project();
 		project1.setId(2L);
 		project1.setName("project1");
-		projectRepo.save(project1);
+		projectRepo.create(project1);
 
 		Task task = new Task();
 		task.setId(3L);
 		task.setName("test");
-		taskRepo.save(task);
+		taskRepo.create(task);
 
 		relRepo.addRelations(task, Arrays.asList(project0.getId(), project1.getId()), "projects");
 		List<Project> relProjects = relRepo.findManyTargets(task.getId(), "projects", new QueryParams());


### PR DESCRIPTION
introduced create(...) method next to save() method to perform an explicit push.

This breaks the current (wrong) contract of just having a save. A method setPushAlways(...) is provided on KatharisClient to enable the old behavior. For the next release it will be enabled to maintain backward
compatibility, but at some point it will be switched to the proper behavio.