### PR TITLE
#182 Improve client-side exception mapping

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/ErrorResponse.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/ErrorResponse.java
@@ -1,5 +1,6 @@
 package io.katharsis.errorhandling;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import io.katharsis.queryspec.internal.QueryAdapter;
@@ -20,6 +21,9 @@ public final class ErrorResponse implements BaseResponseContext {
     }
 
     public Iterable<ErrorData> getErrors(){
+    	if(data == null){
+    		return Collections.emptyList();
+    	}
     	return data;
     }
     

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/exception/BadRequestException.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/exception/BadRequestException.java
@@ -1,0 +1,22 @@
+package io.katharsis.errorhandling.exception;
+
+import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.response.HttpStatus;
+
+public class BadRequestException extends KatharsisMappableException {
+
+	private static final String TITLE = "BAD_REQUEST";
+
+	public BadRequestException(String message) {
+		super(HttpStatus.BAD_REQUEST_400, ErrorData.builder().setTitle(TITLE).setDetail(message)
+				.setStatus(String.valueOf(HttpStatus.BAD_REQUEST_400)).build());
+	}
+
+	public BadRequestException(int httpStatus, ErrorData errorData) {
+		super(httpStatus, errorData);
+	}
+
+	public BadRequestException(int httpStatus, ErrorData errorData, Throwable cause) {
+		super(httpStatus, errorData, cause);
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/exception/InternalServerErrorException.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/exception/InternalServerErrorException.java
@@ -3,7 +3,7 @@ package io.katharsis.errorhandling.exception;
 import io.katharsis.errorhandling.ErrorData;
 import io.katharsis.response.HttpStatus;
 
-public class InternalServerErrorException extends KatharsisMappableException {
+public class InternalServerErrorException extends KatharsisMappableException {  // NOSONAR exception hierarchy deep but ok
 
 	private static final String TITLE = "INTERNAL_SERVER_ERROR";
 

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/exception/InternalServerErrorException.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/exception/InternalServerErrorException.java
@@ -1,0 +1,22 @@
+package io.katharsis.errorhandling.exception;
+
+import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.response.HttpStatus;
+
+public class InternalServerErrorException extends KatharsisMappableException {
+
+	private static final String TITLE = "INTERNAL_SERVER_ERROR";
+
+	public InternalServerErrorException(String message) {
+		super(HttpStatus.INTERNAL_SERVER_ERROR_500, ErrorData.builder().setTitle(TITLE).setDetail(message)
+				.setStatus(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR_500)).build());
+	}
+
+	public InternalServerErrorException(int httpStatus, ErrorData errorData) {
+		super(httpStatus, errorData);
+	}
+
+	public InternalServerErrorException(int httpStatus, ErrorData errorData, Throwable cause) {
+		super(httpStatus, errorData, cause);
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/DefaultExceptionMapperLookup.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/DefaultExceptionMapperLookup.java
@@ -3,7 +3,9 @@ package io.katharsis.errorhandling.mapper;
 import io.katharsis.resource.exception.init.InvalidResourceException;
 import org.reflections.Reflections;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -11,20 +13,26 @@ import java.util.Set;
  * are annotated with the {@link ExceptionMapperProvider} annotation.
  */
 public class DefaultExceptionMapperLookup implements ExceptionMapperLookup {
-    private String resourceSearchPackage;
+	
+    private List<String> resourceSearchPackages;
 
     public DefaultExceptionMapperLookup(String resourceSearchPackage) {
-        this.resourceSearchPackage = resourceSearchPackage;
+    	if(resourceSearchPackage != null){
+    		this.resourceSearchPackages = Arrays.asList(resourceSearchPackage.split(","));
+    	}
+    }
+
+    public DefaultExceptionMapperLookup(List<String> resourceSearchPackages) {
+        this.resourceSearchPackages = resourceSearchPackages;
     }
 
     @Override
     public Set<JsonApiExceptionMapper> getExceptionMappers() {
         Reflections reflections;
-        if (resourceSearchPackage != null) {
-            String[] packageNames = resourceSearchPackage.split(",");
-            reflections = new Reflections(packageNames);
+        if (resourceSearchPackages != null) {
+            reflections = new Reflections(resourceSearchPackages);
         } else {
-            reflections = new Reflections(resourceSearchPackage);
+            reflections = new Reflections();
         }
         Set<Class<?>> exceptionMapperClasses = reflections.getTypesAnnotatedWith(ExceptionMapperProvider.class);
 

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/DefaultExceptionMapperLookup.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/DefaultExceptionMapperLookup.java
@@ -17,9 +17,7 @@ public class DefaultExceptionMapperLookup implements ExceptionMapperLookup {
     private List<String> resourceSearchPackages;
 
     public DefaultExceptionMapperLookup(String resourceSearchPackage) {
-    	if(resourceSearchPackage != null){
-    		this.resourceSearchPackages = Arrays.asList(resourceSearchPackage.split(","));
-    	}
+    	this(resourceSearchPackage != null ? Arrays.asList(resourceSearchPackage.split(",")) : null);
     }
 
     public DefaultExceptionMapperLookup(List<String> resourceSearchPackages) {

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/KatharsisExceptionMapper.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/KatharsisExceptionMapper.java
@@ -1,29 +1,72 @@
 package io.katharsis.errorhandling.mapper;
 
-import io.katharsis.errorhandling.ErrorResponse;
-import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import java.util.Iterator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.errorhandling.ErrorResponse;
+import io.katharsis.errorhandling.exception.BadRequestException;
+import io.katharsis.errorhandling.exception.InternalServerErrorException;
+import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.response.HttpStatus;
+import io.katharsis.security.ForbiddenException;
+import io.katharsis.security.UnauthorizedException;
 
 /**
  * Exception mapper for a generic exception which can be thrown in request processing.
  */
-public final class KatharsisExceptionMapper implements JsonApiExceptionMapper<KatharsisMappableException> {
+public final class KatharsisExceptionMapper implements ExceptionMapper<KatharsisMappableException> {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+	private Logger logger = LoggerFactory.getLogger(getClass());
 
-    @Override
-    public ErrorResponse toErrorResponse(KatharsisMappableException exception) {
-        // log 5xx status as error and anything else as warn
-        if (exception.getHttpStatus() >= 500 && exception.getHttpStatus() < 600) {
-            logger.error("failed to process request", exception);
-        } else {
-            logger.warn("failed to process request", exception);
-        }
+	@Override
+	public ErrorResponse toErrorResponse(KatharsisMappableException exception) {
+		// log 5xx status as error and anything else as warn
+		if (exception.getHttpStatus() >= 500 && exception.getHttpStatus() < 600) {
+			logger.error("failed to process request", exception);
+		}
+		else {
+			logger.warn("failed to process request", exception);
+		}
 
-        return ErrorResponse.builder()
-                .setStatus(exception.getHttpStatus())
-                .setSingleErrorData(exception.getErrorData())
-                .build();
-    }
+		return ErrorResponse.builder().setStatus(exception.getHttpStatus()).setSingleErrorData(exception.getErrorData()).build();
+	}
+
+	@Override
+	public KatharsisMappableException fromErrorResponse(ErrorResponse errorResponse) {
+		String message = getMessage(errorResponse);
+
+		int httpStatus = errorResponse.getHttpStatus();
+		if (httpStatus == HttpStatus.FORBIDDEN_403) {
+			return new ForbiddenException(message);
+		}
+		if (httpStatus == HttpStatus.UNAUTHORIZED_401) {
+			return new UnauthorizedException(message);
+		}
+		if (httpStatus == HttpStatus.BAD_REQUEST_400) {
+			return new BadRequestException(message);
+		}
+		if (httpStatus == HttpStatus.INTERNAL_SERVER_ERROR_500) {
+			return new InternalServerErrorException(message);
+		}
+		throw new IllegalStateException(errorResponse.toString());
+	}
+
+	private String getMessage(ErrorResponse errorResponse) {
+		Iterator<ErrorData> errors = errorResponse.getErrors().iterator();
+		if (errors.hasNext()) {
+			ErrorData data = errors.next();
+			return data.getDetail();
+		}
+		return null;
+	}
+
+	@Override
+	public boolean accepts(ErrorResponse errorResponse) {
+		int httpStatus = errorResponse.getHttpStatus();
+		return httpStatus == HttpStatus.BAD_REQUEST_400 || httpStatus == HttpStatus.FORBIDDEN_403
+				|| httpStatus == HttpStatus.UNAUTHORIZED_401 || httpStatus == HttpStatus.INTERNAL_SERVER_ERROR_500;
+	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/KatharsisExceptionMapper.java
+++ b/katharsis-core/src/main/java/io/katharsis/errorhandling/mapper/KatharsisExceptionMapper.java
@@ -56,11 +56,12 @@ public final class KatharsisExceptionMapper implements ExceptionMapper<Katharsis
 
 	private String getMessage(ErrorResponse errorResponse) {
 		Iterator<ErrorData> errors = errorResponse.getErrors().iterator();
+		String message = null;
 		if (errors.hasNext()) {
 			ErrorData data = errors.next();
-			return data.getDetail();
+			message = data.getDetail();
 		}
-		return null;
+		return message;
 	}
 
 	@Override

--- a/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonDeserializationException.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonDeserializationException.java
@@ -1,13 +1,13 @@
 package io.katharsis.jackson.exception;
 
 import io.katharsis.errorhandling.ErrorData;
-import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.errorhandling.exception.BadRequestException;
 import io.katharsis.response.HttpStatus;
 
 /**
  * Thrown, when is unable to read request body
  */
-public class JsonDeserializationException extends KatharsisMappableException {
+public class JsonDeserializationException extends BadRequestException {
     private static final String TITLE = "invalid request body";
 
     public JsonDeserializationException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonDeserializationException.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonDeserializationException.java
@@ -7,7 +7,7 @@ import io.katharsis.response.HttpStatus;
 /**
  * Thrown, when is unable to read request body
  */
-public class JsonDeserializationException extends BadRequestException {
+public class JsonDeserializationException extends BadRequestException { // NOSONAR exception hierarchy deep but ok
     private static final String TITLE = "invalid request body";
 
     public JsonDeserializationException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonSerializationException.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonSerializationException.java
@@ -7,7 +7,7 @@ import io.katharsis.response.HttpStatus;
 /**
  * Thrown when a Jackson serialization related exception occurs.
  */
-public class JsonSerializationException extends InternalServerErrorException {
+public class JsonSerializationException extends InternalServerErrorException {  // NOSONAR exception hierarchy deep but ok
     private static final String TITLE = "JSON serialization error";
 
     public JsonSerializationException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonSerializationException.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/exception/JsonSerializationException.java
@@ -1,13 +1,13 @@
 package io.katharsis.jackson.exception;
 
 import io.katharsis.errorhandling.ErrorData;
-import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.errorhandling.exception.InternalServerErrorException;
 import io.katharsis.response.HttpStatus;
 
 /**
  * Thrown when a Jackson serialization related exception occurs.
  */
-public class JsonSerializationException extends KatharsisMappableException {
+public class JsonSerializationException extends InternalServerErrorException {
     private static final String TITLE = "JSON serialization error";
 
     public JsonSerializationException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/jackson/exception/ParametersDeserializationException.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/exception/ParametersDeserializationException.java
@@ -7,7 +7,7 @@ import io.katharsis.response.HttpStatus;
 /**
  * Thrown, when is unable to read request parameters
  */
-public class ParametersDeserializationException extends BadRequestException {
+public class ParametersDeserializationException extends BadRequestException {  // NOSONAR exception hierarchy deep but ok
     private static final String TITLE = "Request parameters error";
 
     public ParametersDeserializationException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/jackson/exception/ParametersDeserializationException.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/exception/ParametersDeserializationException.java
@@ -1,13 +1,13 @@
 package io.katharsis.jackson.exception;
 
 import io.katharsis.errorhandling.ErrorData;
-import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.errorhandling.exception.BadRequestException;
 import io.katharsis.response.HttpStatus;
 
 /**
  * Thrown, when is unable to read request parameters
  */
-public class ParametersDeserializationException extends KatharsisMappableException {
+public class ParametersDeserializationException extends BadRequestException {
     private static final String TITLE = "Request parameters error";
 
     public ParametersDeserializationException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/repository/exception/RepositoryMethodException.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/exception/RepositoryMethodException.java
@@ -1,10 +1,10 @@
 package io.katharsis.repository.exception;
 
 import io.katharsis.errorhandling.ErrorData;
-import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.errorhandling.exception.InternalServerErrorException;
 import io.katharsis.response.HttpStatus;
 
-public class RepositoryMethodException extends KatharsisMappableException {
+public class RepositoryMethodException extends InternalServerErrorException {
     private static final String TITLE = "Resource method error";
 
     public RepositoryMethodException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/repository/exception/RepositoryMethodException.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/exception/RepositoryMethodException.java
@@ -4,7 +4,7 @@ import io.katharsis.errorhandling.ErrorData;
 import io.katharsis.errorhandling.exception.InternalServerErrorException;
 import io.katharsis.response.HttpStatus;
 
-public class RepositoryMethodException extends InternalServerErrorException {
+public class RepositoryMethodException extends InternalServerErrorException {  // NOSONAR exception hierarchy deep but ok
     private static final String TITLE = "Resource method error";
 
     public RepositoryMethodException(String message) {

--- a/katharsis-core/src/main/java/io/katharsis/resource/exception/RequestBodyNotFoundException.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/exception/RequestBodyNotFoundException.java
@@ -6,7 +6,7 @@ import io.katharsis.errorhandling.exception.BadRequestException;
 import io.katharsis.errorhandling.exception.KatharsisMappableException;
 import io.katharsis.response.HttpStatus;
 
-public class RequestBodyNotFoundException extends BadRequestException {
+public class RequestBodyNotFoundException extends BadRequestException {  // NOSONAR exception hierarchy deep but ok
 
     private static final String TITLE = "Request body not found";
 

--- a/katharsis-core/src/main/java/io/katharsis/resource/exception/RequestBodyNotFoundException.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/exception/RequestBodyNotFoundException.java
@@ -2,10 +2,11 @@ package io.katharsis.resource.exception;
 
 import io.katharsis.dispatcher.controller.HttpMethod;
 import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.errorhandling.exception.BadRequestException;
 import io.katharsis.errorhandling.exception.KatharsisMappableException;
 import io.katharsis.response.HttpStatus;
 
-public class RequestBodyNotFoundException extends KatharsisMappableException {
+public class RequestBodyNotFoundException extends BadRequestException {
 
     private static final String TITLE = "Request body not found";
 

--- a/katharsis-core/src/main/java/io/katharsis/resource/exception/ResourceException.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/exception/ResourceException.java
@@ -7,7 +7,7 @@ import io.katharsis.response.HttpStatus;
 /**
  * General exception regarding resource building.
  */
-public class ResourceException extends InternalServerErrorException {
+public class ResourceException extends InternalServerErrorException {  // NOSONAR exception hierarchy deep but ok
 
     private static final String TITLE = "Resource error";
 

--- a/katharsis-core/src/main/java/io/katharsis/resource/exception/ResourceException.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/exception/ResourceException.java
@@ -1,13 +1,13 @@
 package io.katharsis.resource.exception;
 
 import io.katharsis.errorhandling.ErrorData;
-import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.errorhandling.exception.InternalServerErrorException;
 import io.katharsis.response.HttpStatus;
 
 /**
  * General exception regarding resource building.
  */
-public class ResourceException extends KatharsisMappableException {
+public class ResourceException extends InternalServerErrorException {
 
     private static final String TITLE = "Resource error";
 

--- a/katharsis-core/src/main/java/io/katharsis/response/HttpStatus.java
+++ b/katharsis-core/src/main/java/io/katharsis/response/HttpStatus.java
@@ -7,6 +7,7 @@ public interface HttpStatus {
     int NO_CONTENT_204 = 204;
     int NOT_FOUND_404 = 404;
     int BAD_REQUEST_400 = 400;
+    int UNAUTHORIZED_401 = 401;
     int FORBIDDEN_403 = 403;
     int CONFLICT_409 = 409;
     int INTERNAL_SERVER_ERROR_500 = 500;

--- a/katharsis-core/src/main/java/io/katharsis/security/ForbiddenException.java
+++ b/katharsis-core/src/main/java/io/katharsis/security/ForbiddenException.java
@@ -4,7 +4,7 @@ import io.katharsis.errorhandling.ErrorData;
 import io.katharsis.errorhandling.exception.KatharsisMappableException;
 import io.katharsis.response.HttpStatus;
 
-public class ForbiddenException extends KatharsisMappableException {
+public class ForbiddenException extends KatharsisMappableException {  // NOSONAR exception hierarchy deep but ok
 
 	private static final String TITLE = "FOBIDDEN";
 

--- a/katharsis-core/src/main/java/io/katharsis/security/ForbiddenException.java
+++ b/katharsis-core/src/main/java/io/katharsis/security/ForbiddenException.java
@@ -1,0 +1,15 @@
+package io.katharsis.security;
+
+import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.response.HttpStatus;
+
+public class ForbiddenException extends KatharsisMappableException {
+
+	private static final String TITLE = "FOBIDDEN";
+
+	public ForbiddenException(String message) {
+		super(HttpStatus.FORBIDDEN_403, ErrorData.builder().setTitle(TITLE).setDetail(message)
+				.setStatus(String.valueOf(HttpStatus.FORBIDDEN_403)).build());
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/security/UnauthorizedException.java
+++ b/katharsis-core/src/main/java/io/katharsis/security/UnauthorizedException.java
@@ -4,7 +4,7 @@ import io.katharsis.errorhandling.ErrorData;
 import io.katharsis.errorhandling.exception.KatharsisMappableException;
 import io.katharsis.response.HttpStatus;
 
-public class UnauthorizedException extends KatharsisMappableException {
+public class UnauthorizedException extends KatharsisMappableException {  // NOSONAR exception hierarchy deep but ok
 
 	private static final String TITLE = "UNAUTHORIZED";
 

--- a/katharsis-core/src/main/java/io/katharsis/security/UnauthorizedException.java
+++ b/katharsis-core/src/main/java/io/katharsis/security/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package io.katharsis.security;
+
+import io.katharsis.errorhandling.ErrorData;
+import io.katharsis.errorhandling.exception.KatharsisMappableException;
+import io.katharsis.response.HttpStatus;
+
+public class UnauthorizedException extends KatharsisMappableException {
+
+	private static final String TITLE = "UNAUTHORIZED";
+
+	public UnauthorizedException(String message) {
+		super(HttpStatus.UNAUTHORIZED_401, ErrorData.builder().setTitle(TITLE).setDetail(message)
+				.setStatus(String.valueOf(HttpStatus.UNAUTHORIZED_401)).build());
+	}
+}

--- a/katharsis-core/src/test/java/io/katharsis/errorhandling/exception/KatharsisExceptionMapperTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/errorhandling/exception/KatharsisExceptionMapperTest.java
@@ -1,39 +1,82 @@
 package io.katharsis.errorhandling.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import org.junit.Test;
+
 import io.katharsis.errorhandling.ErrorData;
 import io.katharsis.errorhandling.ErrorResponse;
 import io.katharsis.errorhandling.mapper.KatharsisExceptionMapper;
 import io.katharsis.response.HttpStatus;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import io.katharsis.security.ForbiddenException;
+import io.katharsis.security.UnauthorizedException;
 
 public class KatharsisExceptionMapperTest {
 
-    private static final String TITLE1 = "title1";
-    private static final String DETAIL1 = "detail1";
+	private static final String TITLE1 = "title1";
 
-    @Test
-    public void shouldMapToErrorResponse() throws Exception {
-        KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
-        ErrorResponse response = mapper.toErrorResponse(new SampleKatharsisException());
+	private static final String DETAIL1 = "detail1";
 
-        assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR_500);
-        assertThat((Iterable<?>) response.getResponse().getEntity())
-                .hasSize(1)
-                .extracting("title", "detail")
-                .containsExactly(tuple(TITLE1, DETAIL1));
-    }
+	@Test
+	public void shouldMapToErrorResponse() throws Exception {
+		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
+		ErrorResponse response = mapper.toErrorResponse(new SampleKatharsisException());
 
-    private static class SampleKatharsisException extends KatharsisMappableException {
+		assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR_500);
+		assertThat((Iterable<?>) response.getResponse().getEntity()).hasSize(1).extracting("title", "detail")
+				.containsExactly(tuple(TITLE1, DETAIL1));
+	}
 
-        SampleKatharsisException() {
-            super(HttpStatus.INTERNAL_SERVER_ERROR_500, ErrorData.builder()
-                    .setTitle(TITLE1)
-                    .setDetail(DETAIL1)
-                    .setStatus(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR_500))
-                    .build());
-        }
-    }
+	@Test
+	public void internalServerError() {
+		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
+		ErrorResponse response = mapper.toErrorResponse(new InternalServerErrorException("testMessage"));
+		assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR_500);
+		assertThat(mapper.accepts(response)).isTrue();
+		KatharsisMappableException exception = mapper.fromErrorResponse(response);
+		assertThat(exception).isInstanceOf(InternalServerErrorException.class);
+		assertThat(exception.getMessage()).isEqualTo("testMessage");
+	}
+
+	@Test
+	public void badRequest() {
+		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
+		ErrorResponse response = mapper.toErrorResponse(new BadRequestException("testMessage"));
+		assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST_400);
+		assertThat(mapper.accepts(response)).isTrue();
+		KatharsisMappableException exception = mapper.fromErrorResponse(response);
+		assertThat(exception).isInstanceOf(BadRequestException.class);
+		assertThat(exception.getMessage()).isEqualTo("testMessage");
+	}
+
+	@Test
+	public void notAuthorized() {
+		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
+		ErrorResponse response = mapper.toErrorResponse(new UnauthorizedException("testMessage"));
+		assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.UNAUTHORIZED_401);
+		assertThat(mapper.accepts(response)).isTrue();
+		KatharsisMappableException exception = mapper.fromErrorResponse(response);
+		assertThat(exception).isInstanceOf(UnauthorizedException.class);
+		assertThat(exception.getMessage()).isEqualTo("testMessage");
+	}
+
+	@Test
+	public void forbidden() {
+		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
+		ErrorResponse response = mapper.toErrorResponse(new ForbiddenException("testMessage"));
+		assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN_403);
+		assertThat(mapper.accepts(response)).isTrue();
+		KatharsisMappableException exception = mapper.fromErrorResponse(response);
+		assertThat(exception).isInstanceOf(ForbiddenException.class);
+		assertThat(exception.getMessage()).isEqualTo("testMessage");
+	}
+
+	private static class SampleKatharsisException extends KatharsisMappableException {
+
+		SampleKatharsisException() {
+			super(HttpStatus.INTERNAL_SERVER_ERROR_500, ErrorData.builder().setTitle(TITLE1).setDetail(DETAIL1)
+					.setStatus(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR_500)).build());
+		}
+	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/errorhandling/exception/KatharsisExceptionMapperTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/errorhandling/exception/KatharsisExceptionMapperTest.java
@@ -39,6 +39,13 @@ public class KatharsisExceptionMapperTest {
 		assertThat(exception.getMessage()).isEqualTo("testMessage");
 	}
 
+
+	@Test(expected=IllegalStateException.class)
+	public void invalidExceptionNotManagedByMapper() {
+		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();
+		mapper.fromErrorResponse(new ErrorResponse(null, 123));
+	}
+
 	@Test
 	public void badRequest() {
 		KatharsisExceptionMapper mapper = new KatharsisExceptionMapper();


### PR DESCRIPTION
- add exception and mapper for UNAUTHORIZED_401
- add exception and mapper for FORBIDDEN_403
- add BadRequestException as supertype for all 400 exceptions
- add InternalSerververErrorException as supertype for all 500
- unmap everything on client-side