### PR TITLE
#186 Add init support to module lifecycle

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/module/InitialzingModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/InitialzingModule.java
@@ -1,0 +1,11 @@
+package io.katharsis.module;
+
+public interface InitialzingModule extends Module {
+
+	/**
+	 * Called once Katharsis is fully initialized. From this point in time, the module is, for example,
+	 * allowed to access the resource registry.
+	 */
+	public void init();
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
@@ -260,6 +260,12 @@ public class ModuleRegistry {
 			this.objectMapper.registerModules(getJacksonModules());
 
 			applyRepositoryRegistration(resourceRegistry);
+			
+			for (Module module : modules) {
+				if (module instanceof InitialzingModule) {
+					((InitialzingModule) module).init();
+				}
+			}
 		}
 	}
 

--- a/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
@@ -87,6 +87,11 @@ public class ModuleTest {
 		Assert.assertTrue(classes.contains(IllegalStateExceptionMapper.class));
 		Assert.assertTrue(classes.contains(SomeIllegalStateExceptionMapper.class));
 	}
+	
+	@Test
+	public void testInitCalled() {
+		Assert.assertTrue(testModule.initialized);
+	}
 
 	@Test(expected = IllegalStateException.class)
 	public void testModuleChangeAfterAddModule() {
@@ -200,9 +205,10 @@ public class ModuleTest {
 		Assert.assertNotNull(responseRelationshipEntry);
 	}
 
-	class TestModule implements Module {
+	class TestModule implements InitialzingModule {
 
 		private ModuleContext context;
+		private boolean initialized;
 
 		@Override
 		public String getModuleName() {
@@ -243,6 +249,11 @@ public class ModuleTest {
 					return set;
 				}
 			});
+		}
+
+		@Override
+		public void init() {
+			initialized = true;
 		}
 	}
 


### PR DESCRIPTION
currently modules just have a configure method where katharsis is not yet up and some things are not available. There should be an additional init() method that is invoked later once katharsis is up.

=> introduced new interface InitializingModule with that method