### PR TITLE
added a quick and dirty test for lazy relations

### DIFF
--- a/katharsis-client/src/test/java/io/katharsis/client/QueryParamsClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/QueryParamsClientTest.java
@@ -148,7 +148,7 @@ public class QueryParamsClientTest extends AbstractClientTest {
 
 	@Test
 	public void testLazyRelation() {
-		relRepoLazy.findOneTarget(1L, "id", new QueryParams());
+		relRepoLazy.findOneTarget(1L, "lazyProject", new QueryParams());
 	}
 
 	@Test

--- a/katharsis-client/src/test/java/io/katharsis/client/QueryParamsClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/QueryParamsClientTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.katharsis.client.mock.models.LazyTask;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -23,6 +24,7 @@ public class QueryParamsClientTest extends AbstractClientTest {
 	protected ResourceRepositoryStub<Project, Long> projectRepo;
 
 	protected RelationshipRepositoryStub<Task, Long, Project, Long> relRepo;
+	protected RelationshipRepositoryStub<LazyTask, Long, Project, Long> relRepoLazy;
 
 	@Before
 	public void setup() {
@@ -31,6 +33,7 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		taskRepo = client.getRepository(Task.class);
 		projectRepo = client.getRepository(Project.class);
 		relRepo = client.getRepository(Task.class, Project.class);
+		relRepoLazy = client.getRepository(LazyTask.class, Project.class);
 	}
 
 	@Test
@@ -141,6 +144,11 @@ public class QueryParamsClientTest extends AbstractClientTest {
 		Project relProject = relRepo.findOneTarget(task.getId(), "project", new QueryParams());
 		Assert.assertNotNull(relProject);
 		Assert.assertEquals(project.getId(), relProject.getId());
+	}
+
+	@Test
+	public void testLazyRelation() {
+		relRepoLazy.findOneTarget(1L, "id", new QueryParams());
 	}
 
 	@Test

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/models/LazyTask.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/models/LazyTask.java
@@ -1,0 +1,34 @@
+package io.katharsis.client.mock.models;
+
+import io.katharsis.resource.annotations.JsonApiId;
+import io.katharsis.resource.annotations.JsonApiResource;
+import io.katharsis.resource.annotations.JsonApiToMany;
+import io.katharsis.resource.annotations.JsonApiToOne;
+
+import java.util.List;
+
+@JsonApiResource(type = "lazy_tasks")
+public class LazyTask {
+
+    @JsonApiId
+    private Long id;
+
+    @JsonApiToOne(lazy = true)
+    private Project lazyProject;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Project getLazyProject() {
+        return lazyProject;
+    }
+
+    public void setLazyProject(Project lazyProject) {
+        this.lazyProject = lazyProject;
+    }
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/LazyTaskRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/LazyTaskRepository.java
@@ -1,0 +1,51 @@
+package io.katharsis.client.mock.repository;
+
+import io.katharsis.client.mock.models.LazyTask;
+import io.katharsis.client.mock.models.Project;
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.ResourceRepository;
+import io.katharsis.resource.exception.ResourceNotFoundException;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LazyTaskRepository implements ResourceRepository<LazyTask, Long> {
+
+    private static final ConcurrentHashMap<Long, LazyTask> THREAD_LOCAL_REPOSITORY = new ConcurrentHashMap<>();
+
+    public static void clear(){
+    	THREAD_LOCAL_REPOSITORY.clear();
+    }
+    
+    @Override
+    public <S extends LazyTask> S save(S entity) {
+        entity.setId((long) (THREAD_LOCAL_REPOSITORY.size() + 1));
+        THREAD_LOCAL_REPOSITORY.put(entity.getId(), entity);
+
+        return entity;
+    }
+
+    @Override
+    public LazyTask findOne(Long aLong, QueryParams queryParams) {
+        LazyTask task = THREAD_LOCAL_REPOSITORY.get(aLong);
+        if (task == null) {
+            throw new ResourceNotFoundException(Project.class.getCanonicalName());
+        }
+        return task;
+    }
+
+    @Override
+    public Iterable<LazyTask> findAll(QueryParams queryParamss) {
+        return THREAD_LOCAL_REPOSITORY.values();
+    }
+
+
+    @Override
+    public Iterable<LazyTask> findAll(Iterable<Long> ids, QueryParams queryParams) {
+        return THREAD_LOCAL_REPOSITORY.values();
+    }
+
+    @Override
+    public void delete(Long aLong) {
+        THREAD_LOCAL_REPOSITORY.remove(aLong);
+    }
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/LazyTaskToProjectRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/LazyTaskToProjectRepository.java
@@ -1,0 +1,105 @@
+package io.katharsis.client.mock.repository;
+
+import io.katharsis.client.mock.models.LazyTask;
+import io.katharsis.client.mock.models.Project;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.queryspec.QuerySpecRelationshipRepository;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class LazyTaskToProjectRepository implements QuerySpecRelationshipRepository<LazyTask, Long, Project, Long> {
+
+	private static final ConcurrentMap<Relation<LazyTask>, Integer> THREAD_LOCAL_REPOSITORY = new ConcurrentHashMap<>();
+
+	public static void clear() {
+		THREAD_LOCAL_REPOSITORY.clear();
+	}
+
+	@Override
+	public void setRelation(LazyTask source, Long targetId, String fieldName) {
+		removeRelations(fieldName);
+		if (targetId != null) {
+			THREAD_LOCAL_REPOSITORY.put(new Relation<>(source, targetId, fieldName), 0);
+		}
+	}
+
+	@Override
+	public void setRelations(LazyTask source, Iterable<Long> targetIds, String fieldName) {
+		removeRelations(fieldName);
+		if (targetIds != null) {
+			for (Long targetId : targetIds) {
+				THREAD_LOCAL_REPOSITORY.put(new Relation<>(source, targetId, fieldName), 0);
+			}
+		}
+	}
+
+	@Override
+	public void addRelations(LazyTask source, Iterable<Long> targetIds, String fieldName) {
+		for (Long targetId : targetIds) {
+			THREAD_LOCAL_REPOSITORY.put(new Relation<>(source, targetId, fieldName), 0);
+		}
+	}
+
+	@Override
+	public void removeRelations(LazyTask source, Iterable<Long> targetIds, String fieldName) {
+		for (Long targetId : targetIds) {
+			Iterator<Relation<LazyTask>> iterator = THREAD_LOCAL_REPOSITORY.keySet().iterator();
+			while (iterator.hasNext()) {
+				Relation<LazyTask> next = iterator.next();
+				if (next.getFieldName().equals(fieldName) && next.getTargetId().equals(targetId)) {
+					iterator.remove();
+				}
+			}
+		}
+	}
+
+	public void removeRelations(String fieldName) {
+		Iterator<Relation<LazyTask>> iterator = THREAD_LOCAL_REPOSITORY.keySet().iterator();
+		while (iterator.hasNext()) {
+			Relation<LazyTask> next = iterator.next();
+			if (next.getFieldName().equals(fieldName)) {
+				iterator.remove();
+			}
+		}
+	}
+
+	@Override
+	public Project findOneTarget(Long sourceId, String fieldName, QuerySpec queryParams) {
+		for (Relation<LazyTask> relation : THREAD_LOCAL_REPOSITORY.keySet()) {
+			if (relation.getSource().getId().equals(sourceId) && relation.getFieldName().equals(fieldName)) {
+				Project project = new Project();
+				project.setId((Long) relation.getTargetId());
+				return project;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Iterable<Project> findManyTargets(Long sourceId, String fieldName, QuerySpec queryParams) {
+		List<Project> projects = new LinkedList<>();
+		for (Relation<LazyTask> relation : THREAD_LOCAL_REPOSITORY.keySet()) {
+			if (relation.getSource().getId().equals(sourceId) && relation.getFieldName().equals(fieldName)) {
+				Project project = new Project();
+				project.setId((Long) relation.getTargetId());
+				projects.add(project);
+			}
+		}
+		return projects;
+	}
+
+	@Override
+	public Class<LazyTask> getSourceResourceClass() {
+		return LazyTask.class;
+	}
+
+	@Override
+	public Class<Project> getTargetResourceClass() {
+		return Project.class;
+	}
+}


### PR DESCRIPTION
Just a quick and dirty test for lazy relations

Since Katharsis 2.7+ lazy relations are not working probably.
Currently (2.8.1) im not able to have current situation:

```java

@Data
@JsonApiResource(type = "foo")
public class foo {
    @JsonApiId
    @Column
    private Long id;
    @Column
    private Boolean active;
    @JsonApiToOne(lazy = true)
    private Bar bar;
}
```

```java

@Data
@JsonApiResource(type = "bar")
public class Bar {
    @JsonApiId
    @Column
    private Long id;
    @Column
    private String stuff;
}
```

having bar = null results in 

```JSON
{  
   "data":[  
      {  
         "type":"foo",
         "id":"1",
         "attributes":{  
            "active":true
         },
         "relationships":{  
            "bar":{  
               "links":{  
                  "self":"/foo/1/relationships/bar",
                  "related":"/foo/1/bar"
               }
            }
         },
         "links":{  
            "self":"/foo/1"
         }
      }
   ]
}
```

requesting `/foo/1/bar` results in an error

```curl
curl 'http://api.xxx/foo/1/bar' -H 'Pragma: no-cache' -H 'Origin: http://127.0.0.1:4200' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: de-DE,de;q=0.8,en-US;q=0.6,en;q=0.4' -H 'Authorization: Bearer 7f6a82dc-f5d4-428e-af87-f8632cb1cfc9' -H 'Accept: application/vnd.api+json' -H 'Cache-Control: no-cache' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.100 Safari/537.36' -H 'Connection: keep-alive' -H 'Referer: http://127.0.0.1:4200/' -H 'DNT: 1' --compressed -v
* About to connect() to api.xxx port 80 (#0)
*   Trying 127.0.0.1...
* Connected to api.xxx (127.0.0.1) port 80 (#0)
> GET /foo/1/bar HTTP/1.1
> Host: api.localdev
> Pragma: no-cache
> Origin: http://127.0.0.1:4200
> Accept-Encoding: gzip, deflate, sdch
> Accept-Language: de-DE,de;q=0.8,en-US;q=0.6,en;q=0.4
> Authorization: Bearer 7f6a82dc-f5d4-428e-af87-f8632cb1cfc9
> Accept: application/vnd.api+json
> Cache-Control: no-cache
> User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.100 Safari/537.36
> Connection: keep-alive
> Referer: http://127.0.0.1:4200/
> DNT: 1
> 
< HTTP/1.1 500 Internal Server Error
< Server: nginx/1.10.1
< Date: Mon, 21 Nov 2016 11:12:41 GMT
< Content-Length: 0
< Connection: keep-alive
< X-Powered-By: Undertow/1
< Access-Control-Allow-Headers: X-Requested-With,Content-Type,Authorization,X-Test
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS
< 
* Connection #0 to host api.xxx left intact
```


```
12:14:32,546 ERROR [io.katharsis.dispatcher.RequestDispatcher] (default task-2) failed to process request: io.katharsis.resource.exception.init.ResourceNotFoundInitializationException: Resource of class not found: org.ddg.DDGRestAPI.model.prod.Bar
	at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:106)
	at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:94)
	at io.katharsis.queryspec.internal.QueryParamsAdapterBuilder.build(QueryParamsAdapterBuilder.java:24)
	at io.katharsis.dispatcher.RequestDispatcher.dispatchRequest(RequestDispatcher.java:75)
	at io.katharsis.rs.KatharsisFilter.dispatchRequest(KatharsisFilter.java:144)
	at io.katharsis.rs.KatharsisFilter.filter(KatharsisFilter.java:111)
	at org.ddg.DDGRestAPI.service.auth.AuthenticationFilter.filter(AuthenticationFilter.java:121)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:140)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:197)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:221)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:292)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:138)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
	at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:272)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:104)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:805)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

12:14:32,546 ERROR [io.katharsis.rs.KatharsisFilter] (default task-2) failed to dispatch request: io.katharsis.resource.exception.init.ResourceNotFoundInitializationException: Resource of class not found: org.ddg.DDGRestAPI.model.prod.Bar
	at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:106)
	at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:94)
	at io.katharsis.queryspec.internal.QueryParamsAdapterBuilder.build(QueryParamsAdapterBuilder.java:24)
	at io.katharsis.dispatcher.RequestDispatcher.dispatchRequest(RequestDispatcher.java:75)
	at io.katharsis.rs.KatharsisFilter.dispatchRequest(KatharsisFilter.java:144)
	at io.katharsis.rs.KatharsisFilter.filter(KatharsisFilter.java:111)
	at org.ddg.DDGRestAPI.service.auth.AuthenticationFilter.filter(AuthenticationFilter.java:121)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:140)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:197)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:221)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:292)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:138)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
	at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:272)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:104)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:805)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

12:14:32,547 ERROR [org.jboss.resteasy.resteasy_jaxrs.i18n] (default task-2) RESTEASY002010: Failed to execute: javax.ws.rs.WebApplicationException: HTTP 500 Internal Server Error
	at io.katharsis.rs.KatharsisFilter.filter(KatharsisFilter.java:117)
	at org.ddg.DDGRestAPI.service.auth.AuthenticationFilter.filter(AuthenticationFilter.java:121)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:140)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:197)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:221)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:292)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:138)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
	at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.api.LegacyThreadSetupActionWrapper$1.call(LegacyThreadSetupActionWrapper.java:44)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:272)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:104)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:805)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: io.katharsis.resource.exception.init.ResourceNotFoundInitializationException: Resource of class not found: org.ddg.DDGRestAPI.model.prod.Bar
	at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:106)
	at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:94)
	at io.katharsis.queryspec.internal.QueryParamsAdapterBuilder.build(QueryParamsAdapterBuilder.java:24)
	at io.katharsis.dispatcher.RequestDispatcher.dispatchRequest(RequestDispatcher.java:75)
	at io.katharsis.rs.KatharsisFilter.dispatchRequest(KatharsisFilter.java:144)
	at io.katharsis.rs.KatharsisFilter.filter(KatharsisFilter.java:111)
	... 44 more

```