### PR TITLE
#104 QuerySpec in-memory filtering fixes

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/queryspec/FilterOperator.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/FilterOperator.java
@@ -1,5 +1,7 @@
 package io.katharsis.queryspec;
 
+import java.util.Collection;
+
 import io.katharsis.utils.CompareUtils;
 
 /**
@@ -18,7 +20,7 @@ public abstract class FilterOperator {
 		}
 
 	};
-	
+
 	/**
 	 * like operation
 	 */
@@ -31,7 +33,6 @@ public abstract class FilterOperator {
 
 	};
 
-	
 	/**
 	 * Boolean or
 	 */
@@ -63,6 +64,9 @@ public abstract class FilterOperator {
 
 		@Override
 		public boolean matches(Object value1, Object value2) {
+			if (value2 instanceof Collection) {
+				return ((Collection<?>) value2).contains(value1);
+			}
 			return CompareUtils.isEquals(value1, value2);
 		}
 

--- a/katharsis-core/src/main/java/io/katharsis/utils/PropertyUtils.java
+++ b/katharsis-core/src/main/java/io/katharsis/utils/PropertyUtils.java
@@ -5,6 +5,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,9 +93,20 @@ public class PropertyUtils {
 	public static Object getProperty(Object bean, List<String> propertyPath) {
 		Object current = bean;
 		for(String propertyName : propertyPath){
-			if(bean == null)
+			if(current == null)
 				return null;
-			current = getProperty(current, propertyName);
+			if(current instanceof Iterable){
+				// follow multi-valued property
+				List<Object> result = new ArrayList<>();
+				Iterable<?> iterable = (Iterable<?>)current;
+				for(Object currentElem : iterable){
+					result.add(getProperty(currentElem, propertyName));
+				}
+				current = result;
+			}else{
+				// follow single-valued property
+				current = getProperty(current, propertyName);
+			}
 		}
 		return current;
 	}


### PR DESCRIPTION
- proper total count computation
- support to traverse multi-valued properties