### PR TITLE
#204 Support to intercept and augment QueryDSL generation in jpa module

### DIFF
--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaEntityRepository.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaEntityRepository.java
@@ -9,6 +9,7 @@ import javax.persistence.EntityManager;
 
 import io.katharsis.jpa.internal.JpaRepositoryBase;
 import io.katharsis.jpa.internal.JpaRepositoryUtils;
+import io.katharsis.jpa.internal.JpaRequestContext;
 import io.katharsis.jpa.internal.meta.MetaAttribute;
 import io.katharsis.jpa.internal.meta.MetaEntity;
 import io.katharsis.jpa.internal.paging.DefaultPagedMetaInformation;
@@ -65,6 +66,7 @@ public class JpaEntityRepository<T, I extends Serializable> extends JpaRepositor
 		QuerySpec filteredQuerySpec = filterQuerySpec(querySpec);
 		JpaQueryFactory queryFactory = module.getQueryFactory();
 		JpaQuery<?> query = queryFactory.query(entityClass);
+		query.setPrivateData(new JpaRequestContext(this, querySpec));
 
 		ComputedAttributeRegistry computedAttributesRegistry = queryFactory.getComputedAttributes();
 		Set<String> computedAttrs = computedAttributesRegistry.getForType(entityClass);

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaRelationshipRepository.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaRelationshipRepository.java
@@ -13,6 +13,7 @@ import javax.persistence.EntityManager;
 
 import io.katharsis.jpa.internal.JpaRepositoryBase;
 import io.katharsis.jpa.internal.JpaRepositoryUtils;
+import io.katharsis.jpa.internal.JpaRequestContext;
 import io.katharsis.jpa.internal.meta.MetaAttribute;
 import io.katharsis.jpa.internal.meta.MetaEntity;
 import io.katharsis.jpa.internal.meta.MetaType;
@@ -219,6 +220,7 @@ public class JpaRelationshipRepository<S, I extends Serializable, T, J extends S
 
 		JpaQueryFactory queryFactory = module.getQueryFactory();
 		JpaQuery<?> query = queryFactory.query(sourceEntityClass, fieldName, sourceIdLists);
+		query.setPrivateData(new JpaRequestContext(this, querySpec));
 		query.addParentIdSelection();
 		query = filterQuery(filteredQuerySpec, query);
 

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaRequestContext.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaRequestContext.java
@@ -1,0 +1,25 @@
+package io.katharsis.jpa.internal;
+
+import io.katharsis.queryspec.QuerySpec;
+
+public class JpaRequestContext {
+
+	private Object repository;
+
+	private QuerySpec querySpec;
+
+	public JpaRequestContext(Object repository, QuerySpec querySpec) {
+		super();
+		this.repository = repository;
+		this.querySpec = querySpec;
+	}
+
+	public Object getRepository() {
+		return repository;
+	}
+
+	public QuerySpec getQuerySpec() {
+		return querySpec;
+	}
+
+}

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/AbstractJpaQueryImpl.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/AbstractJpaQueryImpl.java
@@ -56,6 +56,8 @@ public abstract class AbstractJpaQueryImpl<T, B extends JpaQueryBackend<?, ?, ?,
 	protected boolean parentIdSelection;
 
 	private ComputedAttributeRegistryImpl computedAttrs;
+	
+	private Object privateData;
 
 	protected AbstractJpaQueryImpl(MetaLookup metaLookup, EntityManager em, Class<T> clazz,
 			ComputedAttributeRegistryImpl computedAttrs) {
@@ -63,6 +65,14 @@ public abstract class AbstractJpaQueryImpl<T, B extends JpaQueryBackend<?, ?, ?,
 		this.clazz = clazz;
 		this.meta = metaLookup.getMeta(clazz).asDataObject();
 		this.computedAttrs = computedAttrs;
+	}
+	
+	public Object getPrivateData(){
+		return privateData;
+	}
+	
+	public void setPrivateData(Object privateData){
+		this.privateData = privateData;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/querydsl/QuerydslExecutorImpl.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/querydsl/QuerydslExecutorImpl.java
@@ -27,8 +27,14 @@ public class QuerydslExecutorImpl<T> extends AbstractQueryExecutorImpl<T> implem
 		this.query = query;
 	}
 
+	@Override
 	public JPAQuery<T> getQuery() {
 		return query;
+	}
+	
+	@Override
+	public void setQuery(JPAQuery<T> query){
+		this.query = query;
 	}
 
 	@Override

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/querydsl/QuerydslQueryImpl.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/backend/querydsl/QuerydslQueryImpl.java
@@ -11,20 +11,25 @@ import io.katharsis.jpa.internal.meta.MetaLookup;
 import io.katharsis.jpa.internal.query.AbstractJpaQueryImpl;
 import io.katharsis.jpa.internal.query.ComputedAttributeRegistryImpl;
 import io.katharsis.jpa.query.querydsl.QuerydslQuery;
+import io.katharsis.jpa.query.querydsl.QuerydslTranslationInterceptor;
 
 public class QuerydslQueryImpl<T> extends AbstractJpaQueryImpl<T, QuerydslQueryBackend<T>> implements QuerydslQuery<T> {
 
 	private JPAQueryFactory queryFactory;
 
-	public QuerydslQueryImpl(MetaLookup metaLookup, EntityManager em, Class<T> clazz,
-			ComputedAttributeRegistryImpl computedAttrs) {
+	private List<QuerydslTranslationInterceptor> translationInterceptors;
+
+	public QuerydslQueryImpl(MetaLookup metaLookup, EntityManager em, Class<T> clazz, ComputedAttributeRegistryImpl computedAttrs,
+			List<QuerydslTranslationInterceptor> translationInterceptors) {
 		super(metaLookup, em, clazz, computedAttrs);
+		this.translationInterceptors = translationInterceptors;
 		queryFactory = new JPAQueryFactory(em);
 	}
 
-	public QuerydslQueryImpl(MetaLookup metaLookup, EntityManager em, Class<?> clazz,
-			ComputedAttributeRegistryImpl virtualAttrs, String attrName, List<?> entityIds) {
+	public QuerydslQueryImpl(MetaLookup metaLookup, EntityManager em, Class<?> clazz, ComputedAttributeRegistryImpl virtualAttrs,
+			List<QuerydslTranslationInterceptor> translationInterceptors, String attrName, List<?> entityIds) {
 		super(metaLookup, em, clazz, virtualAttrs, attrName, entityIds);
+		this.translationInterceptors = translationInterceptors;
 		queryFactory = new JPAQueryFactory(em);
 	}
 
@@ -43,7 +48,13 @@ public class QuerydslQueryImpl<T> extends AbstractJpaQueryImpl<T, QuerydslQueryB
 	}
 
 	@Override
-	protected QuerydslExecutorImpl<T> newExecutor(QuerydslQueryBackend<T> ctx, int numAutoSelections, Map<String, Integer> selectionBindings) {
+	protected QuerydslExecutorImpl<T> newExecutor(QuerydslQueryBackend<T> ctx, int numAutoSelections,
+			Map<String, Integer> selectionBindings) {
+
+		for (QuerydslTranslationInterceptor translationInterceptor : translationInterceptors) {
+			translationInterceptor.intercept(this, ctx);
+		}
+
 		return new QuerydslExecutorImpl<>(em, meta, ctx.getQuery(), numAutoSelections, selectionBindings);
 	}
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/JpaQuery.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/JpaQuery.java
@@ -39,4 +39,12 @@ public interface JpaQuery<T> {
 
 	public void addParentIdSelection();
 
+	/**
+	 * @return private data that can be set by the consumer to provide some context for a query, for example, when being called back by an interceptor. Does
+	 * not have any direct impact on the created query.
+	 */
+	public Object getPrivateData();
+
+	public void setPrivateData(Object privateData);
+
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslExecutor.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslExecutor.java
@@ -2,10 +2,16 @@ package io.katharsis.jpa.query.querydsl;
 
 import java.util.List;
 
+import com.querydsl.jpa.impl.JPAQuery;
+
 import io.katharsis.jpa.query.JpaQueryExecutor;
 
 public interface QuerydslExecutor<T> extends JpaQueryExecutor<T> {
 
 	@Override
 	public List<QuerydslTuple> getResultTuples();
+
+	public void setQuery(JPAQuery<T> query);
+
+	public JPAQuery<T> getQuery();
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslQueryFactory.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslQueryFactory.java
@@ -2,12 +2,15 @@ package io.katharsis.jpa.query.querydsl;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.katharsis.jpa.internal.JpaQueryFactoryBase;
 import io.katharsis.jpa.internal.query.backend.querydsl.QuerydslQueryImpl;
 import io.katharsis.jpa.query.JpaQueryFactory;
 
 public class QuerydslQueryFactory extends JpaQueryFactoryBase implements JpaQueryFactory {
+
+	private List<QuerydslTranslationInterceptor> interceptors = new CopyOnWriteArrayList<>();
 
 	private QuerydslQueryFactory() {
 	}
@@ -16,15 +19,19 @@ public class QuerydslQueryFactory extends JpaQueryFactoryBase implements JpaQuer
 		return new QuerydslQueryFactory();
 	}
 
+	public void addInterceptor(QuerydslTranslationInterceptor interceptor) {
+		interceptors.add(interceptor);
+	}
+
 	@Override
 	public <T> QuerydslQuery<T> query(Class<T> entityClass) {
-		return new QuerydslQueryImpl<>(metaLookup, em, entityClass, computedAttrs);
+		return new QuerydslQueryImpl<>(metaLookup, em, entityClass, computedAttrs, interceptors);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public <T> QuerydslQuery<T> query(Class<?> entityClass, String attrName, List<?> entityIds) {
-		return new QuerydslQueryImpl(metaLookup, em, entityClass, computedAttrs, attrName, entityIds);
+		return new QuerydslQueryImpl(metaLookup, em, entityClass, computedAttrs, interceptors, attrName, entityIds);
 	}
 
 	public void registerComputedAttribute(Class<?> targetClass, String attributeName, Type attributeType,

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslRepositoryFilter.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslRepositoryFilter.java
@@ -1,0 +1,18 @@
+package io.katharsis.jpa.query.querydsl;
+
+import io.katharsis.jpa.JpaRepositoryFilter;
+import io.katharsis.queryspec.QuerySpec;
+
+public interface QuerydslRepositoryFilter extends JpaRepositoryFilter {
+
+	/**
+	 * Allows to hook into the translation of the generic query into a querydsl query.
+	 * 
+	 * @param repository invoked
+	 * @param querySpec provided by caller
+	 * @param translationContext to modify the translation
+	 * @return filtered query
+	 */
+	public <T> void filterQueryTranslation(Object repository, QuerySpec querySpec,
+			QuerydslTranslationContext<T> translationContext);
+}

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslRepositoryFilterBase.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslRepositoryFilterBase.java
@@ -1,0 +1,13 @@
+package io.katharsis.jpa.query.querydsl;
+
+import io.katharsis.jpa.JpaRepositoryFilterBase;
+import io.katharsis.queryspec.QuerySpec;
+
+public class QuerydslRepositoryFilterBase extends JpaRepositoryFilterBase implements QuerydslRepositoryFilter {
+
+	@Override
+	public <T> void filterQueryTranslation(Object repository, QuerySpec querySpec,
+			QuerydslTranslationContext<T> translationContext) {
+		// nothing to do
+	}
+}

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslTranslationContext.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslTranslationContext.java
@@ -1,0 +1,35 @@
+package io.katharsis.jpa.query.querydsl;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import io.katharsis.jpa.internal.meta.MetaAttributePath;
+import io.katharsis.queryspec.Direction;
+
+public interface QuerydslTranslationContext<T> {
+
+	JPAQueryFactory getQueryFactory();
+
+	JPAQuery<T> getQuery();
+
+	Path<T> getRoot();
+
+	<P> EntityPath<P> getParentRoot();
+
+	<E> Expression<E> getAttribute(MetaAttributePath attrPath);
+
+	public <E> EntityPath<E> getJoin(MetaAttributePath path);
+
+	void addPredicate(Predicate predicate);
+
+	<E extends Comparable<E>> OrderSpecifier<E> addOrder(Expression<E> expr, Direction dir);
+
+	void addSelection(Expression<?> expression, String name);
+
+	<U> QuerydslTranslationContext<U> castFor(Class<U> type);
+}

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslTranslationInterceptor.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/query/querydsl/QuerydslTranslationInterceptor.java
@@ -1,0 +1,9 @@
+package io.katharsis.jpa.query.querydsl;
+
+import io.katharsis.jpa.internal.query.backend.querydsl.QuerydslQueryImpl;
+
+public interface QuerydslTranslationInterceptor { // NOSONAR not a functional interface
+
+	<T> void intercept(QuerydslQueryImpl<T> query, QuerydslTranslationContext<T> translationContext);
+
+}

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaEntityRepositoryTestBase.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/JpaEntityRepositoryTestBase.java
@@ -23,7 +23,7 @@ import io.katharsis.queryspec.SortSpec;
 @Transactional
 public abstract class JpaEntityRepositoryTestBase extends AbstractJpaTest {
 
-	private JpaEntityRepository<TestEntity, Long> repo;
+	protected JpaEntityRepository<TestEntity, Long> repo;
 
 	@Override
 	@Before

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/querydsl/JpaEntityRepositoryQuerydslTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/querydsl/JpaEntityRepositoryQuerydslTest.java
@@ -12,4 +12,5 @@ public class JpaEntityRepositoryQuerydslTest extends JpaEntityRepositoryTestBase
 	protected JpaQueryFactory createQueryFactory(EntityManager em) {
 		return QuerydslQueryFactory.newInstance();
 	}
+
 }

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/querydsl/QuerydslRepositoryFilterTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/repository/querydsl/QuerydslRepositoryFilterTest.java
@@ -1,0 +1,39 @@
+package io.katharsis.jpa.repository.querydsl;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.katharsis.jpa.JpaEntityRepository;
+import io.katharsis.jpa.model.TestEntity;
+import io.katharsis.jpa.query.AbstractJpaTest;
+import io.katharsis.jpa.query.JpaQueryFactory;
+import io.katharsis.jpa.query.querydsl.QuerydslQueryFactory;
+import io.katharsis.jpa.query.querydsl.QuerydslRepositoryFilterBase;
+import io.katharsis.jpa.query.querydsl.QuerydslTranslationContext;
+import io.katharsis.queryspec.QuerySpec;
+
+@Transactional
+public class QuerydslRepositoryFilterTest extends AbstractJpaTest {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void translationInterceptor() {
+		JpaEntityRepository<TestEntity, Long> repo = new JpaEntityRepository<>(module, TestEntity.class);
+		QuerydslRepositoryFilterBase filter = Mockito.spy(new QuerydslRepositoryFilterBase());
+		module.addFilter(filter);
+
+		QuerySpec querySpec = new QuerySpec(TestEntity.class);
+		repo.findAll(querySpec);
+
+		Mockito.verify(filter, Mockito.times(1)).filterQueryTranslation(Mockito.eq(repo), Mockito.eq(querySpec),
+				Mockito.any(QuerydslTranslationContext.class));
+	}
+
+	@Override
+	protected JpaQueryFactory createQueryFactory(EntityManager em) {
+		return QuerydslQueryFactory.newInstance();
+	}
+}

--- a/katharsis-jpa/src/test/resources/META-INF/beans.xml
+++ b/katharsis-jpa/src/test/resources/META-INF/beans.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bean-discovery-mode="all" version="1.1"
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bean-discovery-mode="all" version="1.2"
 	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
 </beans>


### PR DESCRIPTION
new QuerydslRepositoryFilter will introduced that allows with filterQueryTranslation to intercept and modify the generated QueryDSL queries.