### PR TITLE
#208 ReposistoryInformationBuilder support

### DIFF
--- a/katharsis-client/src/main/java/io/katharsis/client/module/ClientModule.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/module/ClientModule.java
@@ -1,6 +1,8 @@
 package io.katharsis.client.module;
 
 import io.katharsis.module.Module;
+import io.katharsis.repository.information.internal.DefaultRelationshipRepositoryInformationBuilder;
+import io.katharsis.repository.information.internal.DefaultResourceRepositoryInformationBuilder;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.AnnotationResourceInformationBuilder;
 
@@ -14,6 +16,8 @@ public class ClientModule implements Module {
 	@Override
 	public void setupModule(ModuleContext context) {
 		context.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(new ResourceFieldNameTransformer()));
+		context.addRepositoryInformationBuilder(new DefaultResourceRepositoryInformationBuilder());
+		context.addRepositoryInformationBuilder(new DefaultRelationshipRepositoryInformationBuilder());
 	}
 
 }

--- a/katharsis-core/src/main/java/io/katharsis/internal/boot/KatharsisBoot.java
+++ b/katharsis-core/src/main/java/io/katharsis/internal/boot/KatharsisBoot.java
@@ -33,6 +33,8 @@ import io.katharsis.repository.Repository;
 import io.katharsis.repository.ResourceRepository;
 import io.katharsis.repository.annotations.JsonApiRelationshipRepository;
 import io.katharsis.repository.annotations.JsonApiResourceRepository;
+import io.katharsis.repository.information.internal.DefaultRelationshipRepositoryInformationBuilder;
+import io.katharsis.repository.information.internal.DefaultResourceRepositoryInformationBuilder;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.AnnotationResourceInformationBuilder;
 import io.katharsis.resource.registry.ConstantServiceUrlProvider;
@@ -189,6 +191,8 @@ public class KatharsisBoot {
 		ServiceDiscovery serviceDiscovery = moduleRegistry.getServiceDiscovery();
 		SimpleModule module = new SimpleModule("discovery");
 
+		module.addRepositoryInformationBuilder(new DefaultResourceRepositoryInformationBuilder());
+		module.addRepositoryInformationBuilder(new DefaultRelationshipRepositoryInformationBuilder());
 		module.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(resourceFieldNameTransformer));
 
 		for (JsonApiExceptionMapper<?> exceptionMapper : serviceDiscovery.getInstancesByType(JsonApiExceptionMapper.class)) {

--- a/katharsis-core/src/main/java/io/katharsis/module/CoreModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/CoreModule.java
@@ -15,11 +15,8 @@ public class CoreModule extends SimpleModule {
 	public static final String MODULE_NAME = "core";
 
 	public CoreModule(String resourceSearchPackage, ResourceFieldNameTransformer resourceFieldNameTransformer) {
-		super(MODULE_NAME);
+		this(resourceFieldNameTransformer);
 		this.addResourceLookup(new DefaultResourceLookup(resourceSearchPackage));
-		this.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(resourceFieldNameTransformer));
-		this.addRepositoryInformationBuilder(new DefaultResourceRepositoryInformationBuilder());
-		this.addRepositoryInformationBuilder(new DefaultRelationshipRepositoryInformationBuilder());
 		this.addExceptionMapperLookup(new DefaultExceptionMapperLookup(resourceSearchPackage));
 	}
 	

--- a/katharsis-core/src/main/java/io/katharsis/module/CoreModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/CoreModule.java
@@ -1,6 +1,8 @@
 package io.katharsis.module;
 
 import io.katharsis.errorhandling.mapper.DefaultExceptionMapperLookup;
+import io.katharsis.repository.information.internal.DefaultRelationshipRepositoryInformationBuilder;
+import io.katharsis.repository.information.internal.DefaultResourceRepositoryInformationBuilder;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.AnnotationResourceInformationBuilder;
 import io.katharsis.resource.registry.DefaultResourceLookup;
@@ -16,6 +18,15 @@ public class CoreModule extends SimpleModule {
 		super(MODULE_NAME);
 		this.addResourceLookup(new DefaultResourceLookup(resourceSearchPackage));
 		this.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(resourceFieldNameTransformer));
+		this.addRepositoryInformationBuilder(new DefaultResourceRepositoryInformationBuilder());
+		this.addRepositoryInformationBuilder(new DefaultRelationshipRepositoryInformationBuilder());
 		this.addExceptionMapperLookup(new DefaultExceptionMapperLookup(resourceSearchPackage));
+	}
+	
+	public CoreModule(ResourceFieldNameTransformer resourceFieldNameTransformer) {
+		super(MODULE_NAME);
+		this.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(resourceFieldNameTransformer));
+		this.addRepositoryInformationBuilder(new DefaultResourceRepositoryInformationBuilder());
+		this.addRepositoryInformationBuilder(new DefaultRelationshipRepositoryInformationBuilder());
 	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/module/Module.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/Module.java
@@ -4,6 +4,7 @@ import io.katharsis.dispatcher.filter.Filter;
 import io.katharsis.errorhandling.mapper.ExceptionMapper;
 import io.katharsis.errorhandling.mapper.ExceptionMapperLookup;
 import io.katharsis.repository.filter.RepositoryFilter;
+import io.katharsis.repository.information.RepositoryInformationBuilder;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.registry.ResourceLookup;
 import io.katharsis.resource.registry.ResourceRegistry;
@@ -47,6 +48,13 @@ public interface Module {
 		 * @param resourceInformationBuilder resource information builder
 		 */
 		void addResourceInformationBuilder(ResourceInformationBuilder resourceInformationBuilder);
+		
+		/**
+		 * Register the given {@link RepositoryInformationBuilder} in Katharsis.
+		 *
+		 * @param resourceInformationBuilder repository information builder
+		 */
+		void addRepositoryInformationBuilder(RepositoryInformationBuilder repositoryInformationBuilder);
 
 		/**
 		 * Register the given {@link ResourceLookup} in Katharsis.
@@ -64,9 +72,15 @@ public interface Module {
 
 		/**
 		 * Adds the given repository for the given type.
+		 */
+		void addRepository(Object repository);
+		
+		/**
+		 * Adds the given repository for the given type.
 		 *
 		 * @param resourceClass resource class
 		 * @param repository    repository
+		 * @deprecated 
 		 */
 		void addRepository(Class<?> resourceClass, Object repository);
 
@@ -76,6 +90,7 @@ public interface Module {
 		 * @param sourceResourceClass source resource class
 		 * @param targetResourceClass target resource class
 		 * @param repository          repository
+		 * @deprecated 
 		 */
 		void addRepository(Class<?> sourceResourceClass, Class<?> targetResourceClass, Object repository);
 

--- a/katharsis-core/src/main/java/io/katharsis/module/SimpleModule.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/SimpleModule.java
@@ -11,6 +11,7 @@ import io.katharsis.dispatcher.filter.Filter;
 import io.katharsis.errorhandling.mapper.ExceptionMapperLookup;
 import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
 import io.katharsis.repository.filter.RepositoryFilter;
+import io.katharsis.repository.information.RepositoryInformationBuilder;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.registry.ResourceLookup;
 import io.katharsis.security.SecurityProvider;
@@ -22,19 +23,19 @@ public class SimpleModule implements Module {
 
 	private List<ResourceInformationBuilder> resourceInformationBuilders = new ArrayList<>();
 
+	private List<RepositoryInformationBuilder> repositoryInformationBuilders = new ArrayList<>();
+
 	private List<Filter> filters = new ArrayList<>();
 
 	private List<RepositoryFilter> repositoryFilters = new ArrayList<>();
-	
+
 	private List<SecurityProvider> securityProviders = new ArrayList<>();
 
 	private List<ResourceLookup> resourceLookups = new ArrayList<>();
 
 	private List<com.fasterxml.jackson.databind.Module> jacksonModules = new ArrayList<>();
 
-	private List<RelationshipRepositoryRegistration> relationshipRepositoryRegistrations = new ArrayList<>();
-
-	private List<ResourceRepositoryRegistration> resourceRepositoryRegistrations = new ArrayList<>();
+	private List<Object> repositories = new ArrayList<>();
 
 	private List<ExceptionMapperLookup> exceptionMapperLookups = new ArrayList<>();
 
@@ -57,6 +58,9 @@ public class SimpleModule implements Module {
 		for (ResourceInformationBuilder resourceInformationBuilder : resourceInformationBuilders) {
 			context.addResourceInformationBuilder(resourceInformationBuilder);
 		}
+		for (RepositoryInformationBuilder resourceInformationBuilder : repositoryInformationBuilders) {
+			context.addRepositoryInformationBuilder(resourceInformationBuilder);
+		}
 		for (ResourceLookup resourceLookup : resourceLookups) {
 			context.addResourceLookup(resourceLookup);
 		}
@@ -69,11 +73,8 @@ public class SimpleModule implements Module {
 		for (com.fasterxml.jackson.databind.Module jacksonModule : jacksonModules) {
 			context.addJacksonModule(jacksonModule);
 		}
-		for (ResourceRepositoryRegistration reg : resourceRepositoryRegistrations) {
-			context.addRepository(reg.resourceClass, reg.repository);
-		}
-		for (RelationshipRepositoryRegistration reg : relationshipRepositoryRegistrations) {
-			context.addRepository(reg.sourceType, reg.targetType, reg.repository);
+		for (Object repository : repositories) {
+			context.addRepository(repository);
 		}
 		for (ExceptionMapperLookup exceptionMapperLookup : exceptionMapperLookups) {
 			context.addExceptionMapperLookup(exceptionMapperLookup);
@@ -96,6 +97,16 @@ public class SimpleModule implements Module {
 		resourceInformationBuilders.add(resourceInformationBuilder);
 	}
 
+	/**
+	 * Registers a new {@link RepositoryInformationBuilder} with this module.
+	 * 
+	 * @param repositoryInformationBuilder repository information builder
+	 */
+	public void addRepositoryInformationBuilder(RepositoryInformationBuilder repositoryInformationBuilder) {
+		checkInitialized();
+		repositoryInformationBuilders.add(repositoryInformationBuilder);
+	}
+
 	public void addExceptionMapperLookup(ExceptionMapperLookup exceptionMapperLookup) {
 		checkInitialized();
 		exceptionMapperLookups.add(exceptionMapperLookup);
@@ -112,11 +123,16 @@ public class SimpleModule implements Module {
 		return Collections.unmodifiableList(resourceInformationBuilders);
 	}
 
+	protected List<RepositoryInformationBuilder> getRepositoryInformationBuilders() {
+		checkInitialized();
+		return Collections.unmodifiableList(repositoryInformationBuilders);
+	}
+
 	public void addFilter(Filter filter) {
 		checkInitialized();
 		filters.add(filter);
 	}
-	
+
 	public void addRepositoryFilter(RepositoryFilter filter) {
 		checkInitialized();
 		repositoryFilters.add(filter);
@@ -126,7 +142,7 @@ public class SimpleModule implements Module {
 		checkInitialized();
 		return Collections.unmodifiableList(filters);
 	}
-	
+
 	protected List<RepositoryFilter> getRepositoryFilters() {
 		checkInitialized();
 		return Collections.unmodifiableList(repositoryFilters);
@@ -162,70 +178,25 @@ public class SimpleModule implements Module {
 		return Collections.unmodifiableList(resourceLookups);
 	}
 
+	public void addRepository(Object repository) {
+		checkInitialized();
+		repositories.add(repository);
+	}
+
+	@Deprecated
 	public void addRepository(Class<?> resourceClass, Object repository) {
 		checkInitialized();
-		resourceRepositoryRegistrations.add(new ResourceRepositoryRegistration(resourceClass, repository));
+		repositories.add(repository);
 	}
 
+	@Deprecated
 	public void addRepository(Class<?> sourceType, Class<?> targetType, Object repository) {
 		checkInitialized();
-		relationshipRepositoryRegistrations.add(new RelationshipRepositoryRegistration(sourceType, targetType, repository));
+		repositories.add(repository);
 	}
 
-	public List<RelationshipRepositoryRegistration> getRelationshipRepositoryRegistrations() {
-		return Collections.unmodifiableList(relationshipRepositoryRegistrations);
-	}
-
-	public List<ResourceRepositoryRegistration> getResourceRepositoryRegistrations() {
-		return Collections.unmodifiableList(resourceRepositoryRegistrations);
-	}
-
-	public class RelationshipRepositoryRegistration {
-
-		private Class<?> sourceType;
-
-		private Class<?> targetType;
-
-		private Object repository;
-
-		public RelationshipRepositoryRegistration(Class<?> sourceType, Class<?> targetType, Object repository) {
-			this.sourceType = sourceType;
-			this.targetType = targetType;
-			this.repository = repository;
-		}
-
-		public Class<?> getSourceType() {
-			return sourceType;
-		}
-
-		public Class<?> getTargetType() {
-			return targetType;
-		}
-
-		public Object getRepository() {
-			return repository;
-		}
-
-	}
-
-	public static class ResourceRepositoryRegistration {
-
-		private Class<?> resourceClass;
-
-		private Object repository;
-
-		public ResourceRepositoryRegistration(Class<?> resourceClass, Object repository) {
-			this.resourceClass = resourceClass;
-			this.repository = repository;
-		}
-
-		public Class<?> getResourceClass() {
-			return resourceClass;
-		}
-
-		public Object getRepository() {
-			return repository;
-		}
+	public List<Object> getRepositories() {
+		return Collections.unmodifiableList(repositories);
 	}
 
 	public List<ExceptionMapperLookup> getExceptionMapperLookups() {

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RelationshipRepositoryInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RelationshipRepositoryInformation.java
@@ -1,0 +1,15 @@
+package io.katharsis.repository.information;
+
+import io.katharsis.resource.information.ResourceInformation;
+
+/**
+ * Holds information about the type of a resource repository.
+ */
+public interface RelationshipRepositoryInformation extends RepositoryInformation {
+
+	/**
+	 * @return information about the source of the relationship.
+	 */
+	ResourceInformation getSourceResourceInformation();
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformation.java
@@ -1,0 +1,16 @@
+package io.katharsis.repository.information;
+
+import io.katharsis.resource.information.ResourceInformation;
+
+/**
+ * Holds information about the type of a repository.
+ */
+public interface RepositoryInformation {
+
+	Object getRepository();
+
+	/**
+	 * @return information about the resources hold in this repository
+	 */
+	ResourceInformation getResourceInformation();
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformationBuilder.java
@@ -1,0 +1,20 @@
+package io.katharsis.repository.information;
+
+/**
+ * A builder which creates RepositoryInformation instances of a specific class.
+ */
+public interface RepositoryInformationBuilder {
+
+	/**
+	 * @param repositoryClass repository class
+	 * @return true if this builder can process the provided repository class
+	 */
+	boolean accept(Object repository);
+
+	/**
+	 * @param repositoryClass resource class
+	 * @return RepositoryInformation for the provided repository class.
+	 */
+	RepositoryInformation build(Object repository, RepositoryInformationBuilderContext context);
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformationBuilderContext.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformationBuilderContext.java
@@ -1,0 +1,8 @@
+package io.katharsis.repository.information;
+
+import io.katharsis.resource.information.ResourceInformationBuilder;
+
+public interface RepositoryInformationBuilderContext {
+
+	ResourceInformationBuilder getResourceInformationBuilder();
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/ResourceRepositoryInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/ResourceRepositoryInformation.java
@@ -1,0 +1,19 @@
+package io.katharsis.repository.information;
+
+import io.katharsis.resource.information.ResourceInformation;
+
+/**
+ * Holds information about the type of a resource repository.
+ */
+public interface ResourceRepositoryInformation extends RepositoryInformation {
+
+	/**
+	 * @return information about the resources hold in this repository
+	 */
+	ResourceInformation getResourceInformation();
+
+	/**
+	 * @return path from which the repository is accessible
+	 */
+	String getPath();
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultRelationshipRepositoryInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultRelationshipRepositoryInformationBuilder.java
@@ -1,15 +1,11 @@
 package io.katharsis.repository.information.internal;
 
-import java.util.Set;
-
 import io.katharsis.queryspec.QuerySpecRelationshipRepository;
 import io.katharsis.repository.RelationshipRepository;
 import io.katharsis.repository.annotations.JsonApiRelationshipRepository;
 import io.katharsis.repository.information.RepositoryInformation;
 import io.katharsis.repository.information.RepositoryInformationBuilder;
 import io.katharsis.repository.information.RepositoryInformationBuilderContext;
-import io.katharsis.resource.field.ResourceAttributesBridge;
-import io.katharsis.resource.field.ResourceField;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.utils.ClassUtils;
@@ -24,7 +20,7 @@ public class DefaultRelationshipRepositoryInformationBuilder implements Reposito
 		Class<? extends Object> repositoryClass = repository.getClass();
 		return RelationshipRepository.class.isAssignableFrom(repositoryClass)
 				|| QuerySpecRelationshipRepository.class.isAssignableFrom(repositoryClass)
-				|| ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class) != null;
+				|| ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class).isPresent();
 	}
 
 	@Override

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultRelationshipRepositoryInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultRelationshipRepositoryInformationBuilder.java
@@ -1,0 +1,89 @@
+package io.katharsis.repository.information.internal;
+
+import java.util.Set;
+
+import io.katharsis.queryspec.QuerySpecRelationshipRepository;
+import io.katharsis.repository.RelationshipRepository;
+import io.katharsis.repository.annotations.JsonApiRelationshipRepository;
+import io.katharsis.repository.information.RepositoryInformation;
+import io.katharsis.repository.information.RepositoryInformationBuilder;
+import io.katharsis.repository.information.RepositoryInformationBuilderContext;
+import io.katharsis.resource.field.ResourceAttributesBridge;
+import io.katharsis.resource.field.ResourceField;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.utils.ClassUtils;
+import io.katharsis.utils.PreconditionUtil;
+import io.katharsis.utils.java.Optional;
+import net.jodah.typetools.TypeResolver;
+
+public class DefaultRelationshipRepositoryInformationBuilder implements RepositoryInformationBuilder {
+
+	@Override
+	public boolean accept(Object repository) {
+		Class<? extends Object> repositoryClass = repository.getClass();
+		return RelationshipRepository.class.isAssignableFrom(repositoryClass)
+				|| QuerySpecRelationshipRepository.class.isAssignableFrom(repositoryClass)
+				|| ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class) != null;
+	}
+
+	@Override
+	public RepositoryInformation build(Object repository, RepositoryInformationBuilderContext context) {
+		Class<?> sourceResourceClass = getSourceResourceClass(repository);
+		Class<?> targetResourceClass = getTargetResourceClass(repository);
+
+		PreconditionUtil.assertNotNull("no sourceResourceClass", sourceResourceClass);
+		PreconditionUtil.assertNotNull("no targetResourceClass", targetResourceClass);
+
+		ResourceInformationBuilder resourceInformationBuilder = context.getResourceInformationBuilder();
+		PreconditionUtil.assertTrue("cannot get ResourceInformation for " + sourceResourceClass,
+				resourceInformationBuilder.accept(sourceResourceClass));
+		ResourceInformation sourceResourceInformation = resourceInformationBuilder.build(sourceResourceClass);
+
+		ResourceInformation targetResourceInformation;
+		if (resourceInformationBuilder.accept(targetResourceClass)) {
+			targetResourceInformation = resourceInformationBuilder.build(targetResourceClass);
+		}
+		else {
+			// support for polymorphism like relations to java.lang.Object
+			targetResourceInformation = new ResourceInformation(targetResourceClass, null, null, null, null);
+		}
+
+		return new RelationshipRepositoryInformationImpl(repository, sourceResourceInformation, targetResourceInformation);
+	}
+
+	protected Class<?> getSourceResourceClass(Object repository) {
+		Optional<JsonApiRelationshipRepository> annotation = ClassUtils.getAnnotation(repository.getClass(),
+				JsonApiRelationshipRepository.class);
+
+		if (annotation.isPresent()) {
+			return annotation.get().source();
+		}
+		else if (repository instanceof RelationshipRepository) {
+			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(RelationshipRepository.class, repository.getClass());
+			return typeArgs[0];
+		}
+		else {
+			QuerySpecRelationshipRepository<?, ?, ?, ?> querySpecRepo = (QuerySpecRelationshipRepository<?, ?, ?, ?>) repository;
+			return querySpecRepo.getSourceResourceClass();
+		}
+	}
+
+	protected Class<?> getTargetResourceClass(Object repository) {
+		Optional<JsonApiRelationshipRepository> annotation = ClassUtils.getAnnotation(repository.getClass(),
+				JsonApiRelationshipRepository.class);
+
+		if (annotation.isPresent()) {
+			return annotation.get().target();
+		}
+		else if (repository instanceof RelationshipRepository) {
+			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(RelationshipRepository.class, repository.getClass());
+			return typeArgs[2];
+		}
+		else {
+			QuerySpecRelationshipRepository<?, ?, ?, ?> querySpecRepo = (QuerySpecRelationshipRepository<?, ?, ?, ?>) repository;
+			return querySpecRepo.getTargetResourceClass();
+		}
+	}
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultResourceRepositoryInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultResourceRepositoryInformationBuilder.java
@@ -1,0 +1,61 @@
+package io.katharsis.repository.information.internal;
+
+import io.katharsis.queryspec.QuerySpecResourceRepository;
+import io.katharsis.repository.ResourceRepository;
+import io.katharsis.repository.annotations.JsonApiResourceRepository;
+import io.katharsis.repository.information.RepositoryInformation;
+import io.katharsis.repository.information.RepositoryInformationBuilder;
+import io.katharsis.repository.information.RepositoryInformationBuilderContext;
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.information.ResourceInformationBuilder;
+import io.katharsis.utils.ClassUtils;
+import io.katharsis.utils.PreconditionUtil;
+import io.katharsis.utils.java.Optional;
+import net.jodah.typetools.TypeResolver;
+
+public class DefaultResourceRepositoryInformationBuilder implements RepositoryInformationBuilder {
+
+	@Override
+	public boolean accept(Object repository) {
+		Class<? extends Object> repositoryClass = repository.getClass();
+		boolean legacyRepo = ResourceRepository.class.isAssignableFrom(repositoryClass);
+		boolean interfaceRepo = QuerySpecResourceRepository.class.isAssignableFrom(repositoryClass);
+		boolean anontationRepo = ClassUtils.getAnnotation(repositoryClass, JsonApiResourceRepository.class).isPresent();
+		return legacyRepo || interfaceRepo || anontationRepo;
+	}
+
+	@Override
+	public RepositoryInformation build(Object repository, RepositoryInformationBuilderContext context) {
+		Class<?> resourceClass = getResourceClass(repository);
+
+		ResourceInformationBuilder resourceInformationBuilder = context.getResourceInformationBuilder();
+		PreconditionUtil.assertTrue("cannot get ResourceInformation for " + resourceClass,
+				resourceInformationBuilder.accept(resourceClass));
+		ResourceInformation resourceInformation = resourceInformationBuilder.build(resourceClass);
+		String path = getPath(resourceInformation, repository);
+
+		return new ResourceRepositoryInformationImpl(repository, path, resourceInformation);
+	}
+
+	protected String getPath(ResourceInformation resourceInformation, Object repository) { // NOSONAR contract ok
+		return resourceInformation.getResourceType();
+	}
+
+	protected Class<?> getResourceClass(Object repository) {
+		Optional<JsonApiResourceRepository> annotation = ClassUtils.getAnnotation(repository.getClass(),
+				JsonApiResourceRepository.class);
+
+		if (annotation.isPresent()) {
+			return annotation.get().value();
+		}
+		else if (repository instanceof ResourceRepository) {
+			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(ResourceRepository.class, repository.getClass());
+			return typeArgs[0];
+		}
+		else {
+			QuerySpecResourceRepository<?, ?> querySpecRepo = (QuerySpecResourceRepository<?, ?>) repository;
+			return querySpecRepo.getResourceClass();
+		}
+	}
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RelationshipRepositoryInformationImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RelationshipRepositoryInformationImpl.java
@@ -1,0 +1,21 @@
+package io.katharsis.repository.information.internal;
+
+import io.katharsis.repository.information.RelationshipRepositoryInformation;
+import io.katharsis.resource.information.ResourceInformation;
+
+class RelationshipRepositoryInformationImpl extends RepositoryInformationImpl implements RelationshipRepositoryInformation {
+
+	private ResourceInformation sourceResourceInformation;
+
+	public RelationshipRepositoryInformationImpl(Object repository, ResourceInformation sourceResourceInformation,
+			ResourceInformation targetResourceInformation) {
+		super(repository, targetResourceInformation);
+		this.sourceResourceInformation = sourceResourceInformation;
+	}
+
+	@Override
+	public ResourceInformation getSourceResourceInformation() {
+		return sourceResourceInformation;
+	}
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RepositoryInformationImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RepositoryInformationImpl.java
@@ -1,0 +1,27 @@
+package io.katharsis.repository.information.internal;
+
+import io.katharsis.repository.information.RepositoryInformation;
+import io.katharsis.resource.information.ResourceInformation;
+
+abstract class RepositoryInformationImpl implements RepositoryInformation {
+
+	private Object repository;
+
+	private ResourceInformation resourceInformation;
+
+	public RepositoryInformationImpl(Object repository, ResourceInformation resourceInformation) {
+		super();
+		this.repository = repository;
+		this.resourceInformation = resourceInformation;
+	}
+
+	@Override
+	public Object getRepository() {
+		return repository;
+	}
+
+	@Override
+	public ResourceInformation getResourceInformation() {
+		return resourceInformation;
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/ResourceRepositoryInformationImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/ResourceRepositoryInformationImpl.java
@@ -1,0 +1,20 @@
+package io.katharsis.repository.information.internal;
+
+import io.katharsis.repository.information.ResourceRepositoryInformation;
+import io.katharsis.resource.information.ResourceInformation;
+
+class ResourceRepositoryInformationImpl extends RepositoryInformationImpl implements ResourceRepositoryInformation {
+
+	private String path;
+
+	public ResourceRepositoryInformationImpl(Object repository, String path, ResourceInformation resourceInformation) {
+		super(repository, resourceInformation);
+		this.path = path;
+	}
+
+	@Override
+	public String getPath() {
+		return path;
+	}
+
+}

--- a/katharsis-core/src/test/java/io/katharsis/internal/boot/KatharsisBootTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/internal/boot/KatharsisBootTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.dispatcher.RequestDispatcher;
 import io.katharsis.locator.SampleJsonServiceLocator;
+import io.katharsis.module.ServiceDiscovery;
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.queryspec.internal.QueryParamsAdapter;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
@@ -63,5 +64,10 @@ public class KatharsisBootTest {
 		Assert.assertNotNull(response);
 
 		Assert.assertNotNull(requestDispatcher);
+		
+		ServiceDiscovery serviceDiscovery = boot.getServiceDiscovery();
+		Assert.assertNotNull(serviceDiscovery);
+		
+		boot.setDefaultPageLimit(20L);
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
@@ -19,6 +19,7 @@ import io.katharsis.errorhandling.mapper.ExceptionMapperRegistryTest.SomeIllegal
 import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.queryspec.QuerySpecRelationshipRepository;
+import io.katharsis.queryspec.QuerySpecResourceRepository;
 import io.katharsis.resource.annotations.JsonApiId;
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
@@ -172,7 +173,7 @@ public class ModuleTest {
 
 		ResourceInformation testInfo = informationBuilder.build(TestResource.class);
 		Assert.assertEquals("id", testInfo.getIdField().getUnderlyingName());
-		Assert.assertEquals("testId", testInfo.getIdField().getJsonName());
+		Assert.assertEquals("id", testInfo.getIdField().getJsonName());
 	}
 
 	@Test
@@ -339,15 +340,44 @@ public class ModuleTest {
 
 		@Override
 		public Class<TestResource2> getSourceResourceClass() {
-			return null;
+			return TestResource2.class;
 		}
 
 		@Override
 		public Class<TestResource2> getTargetResourceClass() {
-			return null;
+			return TestResource2.class;
 		}
 	}
 
-	class TestRepository2 extends TestRepository {
+	class TestRepository2 implements QuerySpecResourceRepository<TestResource2, Integer>  {
+
+		@Override
+		public <S extends TestResource2> S save(S entity) {
+			return null;
+		}
+
+		@Override
+		public void delete(Integer id) {
+		}
+
+		@Override
+		public Class<TestResource2> getResourceClass() {
+			return TestResource2.class;
+		}
+
+		@Override
+		public TestResource2 findOne(Integer id, QuerySpec querySpec) {
+			return null;
+		}
+
+		@Override
+		public Iterable<TestResource2> findAll(QuerySpec querySpec) {
+			return null;
+		}
+
+		@Override
+		public Iterable<TestResource2> findAll(Iterable<Integer> ids, QuerySpec querySpec) {
+			return null;
+		}
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/ModuleTest.java
@@ -75,11 +75,16 @@ public class ModuleTest {
 	public void getModules() {
 		Assert.assertEquals(2, moduleRegistry.getModules().size());
 	}
-	
+
 	@Test
 	public void testGetServiceDiscovery() {
 		Assert.assertEquals(serviceDiscovery, moduleRegistry.getServiceDiscovery());
 		Assert.assertEquals(serviceDiscovery, testModule.context.getServiceDiscovery());
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void invalidRepository() {
+		moduleRegistry.getRepositoryInformationBuilder().build("no repository", null);
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -349,7 +354,7 @@ public class ModuleTest {
 		}
 	}
 
-	class TestRepository2 implements QuerySpecResourceRepository<TestResource2, Integer>  {
+	class TestRepository2 implements QuerySpecResourceRepository<TestResource2, Integer> {
 
 		@Override
 		public <S extends TestResource2> S save(S entity) {

--- a/katharsis-core/src/test/java/io/katharsis/module/SimpleModuleTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/SimpleModuleTest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.Module;
 
@@ -18,11 +19,9 @@ import io.katharsis.errorhandling.mapper.ExceptionMapperRegistryTest.IllegalStat
 import io.katharsis.errorhandling.mapper.JsonApiExceptionMapper;
 import io.katharsis.errorhandling.mapper.KatharsisExceptionMapper;
 import io.katharsis.module.Module.ModuleContext;
-import io.katharsis.module.SimpleModule.RelationshipRepositoryRegistration;
-import io.katharsis.queryspec.QuerySpecResourceRepository;
 import io.katharsis.repository.filter.RepositoryFilter;
+import io.katharsis.repository.information.RepositoryInformationBuilder;
 import io.katharsis.resource.information.ResourceInformationBuilder;
-import io.katharsis.resource.mock.models.Task;
 import io.katharsis.resource.registry.ResourceLookup;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.security.SecurityProvider;
@@ -54,8 +53,21 @@ public class SimpleModuleTest {
 		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numRepositories);
+	}
+
+	@Test
+	public void testRepositoryInformationBuilder() {
+		module.addRepositoryInformationBuilder(Mockito.mock(RepositoryInformationBuilder.class));
+		Assert.assertEquals(1, module.getRepositoryInformationBuilders().size());
+		module.setupModule(context);
+
+		Assert.assertEquals(1, context.numRepositoryInformationBuilds);
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numRepositories);
 	}
 
 	@Test
@@ -68,8 +80,7 @@ public class SimpleModuleTest {
 		Assert.assertEquals(1, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numRepositories);
 	}
 
 	@Test
@@ -82,8 +93,7 @@ public class SimpleModuleTest {
 		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(1, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numRepositories);
 	}
 
 	@Test
@@ -104,33 +114,14 @@ public class SimpleModuleTest {
 		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(1, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numRepositories);
 	}
 
 	@Test
-	public void testResourceRepository() {
-		module.addRepository(TestResource.class, new TestRepository());
-		Assert.assertEquals(1, module.getResourceRepositoryRegistrations().size());
-		module.setupModule(context);
-
-		Assert.assertEquals(0, context.numResourceInformationBuilds);
-		Assert.assertEquals(0, context.numResourceLookups);
-		Assert.assertEquals(0, context.numFilters);
-		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(1, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
-	}
-
-	@Test
-	public void testRelationshipRepository() {
+	public void testAddRepository() {
 		TestRelationshipRepository repository = new TestRelationshipRepository();
-		module.addRepository(TestResource.class, Task.class, repository);
-		Assert.assertEquals(1, module.getRelationshipRepositoryRegistrations().size());
-		RelationshipRepositoryRegistration reg = module.getRelationshipRepositoryRegistrations().get(0);
-		Assert.assertEquals(TestResource.class, reg.getSourceType());
-		Assert.assertEquals(repository, reg.getRepository());
-		Assert.assertEquals(Task.class, reg.getTargetType());
+		module.addRepository(repository);
+		Assert.assertEquals(1, module.getRepositories().size());
 
 		module.setupModule(context);
 
@@ -138,8 +129,7 @@ public class SimpleModuleTest {
 		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(1, context.numRelationshipRepositories);
+		Assert.assertEquals(1, context.numRepositories);
 		Assert.assertEquals(0, context.numExceptionMapperLookup);
 	}
 
@@ -153,8 +143,7 @@ public class SimpleModuleTest {
 		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numRepositories);
 		Assert.assertEquals(1, context.numExceptionMapperLookup);
 	}
 
@@ -169,8 +158,7 @@ public class SimpleModuleTest {
 		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
-		Assert.assertEquals(0, context.numResourceRepositoreis);
-		Assert.assertEquals(0, context.numRelationshipRepositories);
+		Assert.assertEquals(0, context.numRepositories);
 		Assert.assertEquals(1, context.numExceptionMapperLookup);
 	}
 
@@ -187,13 +175,13 @@ public class SimpleModuleTest {
 
 		private int numResourceInformationBuilds = 0;
 
+		private int numRepositoryInformationBuilds = 0;
+
 		private int numResourceLookups = 0;
 
 		private int numJacksonModules = 0;
 
-		private int numResourceRepositoreis = 0;
-
-		private int numRelationshipRepositories = 0;
+		private int numRepositories = 0;
 
 		private int numFilters = 0;
 
@@ -218,12 +206,12 @@ public class SimpleModuleTest {
 
 		@Override
 		public void addRepository(Class<?> resourceClass, Object repository) {
-			numResourceRepositoreis++;
+			numRepositories++;
 		}
 
 		@Override
 		public void addRepository(Class<?> sourceResourceClass, Class<?> targetResourceClass, Object repository) {
-			numRelationshipRepositories++;
+			numRepositories++;
 		}
 
 		@Override
@@ -264,6 +252,16 @@ public class SimpleModuleTest {
 		@Override
 		public void addRepositoryFilter(RepositoryFilter filter) {
 			numFilters++;
+		}
+
+		@Override
+		public void addRepositoryInformationBuilder(RepositoryInformationBuilder repositoryInformationBuilder) {
+			numRepositoryInformationBuilds++;
+		}
+
+		@Override
+		public void addRepository(Object repository) {
+			numRepositories++;
 		}
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/module/TestRepository.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestRepository.java
@@ -16,7 +16,7 @@ class TestRepository implements QuerySpecResourceRepository<TestResource, Intege
 
 	@Override
 	public Class<TestResource> getResourceClass() {
-		return null;
+		return TestResource.class;
 	}
 
 	@Override

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResource.java
@@ -1,7 +1,12 @@
 package io.katharsis.module;
 
+import io.katharsis.resource.annotations.JsonApiId;
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "test")
 public class TestResource {
 
+	@JsonApiId
 	private int id;
 
 	public int getId() {

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/query/AbstractJpaTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/query/AbstractJpaTest.java
@@ -34,7 +34,9 @@ import io.katharsis.jpa.model.TestNestedEmbeddable;
 import io.katharsis.jpa.query.criteria.JpaCriteriaQueryFactory;
 import io.katharsis.jpa.util.SpringTransactionRunner;
 import io.katharsis.jpa.util.TestConfig;
+import io.katharsis.module.CoreModule;
 import io.katharsis.module.ModuleRegistry;
+import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.registry.ConstantServiceUrlProvider;
 import io.katharsis.resource.registry.ResourceRegistry;
 
@@ -68,6 +70,7 @@ public abstract class AbstractJpaTest {
 		resourceRegistry = new ResourceRegistry(moduleRegistry, new ConstantServiceUrlProvider("http://localhost:1234"));
 		module = JpaModule.newServerModule(emFactory, em, transactionRunner);
 		setupModule(module);
+		moduleRegistry.addModule(new CoreModule(new ResourceFieldNameTransformer()));
 		moduleRegistry.addModule(module);
 		moduleRegistry.init(new ObjectMapper());
 


### PR DESCRIPTION
information extraction from a repository implemented the same way as done for resources (ResourceInfromationBuilder). In the context of #24 where actions need to be implemented this approach allows more flexibility like the jaxrs integration extending the repository information based on the JAXRS annotations (i.e. introduction of actions and configuration of repository url path).