### PR TITLE
#24 action support for JAX-RS

### DIFF
--- a/katharsis-client/pom.xml
+++ b/katharsis-client/pom.xml
@@ -91,11 +91,27 @@
 		</dependency>
 		
 		<dependency>
+			<groupId>org.glassfish.jersey.ext</groupId>
+			<artifactId>jersey-proxy-client</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		
+		<dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <optional>true</optional>
         </dependency>
-
+        
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
@@ -138,7 +154,18 @@
 			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
 
+        <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/katharsis-client/pom.xml
+++ b/katharsis-client/pom.xml
@@ -8,9 +8,7 @@
 		<relativePath>../katharsis-parent</relativePath>
 	</parent>
 
-	<groupId>io.katharsis</groupId>
 	<artifactId>katharsis-client</artifactId>
-    <version>2.8.2-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<name>katharsis-client</name>
@@ -94,24 +92,24 @@
 			<groupId>org.glassfish.jersey.ext</groupId>
 			<artifactId>jersey-proxy-client</artifactId>
 			<version>${jersey.version}</version>
+			<optional>true</optional>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
 			<version>${jersey.version}</version>
+			<optional>true</optional>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
 			<version>${jersey.version}</version>
+			<optional>true</optional>
+			<scope>compile</scope>
 		</dependency>
-		
-		<dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <optional>true</optional>
-        </dependency>
-        
+
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
@@ -124,7 +122,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
+				
+		<dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>

--- a/katharsis-client/src/main/java/io/katharsis/client/KatharsisClient.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/KatharsisClient.java
@@ -1,9 +1,19 @@
 package io.katharsis.client;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
+import org.glassfish.jersey.client.proxy.WebResourceFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -25,11 +35,18 @@ import io.katharsis.jackson.JsonApiModuleBuilder;
 import io.katharsis.module.CoreModule;
 import io.katharsis.module.Module;
 import io.katharsis.module.ModuleRegistry;
+import io.katharsis.queryspec.QuerySpecRelationshipRepository;
+import io.katharsis.queryspec.QuerySpecResourceRepository;
 import io.katharsis.repository.RelationshipRepository;
 import io.katharsis.repository.RepositoryInstanceBuilder;
+import io.katharsis.repository.information.RepositoryInformationBuilder;
+import io.katharsis.repository.information.RepositoryInformationBuilderContext;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
+import io.katharsis.repository.information.internal.ResourceRepositoryInformationImpl;
 import io.katharsis.resource.field.ResourceField;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.registry.ConstantServiceUrlProvider;
 import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.ResourceLookup;
@@ -43,6 +60,7 @@ import io.katharsis.resource.registry.repository.adapter.RelationshipRepositoryA
 import io.katharsis.resource.registry.repository.adapter.ResourceRepositoryAdapter;
 import io.katharsis.response.BaseResponseContext;
 import io.katharsis.utils.JsonApiUrlBuilder;
+import io.katharsis.utils.PreconditionUtil;
 import okhttp3.OkHttpClient;
 
 /**
@@ -69,6 +87,7 @@ public class KatharsisClient {
 	public KatharsisClient(String serviceUrl) {
 		this(new ConstantServiceUrlProvider(normalize(serviceUrl)));
 	}
+
 	public KatharsisClient(ServiceUrlProvider serviceUrlProvider) {
 		httpAdapter = new OkHttpAdapter();
 
@@ -97,8 +116,8 @@ public class KatharsisClient {
 		}
 
 		@Override
-		protected synchronized RegistryEntry<?> getEntry(Class<?> clazz, boolean allowNull) {
-			RegistryEntry<?> entry = super.getEntry(clazz, true);
+		protected synchronized <T> RegistryEntry<T> getEntry(Class<T> clazz, boolean allowNull) {
+			RegistryEntry<T> entry = super.getEntry(clazz, true);
 			if (entry == null) {
 				entry = allocateRepository(clazz, true);
 			}
@@ -194,6 +213,8 @@ public class KatharsisClient {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private <T, I extends Serializable> RegistryEntry<T> allocateRepository(Class<T> resourceClass, boolean allocateRelated) {
 
+		
+		
 		ResourceInformation resourceInformation = moduleRegistry.getResourceInformationBuilder().build(resourceClass);
 		final ResourceRepositoryStub<T, I> repositoryStub = new ResourceRepositoryStubImpl<>(this, resourceClass,
 				resourceInformation, urlBuilder);
@@ -206,9 +227,10 @@ public class KatharsisClient {
 				return repositoryStub;
 			}
 		};
+		ResourceRepositoryInformation repositoryInformation = new ResourceRepositoryInformationImpl(repositoryStub.getClass(), resourceInformation.getResourceType(), resourceInformation);
 		ResourceEntry<T, I> resourceEntry = new DirectResponseResourceEntry<>(repositoryInstanceBuilder);
 		List<ResponseRelationshipEntry<T, ?>> relationshipEntries = new ArrayList<>();
-		RegistryEntry<T> registryEntry = new RegistryEntry<>(resourceInformation, resourceEntry, relationshipEntries);
+		RegistryEntry<T> registryEntry = new RegistryEntry<>(repositoryInformation, resourceEntry, relationshipEntries);
 		resourceRegistry.addEntry(resourceClass, registryEntry);
 
 		allocateRepositoryRelations(registryEntry, allocateRelated, relationshipEntries);
@@ -253,6 +275,64 @@ public class KatharsisClient {
 				}
 			}
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public <R extends QuerySpecResourceRepository<?, ?>> R getResourceRepository(Class<R> repositoryInterfaceClass) {
+		RepositoryInformationBuilder informationBuilder = moduleRegistry.getRepositoryInformationBuilder();
+		PreconditionUtil.assertTrue("no a valid repository interface", informationBuilder.accept(repositoryInterfaceClass));
+		ResourceRepositoryInformation repositoryInformation = (ResourceRepositoryInformation) informationBuilder
+				.build(repositoryInterfaceClass, newRepositoryInformationBuilderContext());
+		Class<?> resourceClass = repositoryInformation.getResourceInformation().getResourceClass();
+		
+		String serviceUrl = resourceRegistry.getServiceUrl();
+		Client client = ClientBuilder.newClient();
+		WebTarget target = client.target(serviceUrl);
+		final Object jaxrsStub = WebResourceFactory.newResource(repositoryInterfaceClass, target);
+		
+		final QuerySpecResourceRepositoryStub<?, Serializable> repositoryStub = getQuerySpecRepository(resourceClass);
+		
+		ClassLoader classLoader = repositoryInterfaceClass.getClassLoader();
+		final Set<String> repositoryMethods = getMethodNames(QuerySpecResourceRepositoryStub.class);
+		InvocationHandler invocationHandler = new InvocationHandler() {
+
+			@Override
+			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+				if (repositoryMethods.contains(method.getName())) {
+					// execute repository method
+					return method.invoke(repositoryStub, args);
+				}
+				else {
+					// execute action
+					return method.invoke(jaxrsStub, args);
+				}
+			}
+		};
+		return (R) Proxy.newProxyInstance(classLoader, new Class[] { repositoryInterfaceClass, QuerySpecResourceRepositoryStub.class }, invocationHandler);
+	}
+
+	private static Set<String> getMethodNames(Class<?> clazz) {
+		Set<String> repositoryMethods = new HashSet<>();
+		Method[] repositoryMethodObjects = clazz.getMethods();
+		for (Method repositoryMethodObject : repositoryMethodObjects) {
+			repositoryMethods.add(repositoryMethodObject.getName());
+		}
+		return repositoryMethods;
+	}
+
+	private RepositoryInformationBuilderContext newRepositoryInformationBuilderContext() {
+		return new RepositoryInformationBuilderContext() {
+
+			@Override
+			public ResourceInformationBuilder getResourceInformationBuilder() {
+				return moduleRegistry.getResourceInformationBuilder();
+			}
+		};
+	}
+
+	public <R extends QuerySpecRelationshipRepository<?, ?, ?, ?>> R getRelationshipRepository(
+			Class<R> repositoryInterfaceClass) {
+		return null;
 	}
 
 	/**

--- a/katharsis-client/src/main/java/io/katharsis/client/action/ActionStubFactory.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/action/ActionStubFactory.java
@@ -1,0 +1,12 @@
+package io.katharsis.client.action;
+
+/**
+ * Used to create stubs for repository interface having action methods. Stub is only used
+ * to invoke the action, not the jsonapi methods.
+ */
+public interface ActionStubFactory {
+
+	void init(ActionStubFactoryContext context);
+
+	<T> T createStub(Class<T> interfaceClass);
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/action/ActionStubFactoryContext.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/action/ActionStubFactoryContext.java
@@ -1,0 +1,12 @@
+package io.katharsis.client.action;
+
+import io.katharsis.client.http.HttpAdapter;
+import io.katharsis.resource.registry.ServiceUrlProvider;
+
+public interface ActionStubFactoryContext {
+
+	ServiceUrlProvider getServiceUrlProvider();
+
+	HttpAdapter getHttpAdapter();
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/action/JerseyActionStubFactory.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/action/JerseyActionStubFactory.java
@@ -1,0 +1,44 @@
+package io.katharsis.client.action;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
+import org.glassfish.jersey.client.proxy.WebResourceFactory;
+
+import io.katharsis.resource.registry.ServiceUrlProvider;
+
+public class JerseyActionStubFactory implements ActionStubFactory {
+
+	private Client client;
+
+	private ActionStubFactoryContext context;
+
+	private JerseyActionStubFactory() {
+	}
+
+	public static JerseyActionStubFactory newInstance() {
+		return newInstance(ClientBuilder.newClient());
+	}
+
+	public static JerseyActionStubFactory newInstance(Client client) {
+		JerseyActionStubFactory factory = new JerseyActionStubFactory();
+		factory.client = client;
+		return factory;
+	}
+
+	@Override
+	public void init(ActionStubFactoryContext context) {
+		this.context = context;
+	}
+
+	@Override
+	public <T> T createStub(Class<T> interfaceClass) {
+		ServiceUrlProvider serviceUrlProvider = context.getServiceUrlProvider();
+		String serviceUrl = serviceUrlProvider.getUrl();
+
+		WebTarget target = client.target(serviceUrl);
+		return WebResourceFactory.newResource(interfaceClass, target);
+	}
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/ClientStubInvocationHandler.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/ClientStubInvocationHandler.java
@@ -1,0 +1,50 @@
+package io.katharsis.client.internal;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.katharsis.client.KatharsisClient;
+import io.katharsis.client.QuerySpecResourceRepositoryStub;
+import io.katharsis.client.action.ActionStubFactory;
+
+public class ClientStubInvocationHandler implements InvocationHandler {
+
+	private static final Set<String> REPOSITORY_METHODS = getMethodNames(QuerySpecResourceRepositoryStub.class);
+
+	private QuerySpecResourceRepositoryStub<?, Serializable> repositoryStub;
+
+	private Object actionStub;
+
+	public ClientStubInvocationHandler(QuerySpecResourceRepositoryStub<?, Serializable> repositoryStub, Object actionStub) {
+		this.repositoryStub = repositoryStub;
+		this.actionStub = actionStub;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		if (method.getDeclaringClass() == Object.class || REPOSITORY_METHODS.contains(method.getName())) {
+			// execute repository method
+			return method.invoke(repositoryStub, args);
+		}
+		else if (actionStub != null) {
+			// execute action
+			return method.invoke(actionStub, args);
+		}
+		else {
+			throw new IllegalStateException("cannot execute actions, no " + ActionStubFactory.class.getSimpleName() + " set with "
+					+ KatharsisClient.class.getName());
+		}
+	}
+
+	private static Set<String> getMethodNames(Class<?> clazz) {
+		Set<String> repositoryMethods = new HashSet<>();
+		Method[] repositoryMethodObjects = clazz.getMethods();
+		for (Method repositoryMethodObject : repositoryMethodObjects) {
+			repositoryMethods.add(repositoryMethodObject.getName());
+		}
+		return repositoryMethods;
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
@@ -12,7 +12,9 @@ import org.junit.Before;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.katharsis.client.action.JerseyActionStubFactory;
 import io.katharsis.client.mock.repository.ProjectRepository;
+import io.katharsis.client.mock.repository.ScheduleRepositoryImpl;
 import io.katharsis.client.mock.repository.TaskRepository;
 import io.katharsis.client.mock.repository.TaskToProjectRepository;
 import io.katharsis.locator.SampleJsonServiceLocator;
@@ -34,10 +36,12 @@ public abstract class AbstractClientTest extends JerseyTest {
 	public void setup() {
 		client = new KatharsisClient(getBaseUri().toString());
 		client.addModule(new TestModule());
+		client.setActionStubFactory(JerseyActionStubFactory.newInstance());
 
 		TaskRepository.clear();
 		ProjectRepository.clear();
 		TaskToProjectRepository.clear();
+		ScheduleRepositoryImpl.clear();
 	}
 
 	@Override

--- a/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
@@ -53,8 +53,12 @@ public abstract class AbstractClientTest extends JerseyTest {
 		return testApplication;
 	}
 
+	protected void setupFeature(KatharsisTestFeature feature) {
+		// nothing to do
+	}
+	
 	@ApplicationPath("/")
-	public static class TestApplication extends ResourceConfig {
+	public class TestApplication extends ResourceConfig {
 
 		private KatharsisTestFeature feature;
 
@@ -72,9 +76,12 @@ public abstract class AbstractClientTest extends JerseyTest {
 			}
 
 			feature.addModule(new TestModule());
+			
+			setupFeature(feature);
 
 			register(feature);
 		}
+
 
 		public KatharsisFeature getFeature() {
 			return feature;

--- a/katharsis-client/src/test/java/io/katharsis/client/ActionTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ActionTest.java
@@ -1,0 +1,47 @@
+package io.katharsis.client;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.client.mock.repository.ScheduleRepository;
+import io.katharsis.queryspec.QuerySpec;
+
+public class ActionTest extends AbstractClientTest {
+
+	protected ScheduleRepository scheduleRepo;
+
+	@Before
+	public void setup() {
+		super.setup();
+		scheduleRepo = client.getResourceRepository(ScheduleRepository.class);
+	}
+
+	@Override
+	protected TestApplication configure() {
+		return new TestApplication(true);
+	}
+
+	@Test
+	public void testCrudFind() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("schedule");
+		scheduleRepo.save(schedule);
+
+		Iterable<Schedule> schedules = scheduleRepo.findAll(new QuerySpec(Schedule.class));
+		schedule = schedules.iterator().next();
+		Assert.assertEquals("schedule", schedule.getName());
+		
+		scheduleRepo.delete(schedule.getId());
+		schedules = scheduleRepo.findAll(new QuerySpec(Schedule.class));
+		Assert.assertFalse(schedules.iterator().hasNext());
+	}
+	
+	@Test
+	public void testInvokeAction() {
+		String result = scheduleRepo.repositoryAction("hello");
+		Assert.assertEquals("repository action: hello", result);
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/ActionTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ActionTest.java
@@ -3,21 +3,45 @@ package io.katharsis.client;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import io.katharsis.client.mock.models.Schedule;
 import io.katharsis.client.mock.repository.ScheduleRepository;
+import io.katharsis.dispatcher.filter.Filter;
+import io.katharsis.dispatcher.filter.FilterChain;
+import io.katharsis.dispatcher.filter.FilterRequestContext;
+import io.katharsis.module.SimpleModule;
 import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.request.path.ActionPath;
+import io.katharsis.response.BaseResponseContext;
 
 public class ActionTest extends AbstractClientTest {
 
 	protected ScheduleRepository scheduleRepo;
+
+	private Filter filter;
 
 	@Before
 	public void setup() {
 		SLF4JBridgeHandler.install();
 		super.setup();
 		scheduleRepo = client.getResourceRepository(ScheduleRepository.class);
+	}
+
+	@Override
+	protected void setupFeature(KatharsisTestFeature feature) {
+		filter = Mockito.spy(new Filter() {
+
+			@Override
+			public BaseResponseContext filter(FilterRequestContext filterRequestContext, FilterChain chain) {
+				return chain.doFilter(filterRequestContext);
+			}
+		});
+		SimpleModule testModule = new SimpleModule("testFilter");
+		testModule.addFilter(filter);
+		feature.addModule(testModule);
 	}
 
 	@Override
@@ -45,16 +69,30 @@ public class ActionTest extends AbstractClientTest {
 	public void testInvokeRepositoryAction() {
 		String result = scheduleRepo.repositoryAction("hello");
 		Assert.assertEquals("repository action: hello", result);
+
+		// check filters
+		ArgumentCaptor<FilterRequestContext> contexts = ArgumentCaptor.forClass(FilterRequestContext.class);
+		Mockito.verify(filter, Mockito.times(1)).filter(contexts.capture(), Mockito.any(FilterChain.class));
+		FilterRequestContext actionContext = contexts.getAllValues().get(0);
+		Assert.assertEquals("GET", actionContext.getMethod());
+		Assert.assertTrue(actionContext.getJsonPath() instanceof ActionPath);
 	}
-	
+
 	@Test
 	public void testInvokeResourceAction() {
 		Schedule schedule = new Schedule();
 		schedule.setId(1L);
 		schedule.setName("scheduleName");
 		scheduleRepo.save(schedule);
-		
+
 		String result = scheduleRepo.resourceAction(1, "hello");
 		Assert.assertEquals("resource action: hello@scheduleName", result);
+
+		// check filters
+		ArgumentCaptor<FilterRequestContext> contexts = ArgumentCaptor.forClass(FilterRequestContext.class);
+		Mockito.verify(filter, Mockito.times(2)).filter(contexts.capture(), Mockito.any(FilterChain.class));
+		FilterRequestContext actionContext = contexts.getAllValues().get(1);
+		Assert.assertEquals("GET", actionContext.getMethod());
+		Assert.assertTrue(actionContext.getJsonPath() instanceof ActionPath);
 	}
 }

--- a/katharsis-client/src/test/java/io/katharsis/client/ActionTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ActionTest.java
@@ -3,6 +3,7 @@ package io.katharsis.client;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import io.katharsis.client.mock.models.Schedule;
 import io.katharsis.client.mock.repository.ScheduleRepository;
@@ -14,6 +15,7 @@ public class ActionTest extends AbstractClientTest {
 
 	@Before
 	public void setup() {
+		SLF4JBridgeHandler.install();
 		super.setup();
 		scheduleRepo = client.getResourceRepository(ScheduleRepository.class);
 	}
@@ -33,15 +35,26 @@ public class ActionTest extends AbstractClientTest {
 		Iterable<Schedule> schedules = scheduleRepo.findAll(new QuerySpec(Schedule.class));
 		schedule = schedules.iterator().next();
 		Assert.assertEquals("schedule", schedule.getName());
-		
+
 		scheduleRepo.delete(schedule.getId());
 		schedules = scheduleRepo.findAll(new QuerySpec(Schedule.class));
 		Assert.assertFalse(schedules.iterator().hasNext());
 	}
-	
+
 	@Test
-	public void testInvokeAction() {
+	public void testInvokeRepositoryAction() {
 		String result = scheduleRepo.repositoryAction("hello");
 		Assert.assertEquals("repository action: hello", result);
+	}
+	
+	@Test
+	public void testInvokeResourceAction() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("scheduleName");
+		scheduleRepo.save(schedule);
+		
+		String result = scheduleRepo.resourceAction(1, "hello");
+		Assert.assertEquals("resource action: hello@scheduleName", result);
 	}
 }

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/models/Schedule.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/models/Schedule.java
@@ -1,0 +1,30 @@
+package io.katharsis.client.mock.models;
+
+import io.katharsis.resource.annotations.JsonApiId;
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "schedules")
+public class Schedule {
+
+	@JsonApiId
+	private Long id;
+
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public Schedule setId(Long id) {
+		this.id = id;
+		return this;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepository.java
@@ -1,0 +1,22 @@
+package io.katharsis.client.mock.repository;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.queryspec.QuerySpecResourceRepository;
+
+@Path("schedules")
+public interface ScheduleRepository extends QuerySpecResourceRepository<Schedule, Long> {
+
+	@GET
+	@Path("repositoryAction")
+	public String repositoryAction(@QueryParam(value = "msg") String msg);
+
+	@GET
+	@Path("{id}/resourceAction")
+	public Response resourceAction(@PathParam("param") String msg);
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepository.java
@@ -4,7 +4,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
 
 import io.katharsis.client.mock.models.Schedule;
 import io.katharsis.queryspec.QuerySpecResourceRepository;
@@ -18,5 +17,5 @@ public interface ScheduleRepository extends QuerySpecResourceRepository<Schedule
 
 	@GET
 	@Path("{id}/resourceAction")
-	public Response resourceAction(@PathParam("param") String msg);
+	public String resourceAction(@PathParam("id") long id, @QueryParam(value = "msg") String msg);
 }

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
@@ -1,0 +1,79 @@
+package io.katharsis.client.mock.repository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.queryspec.QuerySpecLinksRepository;
+import io.katharsis.queryspec.QuerySpecMetaRepository;
+import io.katharsis.queryspec.QuerySpecResourceRepositoryBase;
+import io.katharsis.response.LinksInformation;
+import io.katharsis.response.MetaInformation;
+
+public class ScheduleRepositoryImpl extends QuerySpecResourceRepositoryBase<Schedule, Long>
+		implements ScheduleRepository, QuerySpecMetaRepository<Schedule>, QuerySpecLinksRepository<Schedule> {
+
+	private static Map<Long, Schedule> schedules = new HashMap<>();
+
+	public ScheduleRepositoryImpl() {
+		super(Schedule.class);
+	}
+
+	@Override
+	@GET
+	@Path("repositoryAction")
+	public String repositoryAction(@QueryParam(value = "msg") String msg) {
+		return "repository action: " + msg;
+	}
+
+	@Override
+	@GET
+	@Path("{id}/resourceAction")
+	public Response resourceAction(@PathParam("id") String msg) {
+		String result = "Restful example : " + msg;
+		return Response.status(200).entity(result).build();
+	}
+
+	@Override
+	public Iterable<Schedule> findAll(QuerySpec querySpec) {
+		return querySpec.apply(schedules.values());
+	}
+
+	@Override
+	public <S extends Schedule> S save(S entity) {
+		schedules.put(entity.getId(), entity);
+		return null;
+	}
+
+	@Override
+	public void delete(Long id) {
+		schedules.remove(id);
+	}
+
+	@Override
+	public LinksInformation getLinksInformation(Iterable<Schedule> resources, QuerySpec queryParams) {
+		return new LinksInformation() {
+
+			public String name = "value";
+		};
+	}
+
+	@Override
+	public MetaInformation getMetaInformation(Iterable<Schedule> resources, QuerySpec queryParams) {
+		return new MetaInformation() {
+
+			public String name = "value";
+		};
+	}
+
+	public static void clear() {
+		schedules.clear();
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
@@ -27,18 +27,14 @@ public class ScheduleRepositoryImpl extends QuerySpecResourceRepositoryBase<Sche
 	}
 
 	@Override
-	@GET
-	@Path("repositoryAction")
-	public String repositoryAction(@QueryParam(value = "msg") String msg) {
+	public String repositoryAction(String msg) {
 		return "repository action: " + msg;
 	}
 
 	@Override
-	@GET
-	@Path("{id}/resourceAction")
-	public Response resourceAction(@PathParam("id") String msg) {
-		String result = "Restful example : " + msg;
-		return Response.status(200).entity(result).build();
+	public String resourceAction(long id, String msg) {
+		Schedule schedule = findOne(id, new QuerySpec(Schedule.class));
+		return "resource action: " + msg + "@" + schedule.getName();
 	}
 
 	@Override

--- a/katharsis-client/src/test/resources/logback.xml
+++ b/katharsis-client/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<charset>UTF-8</charset>
+			<pattern>%d{HH:mm:ss,SSS} %-5.5p [%15.15t] [%30.30c] %X{indent}%m%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="ERROR">
+		<appender-ref ref="CONSOLE" />
+	</root>
+</configuration>
+

--- a/katharsis-client/src/test/resources/logback.xml
+++ b/katharsis-client/src/test/resources/logback.xml
@@ -9,7 +9,7 @@
 		</encoder>
 	</appender>
 
-	<root level="ERROR">
+	<root level="WARN">
 		<appender-ref ref="CONSOLE" />
 	</root>
 </configuration>

--- a/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
+++ b/katharsis-core/src/main/java/io/katharsis/dispatcher/RequestDispatcher.java
@@ -135,6 +135,33 @@ public class RequestDispatcher {
 			}
 		}
 	}
+	
+	class ActionFilterChain implements FilterChain {
+
+		protected int filterIndex = 0;
+
+
+		@Override
+		public BaseResponseContext doFilter(FilterRequestContext context) {
+			List<Filter> filters = moduleRegistry.getFilters();
+			if (filterIndex == filters.size()) {
+				return null;
+			}
+			else {
+				Filter filter = filters.get(filterIndex);
+				filterIndex++;
+				return filter.filter(context, this);
+			}
+		}
+	}
+	
+	public void dispatchAction(JsonPath jsonPath, String method, Map<String, Set<String>> parameters) {
+		// preliminary implementation, more to come in the future
+		ActionFilterChain chain = new ActionFilterChain();
+		
+		DefaultFilterRequestContext context = new DefaultFilterRequestContext(jsonPath, null, null, null, method);
+		chain.doFilter(context);		
+	}
 
 	class DefaultFilterRequestContext implements FilterRequestContext {
 

--- a/katharsis-core/src/main/java/io/katharsis/internal/boot/KatharsisBoot.java
+++ b/katharsis-core/src/main/java/io/katharsis/internal/boot/KatharsisBoot.java
@@ -189,8 +189,10 @@ public class KatharsisBoot {
 
 	private void setupComponents() {
 		ServiceDiscovery serviceDiscovery = moduleRegistry.getServiceDiscovery();
-		SimpleModule module = new SimpleModule("discovery");
 
+		// not that the provided default implementation here are added last and as a consequence,
+		// can be overriden by other modules, like the JaxrsResourceRepositoryInformationBuilder.
+		SimpleModule module = new SimpleModule("discovery");
 		module.addRepositoryInformationBuilder(new DefaultResourceRepositoryInformationBuilder());
 		module.addRepositoryInformationBuilder(new DefaultRelationshipRepositoryInformationBuilder());
 		module.addResourceInformationBuilder(new AnnotationResourceInformationBuilder(resourceFieldNameTransformer));

--- a/katharsis-core/src/main/java/io/katharsis/internal/boot/KatharsisBoot.java
+++ b/katharsis-core/src/main/java/io/katharsis/internal/boot/KatharsisBoot.java
@@ -315,4 +315,8 @@ public class KatharsisBoot {
 	public void setDefaultPageLimit(Long defaultPageLimit) {
 		((DefaultQuerySpecDeserializer) this.querySpecDeserializer).setDefaultLimit(defaultPageLimit);
 	}
+
+	public ModuleRegistry getModuleRegistry() {
+		return moduleRegistry;
+	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryAction.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryAction.java
@@ -1,0 +1,7 @@
+package io.katharsis.repository.information;
+
+
+public interface RepositoryAction {
+
+	public String getName();
+}

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformation.java
@@ -7,7 +7,7 @@ import io.katharsis.resource.information.ResourceInformation;
  */
 public interface RepositoryInformation {
 
-	Object getRepository();
+	Class<?> getRepositoryClass();
 
 	/**
 	 * @return information about the resources hold in this repository

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/RepositoryInformationBuilder.java
@@ -1,20 +1,34 @@
 package io.katharsis.repository.information;
 
 /**
- * A builder which creates RepositoryInformation instances of a specific class.
+ * A builder which creates RepositoryInformation instances from repositories or their classes.
+ * Building information from the actual object class is a bit more flexible as it allows
+ * the reuse of the same class for multiple, different repositories classes. 
  */
 public interface RepositoryInformationBuilder {
 
 	/**
-	 * @param repositoryClass repository class
+	 * @param repositoryClass class
+	 * @return true if this builder can process the provided repository class
+	 */
+	boolean accept(Class<?> repositoryClass);
+
+	/**
+	 * @param repository repository ibhect
 	 * @return true if this builder can process the provided repository class
 	 */
 	boolean accept(Object repository);
 
 	/**
-	 * @param repositoryClass resource class
+	 * @param repository object
 	 * @return RepositoryInformation for the provided repository class.
 	 */
 	RepositoryInformation build(Object repository, RepositoryInformationBuilderContext context);
+
+	/**
+	 * @param repositoryClass repository class
+	 * @return RepositoryInformation for the provided repository class.
+	 */
+	RepositoryInformation build(Class<?> repositoryClass, RepositoryInformationBuilderContext context);
 
 }

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/ResourceRepositoryInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/ResourceRepositoryInformation.java
@@ -1,5 +1,7 @@
 package io.katharsis.repository.information;
 
+import java.util.Map;
+
 import io.katharsis.resource.information.ResourceInformation;
 
 /**
@@ -16,4 +18,7 @@ public interface ResourceRepositoryInformation extends RepositoryInformation {
 	 * @return path from which the repository is accessible
 	 */
 	String getPath();
+	
+
+	Map<String, RepositoryAction> getActions();
 }

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultRelationshipRepositoryInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/DefaultRelationshipRepositoryInformationBuilder.java
@@ -40,8 +40,8 @@ public class DefaultRelationshipRepositoryInformationBuilder implements Reposito
 
 	private RepositoryInformation buildInformation(Object repository, Class<? extends Object> repositoryClass,
 			RepositoryInformationBuilderContext context) {
-		Class<?> sourceResourceClass = getSourceResourceClass(repository, repository.getClass());
-		Class<?> targetResourceClass = getTargetResourceClass(repository, repository.getClass());
+		Class<?> sourceResourceClass = getSourceResourceClass(repository, repositoryClass);
+		Class<?> targetResourceClass = getTargetResourceClass(repository, repositoryClass);
 
 		PreconditionUtil.assertNotNull("no sourceResourceClass", sourceResourceClass);
 		PreconditionUtil.assertNotNull("no targetResourceClass", targetResourceClass);

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RelationshipRepositoryInformationImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RelationshipRepositoryInformationImpl.java
@@ -1,15 +1,18 @@
 package io.katharsis.repository.information.internal;
 
+import java.util.Map;
+
 import io.katharsis.repository.information.RelationshipRepositoryInformation;
+import io.katharsis.repository.information.RepositoryAction;
 import io.katharsis.resource.information.ResourceInformation;
 
 class RelationshipRepositoryInformationImpl extends RepositoryInformationImpl implements RelationshipRepositoryInformation {
 
 	private ResourceInformation sourceResourceInformation;
 
-	public RelationshipRepositoryInformationImpl(Object repository, ResourceInformation sourceResourceInformation,
+	public RelationshipRepositoryInformationImpl(Class<?> repositoryClass,ResourceInformation sourceResourceInformation,
 			ResourceInformation targetResourceInformation) {
-		super(repository, targetResourceInformation);
+		super(repositoryClass, targetResourceInformation);
 		this.sourceResourceInformation = sourceResourceInformation;
 	}
 
@@ -17,5 +20,4 @@ class RelationshipRepositoryInformationImpl extends RepositoryInformationImpl im
 	public ResourceInformation getSourceResourceInformation() {
 		return sourceResourceInformation;
 	}
-
 }

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RepositoryInformationImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/RepositoryInformationImpl.java
@@ -5,19 +5,19 @@ import io.katharsis.resource.information.ResourceInformation;
 
 abstract class RepositoryInformationImpl implements RepositoryInformation {
 
-	private Object repository;
-
 	private ResourceInformation resourceInformation;
 
-	public RepositoryInformationImpl(Object repository, ResourceInformation resourceInformation) {
+	private Class<?> repositoryClass;
+
+	public RepositoryInformationImpl(Class<?> repositoryClass, ResourceInformation resourceInformation) {
 		super();
-		this.repository = repository;
+		this.repositoryClass = repositoryClass;
 		this.resourceInformation = resourceInformation;
 	}
 
 	@Override
-	public Object getRepository() {
-		return repository;
+	public Class<?> getRepositoryClass() {
+		return repositoryClass;
 	}
 
 	@Override

--- a/katharsis-core/src/main/java/io/katharsis/repository/information/internal/ResourceRepositoryInformationImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/repository/information/internal/ResourceRepositoryInformationImpl.java
@@ -1,15 +1,26 @@
 package io.katharsis.repository.information.internal;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import io.katharsis.repository.information.RepositoryAction;
 import io.katharsis.repository.information.ResourceRepositoryInformation;
 import io.katharsis.resource.information.ResourceInformation;
 
-class ResourceRepositoryInformationImpl extends RepositoryInformationImpl implements ResourceRepositoryInformation {
+public class ResourceRepositoryInformationImpl extends RepositoryInformationImpl implements ResourceRepositoryInformation {
 
 	private String path;
+	private Map<String, RepositoryAction> actions;
 
-	public ResourceRepositoryInformationImpl(Object repository, String path, ResourceInformation resourceInformation) {
-		super(repository, resourceInformation);
+	public ResourceRepositoryInformationImpl(Class<?> repositoryClass, String path, ResourceInformation resourceInformation){
+		this(repositoryClass, path, resourceInformation, new HashMap<String, RepositoryAction>());
+	}
+	
+	public ResourceRepositoryInformationImpl(Class<?> repositoryClass, String path,
+			ResourceInformation resourceInformation, Map<String, RepositoryAction> actions) {
+		super(repositoryClass, resourceInformation);
 		this.path = path;
+		this.actions = actions;
 	}
 
 	@Override
@@ -17,4 +28,8 @@ class ResourceRepositoryInformationImpl extends RepositoryInformationImpl implem
 		return path;
 	}
 
+	@Override
+	public Map<String, RepositoryAction> getActions() {
+		return actions;
+	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/request/path/ActionPath.java
+++ b/katharsis-core/src/main/java/io/katharsis/request/path/ActionPath.java
@@ -1,0 +1,24 @@
+package io.katharsis.request.path;
+
+/**
+ * Represents a part of a path which relate a field of a resource e.g. for /resource/1/field the first element will be
+ * an object of ResourcePath type and the second will be of FieldPath type.
+ *
+ * FieldPath can refer only to relationship fields.
+ */
+public class ActionPath extends JsonPath {
+
+    public ActionPath(String elementName) {
+        super(elementName);
+    }
+
+    @Override
+    public boolean isCollection() {
+    	throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getResourceName() {
+    	throw new UnsupportedOperationException();
+    }
+}

--- a/katharsis-core/src/main/java/io/katharsis/request/path/PathBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/request/path/PathBuilder.java
@@ -41,9 +41,9 @@ public class PathBuilder {
      * @deprecated use {@link #build(Path)}
      */
     public JsonPath buildPath(String path) {
-    	Optional<JsonPath> optional = build(path);
-    	if(optional.isPresent()){
-    		return optional.get();
+    	JsonPath jsonPath = build(path);
+    	if(jsonPath != null){
+    		return jsonPath;
     	}else{
     		throw new ResourceNotFoundException(path);
     	}
@@ -56,7 +56,7 @@ public class PathBuilder {
      * @param path Path to be parsed
      * @return doubly-linked list which represents path given at the input
      */
-    public Optional<JsonPath> build(String path) {
+    public JsonPath build(String path) {
         String[] strings = splitPath(path);
         if (strings.length == 0 || (strings.length == 1 && "".equals(strings[0]))) {
         	throw new ResourceException("Path is empty");
@@ -110,7 +110,7 @@ public class PathBuilder {
             } else if (entry != null && !relationshipMark) {
                 currentJsonPath = new ResourcePath(elementName);
             } else {
-            	return Optional.empty();
+            	return null;
             }
 
             if (pathIds != null) {
@@ -129,7 +129,7 @@ public class PathBuilder {
             previousJsonPath = currentJsonPath;
         }
 
-        return Optional.of(currentJsonPath);
+        return currentJsonPath;
     }
 
     private JsonPath getNonResourcePath(JsonPath previousJsonPath, String elementName, boolean relationshipMark) {

--- a/katharsis-core/src/main/java/io/katharsis/request/path/PathBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/request/path/PathBuilder.java
@@ -1,8 +1,5 @@
 package io.katharsis.request.path;
 
-import io.katharsis.repository.information.RepositoryAction;
-import io.katharsis.repository.information.RepositoryInformation;
-import io.katharsis.repository.information.ResourceRepositoryInformation;
 import io.katharsis.resource.exception.ResourceException;
 import io.katharsis.resource.exception.ResourceFieldNotFoundException;
 import io.katharsis.resource.exception.ResourceNotFoundException;
@@ -16,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceAction.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceAction.java
@@ -1,0 +1,7 @@
+package io.katharsis.resource.information;
+
+import io.katharsis.repository.information.RepositoryAction;
+
+public interface ResourceAction extends RepositoryAction {
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformation.java
@@ -1,5 +1,7 @@
 package io.katharsis.resource.information;
 
+import io.katharsis.repository.information.RepositoryAction;
+import io.katharsis.repository.information.RepositoryInformation;
 import io.katharsis.resource.field.ResourceAttributesBridge;
 import io.katharsis.resource.field.ResourceField;
 import io.katharsis.utils.PropertyUtils;
@@ -7,6 +9,7 @@ import io.katharsis.utils.parser.TypeParser;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -51,7 +54,7 @@ public class ResourceInformation {
      * Creates a new instance of the given resource.
      */
 	private ResourceInstanceBuilder<?> instanceBuilder;
-
+	
 	public ResourceInformation(Class<?> resourceClass, String resourceType, ResourceField idField, ResourceAttributesBridge attributeFields,
             Set<ResourceField> relationshipFields) {
 		this(resourceClass, resourceType, null, idField, attributeFields, relationshipFields, null, null);
@@ -197,4 +200,5 @@ public class ResourceInformation {
 	public Object getId(Object resource) {
 		return PropertyUtils.getProperty(resource, idField.getUnderlyingName());
 	}
+
 }

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/RegistryEntry.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/RegistryEntry.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import io.katharsis.module.ModuleRegistry;
 import io.katharsis.repository.RepositoryMethodParameterProvider;
 import io.katharsis.repository.exception.RelationshipRepositoryNotFoundException;
+import io.katharsis.repository.information.RepositoryInformation;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.registry.repository.AnnotatedRelationshipEntryBuilder;
 import io.katharsis.resource.registry.repository.AnnotatedResourceEntry;
@@ -35,16 +37,18 @@ public class RegistryEntry<T> {
     private RegistryEntry parentRegistryEntry = null;
     
 	private ModuleRegistry moduleRegistry;
+	private ResourceRepositoryInformation repositoryInformation;
 
-    public RegistryEntry(ResourceInformation resourceInformation,
+    public RegistryEntry(ResourceRepositoryInformation repositoryInformation,
                          @SuppressWarnings("SameParameterValue") ResourceEntry<T, ?> resourceEntry) {
-        this(resourceInformation, resourceEntry, new LinkedList<ResponseRelationshipEntry<T, ?>>());
+        this(repositoryInformation, resourceEntry, new LinkedList<ResponseRelationshipEntry<T, ?>>());
     }
 
-    public RegistryEntry(ResourceInformation resourceInformation,
+    public RegistryEntry(ResourceRepositoryInformation repositoryInformation,
                          ResourceEntry<T, ?> resourceEntry,
                          List<ResponseRelationshipEntry<T, ?>> relationshipEntries) {
-        this.resourceInformation = resourceInformation;
+    	this.repositoryInformation = repositoryInformation;
+        this.resourceInformation = repositoryInformation.getResourceInformation();
         this.resourceEntry = resourceEntry;
         this.relationshipEntries = relationshipEntries;
     }
@@ -105,6 +109,10 @@ public class RegistryEntry<T> {
         return resourceInformation;
     }
 
+	public ResourceRepositoryInformation getRepositoryInformation() {
+		return repositoryInformation;
+	}
+
     public RegistryEntry getParentRegistryEntry() {
         return parentRegistryEntry;
     }
@@ -145,6 +153,7 @@ public class RegistryEntry<T> {
         }
         RegistryEntry<?> that = (RegistryEntry<?>) o;
         return Objects.equals(resourceInformation, that.resourceInformation) &&  // NOSONAR
+        		Objects.equals(repositoryInformation, that.repositoryInformation) &&
             Objects.equals(resourceEntry, that.resourceEntry) &&
             Objects.equals(moduleRegistry, that.moduleRegistry) &&
             Objects.equals(relationshipEntries, that.relationshipEntries) &&
@@ -153,6 +162,6 @@ public class RegistryEntry<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(resourceInformation, resourceEntry, relationshipEntries, moduleRegistry, parentRegistryEntry);
+        return Objects.hash(repositoryInformation, resourceInformation, resourceEntry, relationshipEntries, moduleRegistry, parentRegistryEntry);
     }
 }

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
@@ -169,7 +169,7 @@ public class ResourceRegistry {
      *
      * @return resources
      */
-    public Map<Class, RegistryEntry> getResources() {
-        return Collections.unmodifiableMap(resources);
+    public Map<Class<?>, RegistryEntry<?>> getResources() {
+        return (Map)Collections.unmodifiableMap(resources);
     }
 }

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
@@ -72,8 +72,8 @@ public class ResourceRegistry {
      * @return registry entry
      * @throws ResourceNotFoundInitializationException if resource is not found
      */
-    public RegistryEntry getEntry(String searchType, Class clazz) {
-        RegistryEntry entry = getEntry(searchType);
+    public <T> RegistryEntry<T> getEntry(String searchType, Class<T> clazz) {
+        RegistryEntry<T> entry = getEntry(searchType);
         if (entry == null) {
             return getEntry(clazz, false);
         }
@@ -96,7 +96,7 @@ public class ResourceRegistry {
     	return getEntry(clazz, true) != null;
     }
     
-    protected RegistryEntry<?> getEntry(Class<?> clazz, boolean allowNull) {
+    protected <T> RegistryEntry<T> getEntry(Class<T> clazz, boolean allowNull) {
         Optional<Class<?>> resourceClazz = getResourceClass(clazz);
         if (allowNull && !resourceClazz.isPresent())
             return null;
@@ -105,7 +105,7 @@ public class ResourceRegistry {
         return resources.get(resourceClazz.get());
     }
 
-    public RegistryEntry getEntry(Object targetDataObject) {
+    public <T> RegistryEntry<T> getEntry(T targetDataObject) {
         Class<?> targetDataObjClass = targetDataObject.getClass();
         RegistryEntry relationshipEntry;
         if (targetDataObjClass.getAnnotation(JsonApiResource.class) != null) {

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistryBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistryBuilder.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import io.katharsis.locator.JsonServiceLocator;
 import io.katharsis.module.ModuleRegistry;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
+import io.katharsis.repository.information.internal.ResourceRepositoryInformationImpl;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.registry.repository.ResourceEntry;
@@ -64,9 +66,10 @@ public class ResourceRegistryBuilder {
             List<ResponseRelationshipEntry<?, ?>> relationshipEntries = repositoryEntryBuilder
             .buildRelationshipRepositories(resourceLookup, resourceClass);
             LOGGER.trace("{} has relationship repositories {}", resourceInformation.getResourceClass(), relationshipEntries);
-
-            registryEntries.add(new RegistryEntry(resourceInformation, resourceEntry, relationshipEntries));
-
+            
+            
+            ResourceRepositoryInformation repositoryInformation = new ResourceRepositoryInformationImpl(null, resourceInformation.getResourceType(), resourceInformation);
+            registryEntries.add(new RegistryEntry(repositoryInformation, resourceEntry, relationshipEntries));
         }
 
         ResourceRegistry resourceRegistry = new ResourceRegistry(moduleRegistry, serviceUrl);

--- a/katharsis-core/src/test/java/io/katharsis/internal/boot/KatharsisBootTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/internal/boot/KatharsisBootTest.java
@@ -1,5 +1,6 @@
 package io.katharsis.internal.boot;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -9,7 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.dispatcher.RequestDispatcher;
 import io.katharsis.locator.SampleJsonServiceLocator;
+import io.katharsis.module.Module;
 import io.katharsis.module.ServiceDiscovery;
+import io.katharsis.module.SimpleModule;
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.queryspec.internal.QueryParamsAdapter;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
@@ -24,9 +27,7 @@ public class KatharsisBootTest {
 
 	@Test
 	public void test() {
-
 		KatharsisBoot boot = new KatharsisBoot();
-
 		ObjectMapper objectMapper = boot.getObjectMapper();
 		ResourceFieldNameTransformer resourceFieldNameTransformer = new ResourceFieldNameTransformer(
 				objectMapper.getSerializationConfig());
@@ -51,6 +52,7 @@ public class KatharsisBootTest {
 		});
 		boot.setPropertiesProvider(propertiesProvider);
 		boot.setResourceFieldNameTransformer(resourceFieldNameTransformer);
+		boot.addModule(new SimpleModule("test"));
 		boot.boot();
 
 		RequestDispatcher requestDispatcher = boot.getRequestDispatcher();
@@ -64,10 +66,13 @@ public class KatharsisBootTest {
 		Assert.assertNotNull(response);
 
 		Assert.assertNotNull(requestDispatcher);
-		
+
 		ServiceDiscovery serviceDiscovery = boot.getServiceDiscovery();
 		Assert.assertNotNull(serviceDiscovery);
-		
+		Assert.assertNotNull(boot.getModuleRegistry());
+
+		List<Module> modules = boot.getModuleRegistry().getModules();
+		Assert.assertEquals(2, modules.size());
 		boot.setDefaultPageLimit(20L);
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/QuerySpecAdapterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/QuerySpecAdapterTest.java
@@ -10,6 +10,7 @@ import io.katharsis.queryParams.params.IncludedFieldsParams;
 import io.katharsis.queryParams.params.IncludedRelationsParams;
 import io.katharsis.queryParams.params.TypedParams;
 import io.katharsis.queryspec.internal.QuerySpecAdapter;
+import io.katharsis.repository.information.internal.ResourceRepositoryInformationImpl;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.mock.models.Task;
 import io.katharsis.resource.registry.ConstantServiceUrlProvider;
@@ -22,7 +23,7 @@ public class QuerySpecAdapterTest {
 	public void test() {
 		ResourceRegistry resourceRegistry = new ResourceRegistry(new ModuleRegistry(), new ConstantServiceUrlProvider("http://localhost"));
 		resourceRegistry.addEntry(Task.class,
-				new RegistryEntry(new ResourceInformation(Task.class, "tasks", null, null, null), null, null));
+				new RegistryEntry(new ResourceRepositoryInformationImpl(Task.class, "tasks", new ResourceInformation(Task.class, "tasks", null, null, null)), null, null));
 
 		QuerySpec spec = new QuerySpec(Task.class);
 		spec.includeField(Arrays.asList("test"));

--- a/katharsis-core/src/test/java/io/katharsis/request/path/PathBuilderTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/request/path/PathBuilderTest.java
@@ -1,24 +1,34 @@
 package io.katharsis.request.path;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
 import io.katharsis.locator.SampleJsonServiceLocator;
 import io.katharsis.module.ModuleRegistry;
+import io.katharsis.repository.information.RepositoryAction;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
 import io.katharsis.resource.exception.ResourceException;
 import io.katharsis.resource.exception.ResourceFieldNotFoundException;
 import io.katharsis.resource.exception.ResourceNotFoundException;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.AnnotationResourceInformationBuilder;
 import io.katharsis.resource.information.ResourceInformationBuilder;
-import io.katharsis.resource.registry.*;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import io.katharsis.resource.mock.models.Task;
+import io.katharsis.resource.registry.ConstantServiceUrlProvider;
+import io.katharsis.resource.registry.RegistryEntry;
+import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.resource.registry.ResourceRegistryBuilder;
+import io.katharsis.resource.registry.ResourceRegistryBuilderTest;
+import io.katharsis.resource.registry.ResourceRegistryTest;
 
 public class PathBuilderTest {
 
@@ -37,6 +47,11 @@ public class PathBuilderTest {
             .build(ResourceRegistryBuilderTest.TEST_MODELS_PACKAGE, new ModuleRegistry(), new ConstantServiceUrlProvider(ResourceRegistryTest.TEST_MODELS_URL));
 
         pathBuilder = new PathBuilder(resourceRegistry);
+        
+        RegistryEntry<Task> entry = resourceRegistry.getEntry(Task.class);
+        ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
+        repositoryInformation.getActions().put("someRepositoryAction", Mockito.mock(RepositoryAction.class));
+        repositoryInformation.getActions().put("someResourceAction", Mockito.mock(RepositoryAction.class));
     }
 
     @Test
@@ -76,6 +91,35 @@ public class PathBuilderTest {
         assertThat(jsonPath).isEqualTo(new ResourcePath("tasks", new PathIds("1")));
         assertThat(jsonPath.isCollection()).isFalse();
     }
+    
+    @Test
+    public void onRepositoryActionShouldActionPath() {
+        // GIVEN
+        String path = "/tasks/someRepositoryAction";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.buildPath(path);
+
+        // THEN
+        JsonPath expectedPath = new ActionPath("someRepositoryAction");
+        expectedPath.setParentResource(new ResourcePath("tasks"));
+        assertThat(jsonPath).isEqualTo(expectedPath);
+    }
+    
+    @Test
+    public void onResourceActionShouldActionPath() {
+        // GIVEN
+        String path = "/tasks/123/someResourceAction";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.buildPath(path);
+
+        // THEN
+        JsonPath expectedPath = new ActionPath("someResourceAction");
+        expectedPath.setParentResource(new ResourcePath("tasks", new PathIds("123")));
+        assertThat(jsonPath).isEqualTo(expectedPath);
+    }
+    
 
     @Test
     public void onNestedResourcePathShouldReturnNestedPath() {

--- a/katharsis-core/src/test/java/io/katharsis/resource/registry/RegistryEntryTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/registry/RegistryEntryTest.java
@@ -39,7 +39,7 @@ public class RegistryEntryTest {
 	@Test
 	public void onValidRelationshipClassShouldReturnRelationshipRepository() throws Exception {
 		// GIVEN
-		RegistryEntry<Task> sut = new RegistryEntry(null,
+		RegistryEntry<Task> sut = new RegistryEntry(new ResourceRepositoryInformationImpl(null, null, null),
 				new AnnotatedResourceEntry<>(new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskRepository.class)),
 				Collections.singletonList(new DirectResponseRelationshipEntry<>(
 						new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class))));

--- a/katharsis-core/src/test/java/io/katharsis/resource/registry/RegistryEntryTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/registry/RegistryEntryTest.java
@@ -13,6 +13,8 @@ import io.katharsis.locator.SampleJsonServiceLocator;
 import io.katharsis.module.ModuleRegistry;
 import io.katharsis.repository.RepositoryInstanceBuilder;
 import io.katharsis.repository.exception.RelationshipRepositoryNotFoundException;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
+import io.katharsis.repository.information.internal.ResourceRepositoryInformationImpl;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.mock.models.Document;
 import io.katharsis.resource.mock.models.Memorandum;
@@ -31,79 +33,84 @@ import nl.jqno.equalsverifier.Warning;
 @SuppressWarnings("unchecked")
 public class RegistryEntryTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
-    @Test
-    public void onValidRelationshipClassShouldReturnRelationshipRepository() throws Exception {
-        // GIVEN
-        RegistryEntry<Task> sut = new RegistryEntry(null, new AnnotatedResourceEntry<>(
-            new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskRepository.class)),
-            Collections.singletonList(new DirectResponseRelationshipEntry<>(new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class))));
+	@Test
+	public void onValidRelationshipClassShouldReturnRelationshipRepository() throws Exception {
+		// GIVEN
+		RegistryEntry<Task> sut = new RegistryEntry(null,
+				new AnnotatedResourceEntry<>(new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskRepository.class)),
+				Collections.singletonList(new DirectResponseRelationshipEntry<>(
+						new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class))));
 
-        // WHEN
-        RelationshipRepositoryAdapter<Task, ?, ?, ?> relationshipRepository = sut.getRelationshipRepositoryForClass(Project.class, null);
+		// WHEN
+		RelationshipRepositoryAdapter<Task, ?, ?, ?> relationshipRepository = sut.getRelationshipRepositoryForClass(Project.class,
+				null);
 
-        // THEN
-        assertThat(relationshipRepository).isExactlyInstanceOf(RelationshipRepositoryAdapter.class);
-    }
+		// THEN
+		assertThat(relationshipRepository).isExactlyInstanceOf(RelationshipRepositoryAdapter.class);
+	}
 
-    @Test
-    public void onInvalidRelationshipClassShouldThrowException() throws Exception {
-        // GIVEN
-        ResourceInformation resourceInformation = new ResourceInformation(Task.class, null, null, null, null);
-        RegistryEntry<Task> sut = new RegistryEntry(resourceInformation, null,
-            Collections.singletonList(new DirectResponseRelationshipEntry<>(
-                new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class))));
+	@Test
+	public void onInvalidRelationshipClassShouldThrowException() throws Exception {
+		// GIVEN
+		ResourceRepositoryInformation resourceInformation = newRepositoryInformation(Task.class, "tasks");
+		RegistryEntry<Task> sut = new RegistryEntry(resourceInformation, null,
+				Collections.singletonList(new DirectResponseRelationshipEntry<>(
+						new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class))));
 
-        // THEN
-        expectedException.expect(RelationshipRepositoryNotFoundException.class);
+		// THEN
+		expectedException.expect(RelationshipRepositoryNotFoundException.class);
 
-        // WHEN
-        sut.getRelationshipRepositoryForClass(User.class, null);
-    }
+		// WHEN
+		sut.getRelationshipRepositoryForClass(User.class, null);
+	}
 
-    @Test
-    public void onValidParentShouldReturnTrue() throws Exception {
-        // GIVEN
-        RegistryEntry<Thing> thing = new RegistryEntry<>(new ResourceInformation(Thing.class, null, null, null, null), null);
-        RegistryEntry<Document> document = new RegistryEntry<>(new ResourceInformation(Document.class, null, null, null, null), null);
-        document.setParentRegistryEntry(thing);
-        RegistryEntry<Memorandum> memorandum = new RegistryEntry<>(new ResourceInformation(Memorandum.class, null, null, null, null), null);
-        memorandum.setParentRegistryEntry(document);
+	private <T> ResourceRepositoryInformation newRepositoryInformation(Class<T> repositoryClass, String path) {
+		return new ResourceRepositoryInformationImpl(null, path, new ResourceInformation(Task.class, path, null, null, null));
+	}
 
-        // WHEN
-        boolean result = memorandum.isParent(thing);
+	@Test
+	public void onValidParentShouldReturnTrue() throws Exception {
+		// GIVEN
+		RegistryEntry<Thing> thing = new RegistryEntry<>(newRepositoryInformation(Thing.class, "things"), null);
+		RegistryEntry<Document> document = new RegistryEntry<>(newRepositoryInformation(Document.class, "documents"), null);
+		document.setParentRegistryEntry(thing);
+		RegistryEntry<Memorandum> memorandum = new RegistryEntry<>(newRepositoryInformation(Memorandum.class, "memorandum"),
+				null);
+		memorandum.setParentRegistryEntry(document);
 
-        // THEN
-        assertThat(result).isTrue();
-    }
+		// WHEN
+		boolean result = memorandum.isParent(thing);
 
-    @Test
-    public void onInvalidParentShouldReturnFalse() throws Exception {
-        // GIVEN
-        RegistryEntry<Document> document = new RegistryEntry<>(new ResourceInformation(Document.class, null, null, null, null), null);
-        RegistryEntry<Task> task = new RegistryEntry<>(new ResourceInformation(Task.class, null, null, null, null), null);
+		// THEN
+		assertThat(result).isTrue();
+	}
 
-        // WHEN
-        boolean result = document.isParent(task);
+	@Test
+	public void onInvalidParentShouldReturnFalse() throws Exception {
+		// GIVEN
+		RegistryEntry<Document> document = new RegistryEntry<>(newRepositoryInformation(Document.class, "documents"), null);
+		RegistryEntry<Task> task = new RegistryEntry<>(newRepositoryInformation(Task.class, "tasks"), null);
 
-        // THEN
-        assertThat(result).isFalse();
-    }
+		// WHEN
+		boolean result = document.isParent(task);
 
-    @Test
-    public void equalsContract() throws NoSuchFieldException {
-    	ModuleRegistry moduleRegistry = new ModuleRegistry();
-        RegistryEntry blue = new RegistryEntry(new ResourceInformation(String.class, null, null, null, null), null);
-        RegistryEntry red = new RegistryEntry(new ResourceInformation(Long.class, null, null, null, null), null);
-        EqualsVerifier.forClass(RegistryEntry.class)
-                .withPrefabValues(RegistryEntry.class, blue, red)
-                .withPrefabValues(ResourceInformation.class, new ResourceInformation(String.class, null, null, null, null), new ResourceInformation(Long.class, null, null, null, null))
-                .withPrefabValues(Field.class, String.class.getDeclaredField("value"), String.class.getDeclaredField("hash"))
-                .withPrefabValues(ModuleRegistry.class, new ModuleRegistry(), new ModuleRegistry())
-                .suppress(Warning.NONFINAL_FIELDS)
-                .suppress(Warning.STRICT_INHERITANCE)
-                .verify();
-    }
+		// THEN
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void equalsContract() throws NoSuchFieldException {
+		ModuleRegistry moduleRegistry = new ModuleRegistry();
+		RegistryEntry blue = new RegistryEntry(newRepositoryInformation(String.class, "strings"), null);
+		RegistryEntry red = new RegistryEntry(newRepositoryInformation(Long.class, "longs"), null);
+		EqualsVerifier.forClass(RegistryEntry.class).withPrefabValues(RegistryEntry.class, blue, red)
+				.withPrefabValues(ResourceInformation.class, new ResourceInformation(String.class, null, null, null, null),
+						new ResourceInformation(Long.class, null, null, null, null))
+				.withPrefabValues(Field.class, String.class.getDeclaredField("value"), String.class.getDeclaredField("hash"))
+				.withPrefabValues(ModuleRegistry.class, new ModuleRegistry(), new ModuleRegistry())
+				.suppress(Warning.NONFINAL_FIELDS).suppress(Warning.STRICT_INHERITANCE).verify();
+	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/response/ResponseContractTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/response/ResponseContractTest.java
@@ -1,7 +1,10 @@
 package io.katharsis.response;
 
 import io.katharsis.queryParams.QueryParams;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
+import io.katharsis.repository.information.internal.ResourceRepositoryInformationImpl;
 import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.mock.models.Task;
 import io.katharsis.resource.registry.RegistryEntry;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -31,20 +34,24 @@ public class ResponseContractTest {
 
     @Test
     public void LinkageContainerContainerEqualsContract() throws NoSuchFieldException {
-        ResourceInformation resourceInformationRed = new ResourceInformation(String.class, null, null, null, null);
-        ResourceInformation resourceInformationBlack = new ResourceInformation(Integer.class, null, null, null, null);
+        ResourceRepositoryInformation resourceInformationRed = newRepositoryInformation(String.class, null);
+        ResourceRepositoryInformation resourceInformationBlack = newRepositoryInformation(Integer.class, null);
 
         @SuppressWarnings("unchecked") RegistryEntry registryEntryRed = new RegistryEntry(resourceInformationRed, null, null);
         @SuppressWarnings("unchecked") RegistryEntry registryEntryBlack = new RegistryEntry(resourceInformationBlack, null, null);
 
         EqualsVerifier.forClass(LinkageContainer.class)
                 .withPrefabValues(Field.class, String.class.getDeclaredField("value"), String.class.getDeclaredField("hash"))
-                .withPrefabValues(ResourceInformation.class, resourceInformationRed, resourceInformationBlack)
+                .withPrefabValues(ResourceRepositoryInformation.class, resourceInformationRed, resourceInformationBlack)
                 .withPrefabValues(RegistryEntry.class, registryEntryRed, registryEntryBlack)
                 .usingGetClass()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
+    
+    private <T> ResourceRepositoryInformation newRepositoryInformation(Class<T> repositoryClass, String path) {
+		return new ResourceRepositoryInformationImpl(null, path, new ResourceInformation(Task.class, path, null, null, null));
+	}
 
     @Test
     public void RelationshipContainerContainerEqualsContract() throws NoSuchFieldException {

--- a/katharsis-jpa/pom.xml
+++ b/katharsis-jpa/pom.xml
@@ -213,6 +213,18 @@
 			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/katharsis-parent/pom.xml
+++ b/katharsis-parent/pom.xml
@@ -38,6 +38,7 @@
         <typetools.version>0.4.4</typetools.version>
         <jackson.version>2.6.3</jackson.version>
         <slf4j.version>1.7.13</slf4j.version>
+		<logback.version>1.1.7</logback.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
@@ -109,6 +110,16 @@
                 <version>${assertj.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+	            <groupId>ch.qos.logback</groupId>
+	            <artifactId>logback-classic</artifactId>
+	            <version>${logback.version}</version>
+	        </dependency>
+	        <dependency>
+			    <groupId>org.slf4j</groupId>
+			     <artifactId>jul-to-slf4j</artifactId>
+	            <version>${slf4j.version}</version>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/katharsis-rs/pom.xml
+++ b/katharsis-rs/pom.xml
@@ -128,6 +128,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-jetty</artifactId>
             <version>2.17</version>

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFeature.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFeature.java
@@ -19,7 +19,6 @@ import io.katharsis.internal.boot.KatharsisBoot;
 import io.katharsis.internal.boot.PropertiesProvider;
 import io.katharsis.locator.JsonServiceLocator;
 import io.katharsis.module.Module;
-import io.katharsis.module.ModuleRegistry;
 import io.katharsis.queryParams.QueryParamsBuilder;
 import io.katharsis.queryspec.QuerySpecDeserializer;
 import io.katharsis.repository.information.ResourceRepositoryInformation;

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFeature.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFeature.java
@@ -1,5 +1,8 @@
 package io.katharsis.rs;
 
+import java.io.Serializable;
+import java.util.Collection;
+
 import javax.ws.rs.ConstrainedTo;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.WebApplicationException;
@@ -16,11 +19,15 @@ import io.katharsis.internal.boot.KatharsisBoot;
 import io.katharsis.internal.boot.PropertiesProvider;
 import io.katharsis.locator.JsonServiceLocator;
 import io.katharsis.module.Module;
+import io.katharsis.module.ModuleRegistry;
 import io.katharsis.queryParams.QueryParamsBuilder;
 import io.katharsis.queryspec.QuerySpecDeserializer;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
 import io.katharsis.resource.field.ResourceFieldNameTransformer;
+import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.ServiceUrlProvider;
+import io.katharsis.resource.registry.repository.adapter.ResourceRepositoryAdapter;
 import io.katharsis.rs.internal.JaxrsModule;
 import io.katharsis.rs.parameterProvider.RequestContextParameterProviderRegistry;
 import io.katharsis.rs.parameterProvider.RequestContextParameterProviderRegistryBuilder;
@@ -106,8 +113,29 @@ public class KatharsisFeature implements Feature {
 			throw new WebApplicationException(e);
 		}
 		context.register(katharsisFilter);
+		
+		registerActionRepositories(context, boot);
 
 		return true;
+	}
+
+	/**
+	 * All repositories with JAX-RS action need to be registered with JAX-RS as singletons.
+	 * 
+	 * @param context of jaxrs
+	 * @param boot of katharsis
+	 */
+	private void registerActionRepositories(FeatureContext context, KatharsisBoot boot) {
+		ResourceRegistry resourceRegistry = boot.getResourceRegistry();
+		Collection<RegistryEntry<?>> registryEntries = resourceRegistry.getResources().values();
+		for(RegistryEntry<?> registryEntry : registryEntries){
+			ResourceRepositoryInformation repositoryInformation = registryEntry.getRepositoryInformation();
+			if(!repositoryInformation.getActions().isEmpty()){
+				ResourceRepositoryAdapter<?, Serializable> repositoryAdapter = registryEntry.getResourceRepository(null);
+				Object resourceRepository = repositoryAdapter.getResourceRepository();
+				context.register(resourceRepository);
+			}
+		}		
 	}
 
 	private RequestContextParameterProviderRegistry buildParameterProviderRegistry() {

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -135,8 +135,8 @@ public class KatharsisFilter implements ContainerRequestFilter {
             	((UriInfoServiceUrlProvider)serviceUrlProvider).onRequestStarted(uriInfo);
             }
 
-            Optional<JsonPath> jsonPath = new PathBuilder(resourceRegistry).build(path);
-	        if(jsonPath.isPresent() && !(jsonPath.get() instanceof ActionPath)){
+            JsonPath jsonPath = new PathBuilder(resourceRegistry).build(path);
+	        if(jsonPath != null && !(jsonPath instanceof ActionPath)){
 	            Map<String, Set<String>> parameters = getParameters(uriInfo);
 	
 	            String method = requestContext.getMethod();
@@ -144,7 +144,7 @@ public class KatharsisFilter implements ContainerRequestFilter {
 	
 	            JaxRsParameterProvider parameterProvider = new JaxRsParameterProvider(objectMapper, requestContext, parameterProviderRegistry);
 	            katharsisResponse = requestDispatcher
-	                .dispatchRequest(jsonPath.get(), method, parameters, parameterProvider, requestBody);
+	                .dispatchRequest(jsonPath, method, parameters, parameterProvider, requestBody);
             }else{
             	passToMethodMatcher = true;
             }

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -135,16 +135,23 @@ public class KatharsisFilter implements ContainerRequestFilter {
             }
 
             JsonPath jsonPath = new PathBuilder(resourceRegistry).build(path);
-	        if(jsonPath != null && !(jsonPath instanceof ActionPath)){
-	            Map<String, Set<String>> parameters = getParameters(uriInfo);
-	
-	            String method = requestContext.getMethod();
+            Map<String, Set<String>> parameters = getParameters(uriInfo);
+            String method = requestContext.getMethod();
+            
+            if(jsonPath instanceof ActionPath){
+            	// inital implementation, has to improve
+            	requestDispatcher.dispatchAction(jsonPath, method, parameters);
+            	
+            	// nothing further done, forward the call to JAX-RS
+            	passToMethodMatcher = true;
+            }else if(jsonPath != null){
 	            RequestBody requestBody = inputStreamToBody(requestContext.getEntityStream());
 	
 	            JaxRsParameterProvider parameterProvider = new JaxRsParameterProvider(objectMapper, requestContext, parameterProviderRegistry);
 	            katharsisResponse = requestDispatcher
 	                .dispatchRequest(jsonPath, method, parameters, parameterProvider, requestBody);
             }else{
+            	// no repositories invoked, we do nothing and forward the call to JAX-RS
             	passToMethodMatcher = true;
             }
         } catch (KatharsisMappableException e) {

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -110,7 +110,7 @@ public class KatharsisFilter implements ContainerRequestFilter {
         }
 
         try {
-            dispatchRequest(requestContext);
+        	dispatchRequest(requestContext);
         } catch (WebApplicationException e) {
         	LOGGER.error("failed to dispatch request", e);
             throw e;

--- a/katharsis-rs/src/main/java/io/katharsis/rs/internal/JaxrsModule.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/internal/JaxrsModule.java
@@ -1,12 +1,28 @@
 package io.katharsis.rs.internal;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.SecurityContext;
 
 import io.katharsis.module.Module;
+import io.katharsis.repository.information.RepositoryAction;
+import io.katharsis.repository.information.internal.DefaultResourceRepositoryInformationBuilder;
 
 public class JaxrsModule implements Module {
 
 	private SecurityContext securityContext;
+
+	private static final String ID_ACTION_PARAMETER = "{id}";
 
 	public JaxrsModule(SecurityContext securityContext) {
 		this.securityContext = securityContext;
@@ -14,8 +30,10 @@ public class JaxrsModule implements Module {
 
 	@Override
 	public void setupModule(ModuleContext context) {
-//		context.addExceptionMapper(new JaxrsNotAuthorizedExceptionMapper());
-//		context.addExceptionMapper(new JaxrsForbiddenExceptionMapper());
+		//		context.addExceptionMapper(new JaxrsNotAuthorizedExceptionMapper());
+		//		context.addExceptionMapper(new JaxrsForbiddenExceptionMapper());
+
+		context.addRepositoryInformationBuilder(new JaxrsResourceRepositoryInformationBuilder());
 
 		if (securityContext != null) {
 			context.addSecurityProvider(new JaxrsSecurityProvider(securityContext));
@@ -27,4 +45,82 @@ public class JaxrsModule implements Module {
 		return "jaxrs";
 	}
 
+	class JaxrsResourceRepositoryInformationBuilder extends DefaultResourceRepositoryInformationBuilder {
+
+		@Override
+		protected Map<String, RepositoryAction> buildActions(Class<? extends Object> repositoryClass) {
+			HashMap<String, RepositoryAction> actions = new HashMap<>();
+			for (Method method : repositoryClass.getMethods()) {
+
+				Path pathAnnotation = method.getAnnotation(Path.class);
+				boolean isGet = method.getAnnotation(GET.class) != null;
+				boolean isPost = method.getAnnotation(POST.class) != null;
+				boolean isPut = method.getAnnotation(PUT.class) != null;
+				boolean isDelete = method.getAnnotation(DELETE.class) != null;
+
+				boolean isJaxRs = isGet || isPost || isPut || isDelete;
+				isJaxRs = isJaxRs || pathAnnotation != null;
+				Annotation[][] parameterAnnotationsArray = method.getParameterAnnotations();
+
+				for (int paramIndex = 0; paramIndex < parameterAnnotationsArray.length; paramIndex++) {
+					Annotation[] parameterAnnotations = parameterAnnotationsArray[paramIndex];
+					for (Annotation parameterAnnotation : parameterAnnotations) {
+						isJaxRs = isJaxRs || parameterAnnotation instanceof PathParam
+								|| parameterAnnotation instanceof QueryParam;
+					}
+				}
+
+				if (pathAnnotation != null) {
+					String path = normPath(pathAnnotation.value());
+					String[] pathElements = path.split("\\/");
+					if (pathElements.length == 0) {
+						throw new IllegalStateException("@Path value must not be empty: " + method);
+					}
+					if (pathElements.length > 2) {
+						throw new IllegalStateException("@Path value must not contain more than to elements: " + method);
+					}
+
+					if (pathElements.length == 1 && pathElements[0].equals(ID_ACTION_PARAMETER)) {
+						throw new IllegalStateException("single element in @Path cannot be {id}, add action name: " + method);
+					}
+					if (pathElements.length == 2 && !pathElements[0].equals(ID_ACTION_PARAMETER)) {
+						throw new IllegalStateException(
+								"for two elements in @Path the first one must be {id}, the second the action name: " + method);
+					}
+					String name = pathElements[pathElements.length - 1];
+					RepositoryAction action = new JaxrsRepositoryAction(name);
+					actions.put(name, action);
+				}
+				else if (isJaxRs) {
+					throw new IllegalStateException("JAXRS actions must be annotated with @Path: " + method);
+				}
+			}
+			return actions;
+		}
+
+		private String normPath(String path) {
+			String normPath = path;
+			if (normPath.startsWith("/")) {
+				normPath = normPath.substring(1);
+			}
+			if (normPath.endsWith("/")) {
+				normPath = normPath.substring(0, normPath.length() - 1);
+			}
+			return normPath;
+		}
+	}
+
+	class JaxrsRepositoryAction implements RepositoryAction {
+
+		private String name;
+
+		public JaxrsRepositoryAction(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+	}
 }

--- a/katharsis-validation/pom.xml
+++ b/katharsis-validation/pom.xml
@@ -164,6 +164,18 @@
 			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
by allowing katharsis repositories to be complemented with JAX-RS methods. Other implementations like Vert.x can follow the same pattern. Methods have to obey some rule to be recognized as either repository or resource actions.