### PR TITLE
#216 Support apache commons http client in katharsis client

### DIFF
--- a/katharsis-brave/pom.xml
+++ b/katharsis-brave/pom.xml
@@ -12,13 +12,6 @@
 	<packaging>bundle</packaging>
 	<name>katharsis-brave</name>
 
-	<properties>
-		<brave.version>3.14.1</brave.version>
-		<jersey.version>2.17</jersey.version>
-		<javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
-		<guava.version>15.0</guava.version>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -54,6 +47,13 @@
 		</dependency>
 		
 		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${httpclient.version}</version>
+			<optional>true</optional>
+		</dependency>
+		
+		<dependency>
 			<groupId>io.katharsis</groupId>
 			<artifactId>katharsis-client</artifactId>
 			<version>${project.version}</version>
@@ -65,6 +65,22 @@
 			<artifactId>brave-okhttp</artifactId>
 			<version>${brave.version}</version>
 			<scope>compile</scope>
+			<optional>true</optional>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp.version}</version>
+			<optional>true</optional>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.zipkin.brave</groupId>
+  			<artifactId>brave-apache-http-interceptors</artifactId>
+			<version>${brave.version}</version>
+			<scope>compile</scope>
+			<optional>true</optional>
 		</dependency>
 		
 		<dependency>

--- a/katharsis-brave/src/main/java/io/katharsis/brave/internal/HttpClientBraveIntegration.java
+++ b/katharsis-brave/src/main/java/io/katharsis/brave/internal/HttpClientBraveIntegration.java
@@ -1,0 +1,33 @@
+package io.katharsis.brave.internal;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientRequestInterceptor;
+import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.http.SpanNameProvider;
+import com.github.kristofa.brave.httpclient.BraveHttpRequestInterceptor;
+import com.github.kristofa.brave.httpclient.BraveHttpResponseInterceptor;
+
+import io.katharsis.client.http.apache.HttpClientAdapterListener;
+
+public class HttpClientBraveIntegration implements HttpClientAdapterListener {
+
+	private Brave brave;
+
+	private SpanNameProvider spanNameProvider;
+
+	public HttpClientBraveIntegration(Brave brave, SpanNameProvider spanNameProvider) {
+		this.brave = brave;
+		this.spanNameProvider = spanNameProvider;
+	}
+
+	@Override
+	public void onBuild(HttpClientBuilder builder) {
+		ClientRequestInterceptor clientRequestInterceptor = brave.clientRequestInterceptor();
+		ClientResponseInterceptor clientResponseInterceptor = brave.clientResponseInterceptor();
+		builder.addInterceptorFirst(new BraveHttpRequestInterceptor(clientRequestInterceptor, spanNameProvider));
+		builder.addInterceptorFirst(new BraveHttpResponseInterceptor(clientResponseInterceptor));
+	}
+
+}

--- a/katharsis-brave/src/main/java/io/katharsis/brave/internal/OkHttpBraveIntegration.java
+++ b/katharsis-brave/src/main/java/io/katharsis/brave/internal/OkHttpBraveIntegration.java
@@ -1,0 +1,38 @@
+package io.katharsis.brave.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.BraveExecutorService;
+import com.github.kristofa.brave.okhttp.BraveTracingInterceptor;
+
+import io.katharsis.client.http.okhttp.OkHttpAdapterListener;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
+
+public class OkHttpBraveIntegration implements OkHttpAdapterListener {
+
+	private Brave brave;
+
+	public OkHttpBraveIntegration(Brave brave) {
+		this.brave = brave;
+	}
+
+	@Override
+	public void onBuild(OkHttpClient.Builder builder) {
+		BraveTracingInterceptor interceptor = buildInterceptor();
+
+		BraveExecutorService tracePropagatingExecutor = buildExecutor(builder);
+
+		builder.addInterceptor(interceptor);
+		builder.addNetworkInterceptor(interceptor);
+		builder.dispatcher(new Dispatcher(tracePropagatingExecutor));
+	}
+
+	protected BraveExecutorService buildExecutor(okhttp3.OkHttpClient.Builder builder) {
+		return new BraveExecutorService(new Dispatcher().executorService(), brave.serverSpanThreadBinder());
+	}
+
+	protected BraveTracingInterceptor buildInterceptor() {
+		BraveTracingInterceptor.Builder tracingBuilder = BraveTracingInterceptor.builder(brave);
+		return tracingBuilder.build();
+	}
+}

--- a/katharsis-brave/src/test/java/io/katharsis/brave/ApacheHttpBraveModuleTest.java
+++ b/katharsis-brave/src/test/java/io/katharsis/brave/ApacheHttpBraveModuleTest.java
@@ -1,0 +1,10 @@
+package io.katharsis.brave;
+
+import io.katharsis.client.http.apache.HttpClientAdapter;
+
+public class ApacheHttpBraveModuleTest extends AbstractBraveModuleTest {
+
+	public ApacheHttpBraveModuleTest() {
+		super(HttpClientAdapter.newInstance());
+	}
+}

--- a/katharsis-brave/src/test/java/io/katharsis/brave/OkHttpBraveModuleTest.java
+++ b/katharsis-brave/src/test/java/io/katharsis/brave/OkHttpBraveModuleTest.java
@@ -1,0 +1,10 @@
+package io.katharsis.brave;
+
+import io.katharsis.client.http.okhttp.OkHttpAdapter;
+
+public class OkHttpBraveModuleTest extends AbstractBraveModuleTest {
+
+	public OkHttpBraveModuleTest() {
+		super(OkHttpAdapter.newInstance());
+	}
+}

--- a/katharsis-client/pom.xml
+++ b/katharsis-client/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -34,11 +35,6 @@
 			<organization>Katharsis community</organization>
 		</developer>
 	</developers>
-
-	<properties>
-		<okhttp.version>3.4.1</okhttp.version>
-		<jersey.version>2.17</jersey.version>
-	</properties>
 
 	<build>
 		<plugins>
@@ -87,7 +83,14 @@
 			<artifactId>katharsis-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${httpclient.version}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
 			<artifactId>jersey-proxy-client</artifactId>
@@ -114,20 +117,21 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<version>${okhttp.version}</version>
+			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>io.katharsis</groupId>
 			<artifactId>katharsis-rs</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-				
+
 		<dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <scope>test</scope>
-        </dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
@@ -157,17 +161,17 @@
 			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
 
-        <dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>jul-to-slf4j</artifactId>
-            <scope>test</scope>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jul-to-slf4j</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapter.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapter.java
@@ -1,5 +1,13 @@
 package io.katharsis.client.http;
 
+import java.util.concurrent.TimeUnit;
+
+import io.katharsis.dispatcher.controller.HttpMethod;
+
 public interface HttpAdapter {
+
+	HttpAdapterRequest newRequest(String url, HttpMethod method, String requestBody);
+
+	void setReceiveTimeout(int timeout, TimeUnit unit);
 
 }

--- a/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapterRequest.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapterRequest.java
@@ -1,0 +1,11 @@
+package io.katharsis.client.http;
+
+import java.io.IOException;
+
+public interface HttpAdapterRequest {
+
+	void header(String name, String value);
+
+	HttpAdapterResponse execute() throws IOException;
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapterResponse.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/HttpAdapterResponse.java
@@ -1,0 +1,15 @@
+package io.katharsis.client.http;
+
+import java.io.IOException;
+
+public interface HttpAdapterResponse {
+
+	boolean isSuccessful();
+
+	String body() throws IOException;
+
+	int code();
+
+	String message();
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientAdapter.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientAdapter.java
@@ -1,0 +1,70 @@
+package io.katharsis.client.http.apache;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+
+import io.katharsis.client.http.HttpAdapter;
+import io.katharsis.client.http.HttpAdapterRequest;
+import io.katharsis.dispatcher.controller.HttpMethod;
+
+public class HttpClientAdapter implements HttpAdapter {
+
+	private CloseableHttpClient impl;
+
+	private CopyOnWriteArrayList<HttpClientAdapterListener> listeners = new CopyOnWriteArrayList<>();
+
+	private Integer receiveTimeout;
+
+	public void addListener(HttpClientAdapterListener listener) {
+		if (impl != null) {
+			throw new IllegalStateException("already initialized");
+		}
+		listeners.add(listener);
+	}
+
+	public CloseableHttpClient getImplementation() {
+		if (impl == null) {
+			initImpl();
+		}
+		return impl;
+	}
+
+	private void initImpl() {
+		synchronized (this) {
+			if (impl == null) {
+				HttpClientBuilder builder = HttpClients.custom();
+
+				if (receiveTimeout != null) {
+					RequestConfig.Builder requestBuilder = RequestConfig.custom();
+					requestBuilder = requestBuilder.setSocketTimeout(receiveTimeout);
+					builder.setDefaultRequestConfig(requestBuilder.build());
+				}
+
+				for (HttpClientAdapterListener listener : listeners) {
+					listener.onBuild(builder);
+				}
+				impl = builder.build();
+			}
+		}
+	}
+
+	@Override
+	public HttpAdapterRequest newRequest(String url, HttpMethod method, String requestBody) {
+		CloseableHttpClient impl = getImplementation();
+		return new HttpClientRequest(impl, url, method, requestBody);
+	}
+
+	public static HttpAdapter newInstance() {
+		return new HttpClientAdapter();
+	}
+
+	@Override
+	public void setReceiveTimeout(int timeout, TimeUnit unit) {
+		receiveTimeout = (int) unit.toMillis(timeout);
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientAdapterListener.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientAdapterListener.java
@@ -1,0 +1,9 @@
+package io.katharsis.client.http.apache;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+
+public interface HttpClientAdapterListener {
+
+	void onBuild(HttpClientBuilder builder);
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientAdapterListenerBase.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientAdapterListenerBase.java
@@ -1,0 +1,11 @@
+package io.katharsis.client.http.apache;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+
+public class HttpClientAdapterListenerBase implements HttpClientAdapterListener {
+
+	@Override
+	public void onBuild(HttpClientBuilder builder) {
+		// nothing to do
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientRequest.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientRequest.java
@@ -1,0 +1,63 @@
+package io.katharsis.client.http.apache;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import io.katharsis.client.http.HttpAdapterRequest;
+import io.katharsis.client.http.HttpAdapterResponse;
+import io.katharsis.client.internal.AbstractStub;
+import io.katharsis.dispatcher.controller.HttpMethod;
+
+public class HttpClientRequest implements HttpAdapterRequest {
+
+	private static final Charset CHARSET_UTF8 = Charset.forName("UTF8");
+
+	private static final ContentType CONTENT_TYPE = ContentType.create(AbstractStub.CONTENT_TYPE, CHARSET_UTF8);
+
+	private HttpRequestBase requestBase;
+
+	private CloseableHttpClient impl;
+
+	public HttpClientRequest(CloseableHttpClient impl, String url, HttpMethod method, String requestBody) {
+		this.impl = impl;
+		if (method == HttpMethod.GET) {
+			requestBase = new HttpGet(url);
+		}
+		else if (method == HttpMethod.POST) {
+			HttpPost post = new HttpPost(url);
+			post.setEntity(new StringEntity(requestBody, CONTENT_TYPE));
+			requestBase = post;
+		}
+		else if (method == HttpMethod.PATCH) {
+			HttpPatch post = new HttpPatch(url);
+			post.setEntity(new StringEntity(requestBody, CONTENT_TYPE));
+			requestBase = post;
+		}
+		else if (method == HttpMethod.DELETE) {
+			requestBase = new HttpDelete(url);
+		}
+		else {
+			throw new UnsupportedOperationException(method.toString());
+		}
+
+	}
+
+	@Override
+	public void header(String name, String value) {
+		requestBase.setHeader(name, value);
+	}
+
+	@Override
+	public HttpAdapterResponse execute() throws IOException {
+		return new HttpClientResponse(impl.execute(requestBase));
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientResponse.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/apache/HttpClientResponse.java
@@ -1,0 +1,47 @@
+package io.katharsis.client.http.apache;
+
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.ParseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+
+import io.katharsis.client.http.HttpAdapterResponse;
+
+public class HttpClientResponse implements HttpAdapterResponse {
+
+	private CloseableHttpResponse response;
+	
+	private String body;
+
+	public HttpClientResponse(CloseableHttpResponse response) throws ParseException, IOException {
+		this.response = response;
+		
+		HttpEntity entity = response.getEntity();
+		if (entity != null) {
+			body = EntityUtils.toString(entity);
+		}
+	}
+
+	@Override
+	public boolean isSuccessful() {
+		return response.getStatusLine().getStatusCode() < 400;
+	}
+
+	@Override
+	public String body() throws IOException {
+		return body;
+	}
+
+	@Override
+	public int code() {
+		return response.getStatusLine().getStatusCode();
+	}
+
+	@Override
+	public String message() {
+		return response.getStatusLine().getReasonPhrase();
+	}
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpRequest.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpRequest.java
@@ -1,0 +1,40 @@
+package io.katharsis.client.http.okhttp;
+
+import java.io.IOException;
+
+import io.katharsis.client.http.HttpAdapterRequest;
+import io.katharsis.client.http.HttpAdapterResponse;
+import io.katharsis.dispatcher.controller.HttpMethod;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class OkHttpRequest implements HttpAdapterRequest {
+
+	private Builder builder;
+
+	private OkHttpClient client;
+
+	public OkHttpRequest(OkHttpClient client, String url, HttpMethod method, String requestBody) {
+		this.client = client;
+		builder = new Request.Builder().url(url);
+		
+		RequestBody requestBodyObj = requestBody != null ? RequestBody.create(null, requestBody) : null;
+		builder.method(method.toString(), requestBodyObj);
+	}
+
+	@Override
+	public void header(String name, String value) {
+		builder = builder.header(name, value);
+	}
+
+	@Override
+	public HttpAdapterResponse execute() throws IOException {
+		Request request = builder.build();
+		Response response = client.newCall(request).execute();
+		return new OkHttpResponse(response);
+	}
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpResponse.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/http/okhttp/OkHttpResponse.java
@@ -1,0 +1,37 @@
+package io.katharsis.client.http.okhttp;
+
+import java.io.IOException;
+
+import io.katharsis.client.http.HttpAdapterResponse;
+import okhttp3.Response;
+
+
+public class OkHttpResponse implements HttpAdapterResponse {
+
+	private Response response;
+
+	public OkHttpResponse(Response response) {
+		this.response = response;
+	}
+
+	@Override
+	public boolean isSuccessful() {
+		return response.isSuccessful();
+	}
+
+	@Override
+	public String body() throws IOException {
+		return response.body().string();
+	}
+
+	@Override
+	public int code() {
+		return response.code();
+	}
+
+	@Override
+	public String message() {
+		return response.message();
+	}
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/AbstractStub.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/AbstractStub.java
@@ -1,9 +1,18 @@
 package io.katharsis.client.internal;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.katharsis.client.ClientException;
 import io.katharsis.client.KatharsisClient;
+import io.katharsis.client.http.HttpAdapter;
+import io.katharsis.client.http.HttpAdapterRequest;
+import io.katharsis.client.http.HttpAdapterResponse;
 import io.katharsis.client.response.ResourceList;
+import io.katharsis.dispatcher.controller.HttpMethod;
 import io.katharsis.errorhandling.ErrorData;
 import io.katharsis.errorhandling.ErrorResponse;
 import io.katharsis.errorhandling.mapper.ExceptionMapper;
@@ -14,20 +23,13 @@ import io.katharsis.response.LinksInformation;
 import io.katharsis.response.MetaInformation;
 import io.katharsis.utils.JsonApiUrlBuilder;
 import io.katharsis.utils.java.Optional;
-import okhttp3.HttpUrl;
-import okhttp3.Request;
-import okhttp3.Request.Builder;
-import okhttp3.Response;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 public class AbstractStub {
 
-	private static final String CONTENT_TYPE = "application/vnd.api+json";
+	public static final String CONTENT_TYPE = "application/vnd.api+json";
 
 	protected KatharsisClient katharsis;
+
 	protected JsonApiUrlBuilder urlBuilder;
 
 	public AbstractStub(KatharsisClient client, JsonApiUrlBuilder urlBuilder) {
@@ -35,81 +37,85 @@ public class AbstractStub {
 		this.urlBuilder = urlBuilder;
 	}
 
-	protected BaseResponseContext executeGet(HttpUrl requestUrl) {
-		Builder builder = new Request.Builder().url(requestUrl);
-		return execute(builder, true);
+	protected BaseResponseContext executeGet(String requestUrl) {
+		return execute(requestUrl, true, HttpMethod.GET, null);
 	}
 
-	protected BaseResponseContext executeDelete(HttpUrl requestUrl) {
-		Builder builder = new Request.Builder().url(requestUrl);
-		builder.delete();
-		return execute(builder, false);
+	protected BaseResponseContext executeDelete(String requestUrl) {
+		return execute(requestUrl, false, HttpMethod.DELETE, null);
 	}
 
 	@SuppressWarnings("unchecked")
 	protected <T> ResourceList<T> toList(JsonApiResponse response) {
 		Object entity = response.getEntity();
 		List<T> list;
-		if(entity instanceof List){
+		if (entity instanceof List) {
 			list = (List<T>) entity;
-		}else{
+		}
+		else {
 			list = (List<T>) Arrays.asList(entity);
 		}
 		LinksInformation linksInformation = response.getLinksInformation();
 		MetaInformation metaInformation = response.getMetaInformation();
 		return new ResourceList<>(list, linksInformation, metaInformation);
 	}
-	
-	protected BaseResponseContext execute(Builder builder, boolean getResponse) {
-		try {
-			Builder complementedBuilder = 
-				builder
-					.header("Content-Type", CONTENT_TYPE)
-					.header("Accept", CONTENT_TYPE);
 
-			Request request = complementedBuilder.build();
-			Response response = katharsis.getHttpClient().newCall(request).execute();
+	protected BaseResponseContext execute(String url, boolean getResponse, HttpMethod method, String requestBody) {
+		try {
+
+			HttpAdapter httpAdapter = katharsis.getHttpAdapter();
+			HttpAdapterRequest request = httpAdapter.newRequest(url, method, requestBody);
+
+			request.header("Content-Type", CONTENT_TYPE);
+			request.header("Accept", CONTENT_TYPE);
+
+			HttpAdapterResponse response = request.execute();
 			if (!response.isSuccessful()) {
 				handleError(response);
 			}
 
-			String body = response.body().string();
+			String body = response.body();
 			ObjectMapper objectMapper = katharsis.getObjectMapper();
 			if (getResponse) {
 				return objectMapper.readValue(body, BaseResponseContext.class);
-			} else {
+			}
+			else {
 				return null;
 			}
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new IllegalStateException(e);
 		}
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private void handleError(Response response) throws IOException {
-		String body = response.body().string(); // wise to do null check here
+	private void handleError(HttpAdapterResponse response) throws IOException {
+		String body = response.body();
 
 		ErrorResponse errorResponse = null;
-		if(body.length() > 0){
+		if (body.length() > 0) {
 			ObjectMapper objectMapper = katharsis.getObjectMapper();
 			errorResponse = objectMapper.readValue(body, ErrorResponse.class);
 		}
-		if(errorResponse != null){
+		if (errorResponse != null) {
 			errorResponse = new ErrorResponse((Iterable<ErrorData>) errorResponse.getResponse().getEntity(), response.code());
-		}else{
+		}
+		else {
 			errorResponse = new ErrorResponse(null, response.code());
 		}
-			
+
 		ExceptionMapperRegistry exceptionMapperRegistry = katharsis.getExceptionMapperRegistry();
 		Optional<ExceptionMapper<?>> mapper = exceptionMapperRegistry.findMapperFor(errorResponse);
-		if(mapper.isPresent()){
-			 Throwable throwable = mapper.get().fromErrorResponse(errorResponse);
-			 if(throwable instanceof RuntimeException){
-				 throw (RuntimeException)throwable;
-			 }else{
-				 throw new ClientException(response.code(), response.message(), throwable);
-			 }
-		}else{
+		if (mapper.isPresent()) {
+			Throwable throwable = mapper.get().fromErrorResponse(errorResponse);
+			if (throwable instanceof RuntimeException) {
+				throw (RuntimeException) throwable;
+			}
+			else {
+				throw new ClientException(response.code(), response.message(), throwable);
+			}
+		}
+		else {
 			throw new ClientException(response.code(), response.message());
 		}
 	}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/RelationshipRepositoryStubImpl.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/RelationshipRepositoryStubImpl.java
@@ -6,15 +6,12 @@ import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import okhttp3.HttpUrl;
-import okhttp3.Request;
-import okhttp3.Request.Builder;
-import okhttp3.RequestBody;
 
 import io.katharsis.client.KatharsisClient;
 import io.katharsis.client.QuerySpecRelationshipRepositoryStub;
 import io.katharsis.client.RelationshipRepositoryStub;
 import io.katharsis.client.response.ResourceList;
+import io.katharsis.dispatcher.controller.HttpMethod;
 import io.katharsis.queryParams.QueryParams;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.queryspec.internal.QueryAdapter;
@@ -28,8 +25,8 @@ import io.katharsis.response.CollectionResponseContext;
 import io.katharsis.response.JsonApiResponse;
 import io.katharsis.response.LinkageContainer;
 import io.katharsis.response.ResourceResponseContext;
-import io.katharsis.utils.PropertyUtils;
 import io.katharsis.utils.JsonApiUrlBuilder;
+import io.katharsis.utils.PropertyUtils;
 
 public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J extends Serializable> extends AbstractStub
 		implements RelationshipRepositoryStub<T, I, D, J>, QuerySpecRelationshipRepositoryStub<T, I, D, J> {
@@ -54,29 +51,29 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 	@Override
 	public void setRelation(T source, J targetId, String fieldName) {
 		Serializable sourceId = getSourceId(source);
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName));
-		execute(url, "PATCH", targetId);
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName);
+		execute(url, HttpMethod.PATCH, targetId);
 	}
 
 	@Override
 	public void setRelations(T source, Iterable<J> targetIds, String fieldName) {
 		Serializable sourceId = getSourceId(source);
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName));
-		execute(url, "PATCH", targetIds);
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName);
+		execute(url, HttpMethod.PATCH, targetIds);
 	}
 
 	@Override
 	public void addRelations(T source, Iterable<J> targetIds, String fieldName) {
 		Serializable sourceId = getSourceId(source);
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName));
-		execute(url, "POST", targetIds);
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName);
+		execute(url, HttpMethod.POST, targetIds);
 	}
 
 	@Override
 	public void removeRelations(T source, Iterable<J> targetIds, String fieldName) {
 		Serializable sourceId = getSourceId(source);
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName));
-		execute(url, "DELETE", targetIds);
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, (QuerySpec) null, fieldName);
+		execute(url, HttpMethod.DELETE, targetIds);
 	}
 
 	private Serializable getSourceId(T source) {
@@ -87,7 +84,7 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 	@SuppressWarnings("unchecked")
 	@Override
 	public D findOneTarget(I sourceId, String fieldName, QueryParams queryParams) {
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, queryParams, fieldName));
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, queryParams, fieldName);
 		BaseResponseContext responseContext = executeGet(url);
 		return (D) responseContext.getResponse().getEntity();
 	}
@@ -95,7 +92,7 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<D> findManyTargets(I sourceId, String fieldName, QueryParams queryParams) {
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, queryParams, fieldName));
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, queryParams, fieldName);
 		BaseResponseContext responseContext = executeGet(url);
 		return (List<D>) responseContext.getResponse().getEntity();
 	}
@@ -103,19 +100,19 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 	@SuppressWarnings("unchecked")
 	@Override
 	public D findOneTarget(I sourceId, String fieldName, QuerySpec querySpec) {
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, querySpec, fieldName));
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, querySpec, fieldName);
 		BaseResponseContext responseContext = executeGet(url);
 		return (D) responseContext.getResponse().getEntity();
 	}
 
 	@Override
 	public ResourceList<D> findManyTargets(I sourceId, String fieldName, QuerySpec querySpec) {
-		HttpUrl url = HttpUrl.parse(urlBuilder.buildUrl(sourceClass, sourceId, querySpec, fieldName));
+		String url = urlBuilder.buildUrl(sourceClass, sourceId, querySpec, fieldName);
 		BaseResponseContext responseContext = executeGet(url);
 		return toList(responseContext.getResponse());
 	}
 
-	private void execute(HttpUrl requestUrl, String method, Object targetIds) {
+	private void execute(String requestUrl, HttpMethod method, Object targetIds) {
 		JsonPath fieldPath = new ResourcePath(resourceInformation.getResourceType());
 
 		JsonApiResponse response = new JsonApiResponse();
@@ -143,9 +140,7 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 			throw new IllegalStateException(e);
 		}
 
-		Builder builder = new Request.Builder().url(requestUrl);
-		builder = builder.method(method, RequestBody.create(null, requestBodyValue));
-		execute(builder, false);
+		execute(requestUrl, false, method, requestBodyValue);
 	}
 
 	@Override

--- a/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
@@ -37,11 +37,16 @@ public abstract class AbstractClientTest extends JerseyTest {
 		client = new KatharsisClient(getBaseUri().toString());
 		client.addModule(new TestModule());
 		client.setActionStubFactory(JerseyActionStubFactory.newInstance());
+		setupClient(client);
 
 		TaskRepository.clear();
 		ProjectRepository.clear();
 		TaskToProjectRepository.clear();
 		ScheduleRepositoryImpl.clear();
+	}
+
+	protected void setupClient(KatharsisClient client) {
+
 	}
 
 	@Override
@@ -56,7 +61,7 @@ public abstract class AbstractClientTest extends JerseyTest {
 	protected void setupFeature(KatharsisTestFeature feature) {
 		// nothing to do
 	}
-	
+
 	@ApplicationPath("/")
 	public class TestApplication extends ResourceConfig {
 
@@ -76,12 +81,11 @@ public abstract class AbstractClientTest extends JerseyTest {
 			}
 
 			feature.addModule(new TestModule());
-			
+
 			setupFeature(feature);
 
 			register(feature);
 		}
-
 
 		public KatharsisFeature getFeature() {
 			return feature;

--- a/katharsis-client/src/test/java/io/katharsis/client/ApacheHttpClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ApacheHttpClientTest.java
@@ -1,0 +1,12 @@
+package io.katharsis.client;
+
+import io.katharsis.client.http.apache.HttpClientAdapter;
+
+public class ApacheHttpClientTest extends QuerySpecClientTest {
+
+	@Override
+	protected void setupClient(KatharsisClient client) {
+		super.setupClient(client);
+		client.setHttpAdapter(HttpClientAdapter.newInstance());
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/OkHttpClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/OkHttpClientTest.java
@@ -1,0 +1,12 @@
+package io.katharsis.client;
+
+import io.katharsis.client.http.okhttp.OkHttpAdapter;
+
+public class OkHttpClientTest extends QuerySpecClientTest {
+
+	@Override
+	protected void setupClient(KatharsisClient client) {
+		super.setupClient(client);
+		client.setHttpAdapter(OkHttpAdapter.newInstance());
+	}
+}

--- a/katharsis-jpa/pom.xml
+++ b/katharsis-jpa/pom.xml
@@ -136,6 +136,13 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>javax.ws.rs</groupId>

--- a/katharsis-parent/pom.xml
+++ b/katharsis-parent/pom.xml
@@ -52,6 +52,14 @@
         <coveralls-maven-plugin.version>4.2.0</coveralls-maven-plugin.version>
         <gitlog-maven-plugin.version>1.12.3</gitlog-maven-plugin.version>
         <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
+        
+        <okhttp.version>3.4.1</okhttp.version>
+        <httpclient.version>4.5.2</httpclient.version>
+		<jersey.version>2.17</jersey.version>
+		
+		<brave.version>3.14.1</brave.version>
+		<javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
+		<guava.version>15.0</guava.version>
 
         <gpg.passphrase />
         <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>

--- a/katharsis-validation/pom.xml
+++ b/katharsis-validation/pom.xml
@@ -108,6 +108,13 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
- make okhttp dependency optional
- let consumer choose implementation
- let KatharsisClient auto-detect implementation
- support tracing for both clients
- OkHttpAdapter implementation
- HttpClientAdapter implementation
- adapter can also be set manually on KatharsisClient