### PR TITLE
#193 QuerySpec custom fields in filter

### DIFF
--- a/katharsis-client/src/test/java/io/katharsis/client/QuerySpecUnknownAttributeClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/QuerySpecUnknownAttributeClientTest.java
@@ -1,0 +1,77 @@
+package io.katharsis.client;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.katharsis.client.mock.models.Project;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.queryspec.DefaultQuerySpecDeserializer;
+import io.katharsis.queryspec.Direction;
+import io.katharsis.queryspec.FilterOperator;
+import io.katharsis.queryspec.FilterSpec;
+import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.queryspec.SortSpec;
+
+public class QuerySpecUnknownAttributeClientTest extends AbstractClientTest {
+
+	protected QuerySpecResourceRepositoryStub<Task, Long> taskRepo;
+
+	protected QuerySpecResourceRepositoryStub<Project, Long> projectRepo;
+
+	protected QuerySpecRelationshipRepositoryStub<Task, Long, Project, Long> relRepo;
+
+	private DefaultQuerySpecDeserializer deserializer;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		taskRepo = client.getQuerySpecRepository(Task.class);
+		projectRepo = client.getQuerySpecRepository(Project.class);
+		relRepo = client.getQuerySpecRepository(Task.class, Project.class);
+	}
+
+	@Override
+	protected TestApplication configure() {
+		TestApplication app = new TestApplication(true);
+		deserializer = (DefaultQuerySpecDeserializer) app.getFeature().getQuerySpecDeserializer();
+		deserializer.setAllowUnknownAttributes(true);
+		return app;
+	}
+
+	@Test
+	public void testCall() {
+		QuerySpec querySpec = new QuerySpec(Task.class);
+		querySpec.addSort(new SortSpec(Arrays.asList("unknownAttr"), Direction.ASC));
+		querySpec.addFilter(new FilterSpec(Arrays.asList("unknownAttr"), FilterOperator.EQ, "test"));
+		List<Task> tasks = taskRepo.findAll(querySpec);
+		Assert.assertEquals(0, tasks.size()); // no matches naturally...
+	}
+
+	@Test
+	public void testDeserialize() {
+		Map<String, Set<String>> parameterMap = new HashMap<>();
+		parameterMap.put("filter[unknownAttr]", Collections.singleton("test"));
+		parameterMap.put("sort", Collections.singleton("-unknownAttr"));
+		QuerySpec querySpec = deserializer.deserialize(Task.class, parameterMap);
+		Assert.assertEquals(1, querySpec.getFilters().size());
+		FilterSpec filterSpec = querySpec.getFilters().get(0);
+		Assert.assertEquals("unknownAttr", filterSpec.getAttributePath().get(0));
+		Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
+		Assert.assertEquals("test", filterSpec.getValue());
+
+		Assert.assertEquals(1, querySpec.getSort().size());
+		SortSpec sortSpec = querySpec.getSort().get(0);
+		Assert.assertEquals("unknownAttr", sortSpec.getAttributePath().get(0));
+		Assert.assertEquals(Direction.DESC, sortSpec.getDirection());
+	}
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/DefaultQuerySpecDeserializer.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/DefaultQuerySpecDeserializer.java
@@ -14,6 +14,7 @@ import io.katharsis.jackson.exception.ParametersDeserializationException;
 import io.katharsis.resource.RestrictedQueryParamsMembers;
 import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.utils.PropertyException;
 import io.katharsis.utils.PropertyUtils;
 import io.katharsis.utils.parser.TypeParser;
 
@@ -40,6 +41,8 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 
 	private ResourceRegistry resourceRegistry;
 
+	private boolean allowUnknownAttributes = false;
+
 	public DefaultQuerySpecDeserializer() {
 		supportedOperators.add(FilterOperator.LIKE);
 		supportedOperators.add(FilterOperator.EQ);
@@ -48,6 +51,14 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 		supportedOperators.add(FilterOperator.GE);
 		supportedOperators.add(FilterOperator.LT);
 		supportedOperators.add(FilterOperator.LE);
+	}
+
+	public boolean getAllowUnknownAttributes() {
+		return allowUnknownAttributes;
+	}
+
+	public void setAllowUnknownAttributes(boolean allowUnknownAttributes) {
+		this.allowUnknownAttributes = allowUnknownAttributes;
 	}
 
 	public long getDefaultOffset() {
@@ -203,7 +214,7 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 			filterOp = defaultOperator;
 		}
 
-		Class<?> attributeType = PropertyUtils.getPropertyClass(querySpec.getResourceClass(), attributePath);
+		Class<?> attributeType = getAttributeType(querySpec, attributePath);
 		Set<Object> typedValues = new HashSet<>();
 		for (String stringValue : parameter.values) {
 			@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -213,6 +224,20 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 		Object value = typedValues.size() == 1 ? typedValues.iterator().next() : typedValues;
 
 		querySpec.addFilter(new FilterSpec(attributePath, filterOp, value));
+	}
+
+	private Class<?> getAttributeType(QuerySpec querySpec, List<String> attributePath) {
+		try {
+			return PropertyUtils.getPropertyClass(querySpec.getResourceClass(), attributePath);
+		}
+		catch (PropertyException e) {
+			if (allowUnknownAttributes) {
+				return String.class;
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	private void deserializeSort(QuerySpec querySpec, Parameter parameter) {

--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFeature.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFeature.java
@@ -156,4 +156,8 @@ public class KatharsisFeature implements Feature {
 	public void setDefaultPageLimit(Long defaultPageLimit){
 		boot.setDefaultPageLimit(defaultPageLimit);
 	}
+
+	public QuerySpecDeserializer getQuerySpecDeserializer() {
+		return boot.getQuerySpecDeserializer();
+	}
 }


### PR DESCRIPTION
introduced flag with setAllowUnknownAttributes to DefaultQuerySpecDeserializer to ignore unknown attributes. 

e.g. 

deserializer = (DefaultQuerySpecDeserializer) katharsisFeature.getQuerySpecDeserializer();
deserializer.setAllowUnknownAttributes(true);