### PR TITLE
#221 Support lazy proxies for katharsis-client

### DIFF
--- a/katharsis-client/src/main/java/io/katharsis/client/internal/AbstractStub.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/AbstractStub.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.client.ClientException;
@@ -25,6 +28,8 @@ import io.katharsis.utils.JsonApiUrlBuilder;
 import io.katharsis.utils.java.Optional;
 
 public class AbstractStub {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStub.class);
 
 	public static final String CONTENT_TYPE = "application/vnd.api+json";
 
@@ -63,8 +68,14 @@ public class AbstractStub {
 	protected BaseResponseContext execute(String url, boolean getResponse, HttpMethod method, String requestBody) {
 		try {
 
+
 			HttpAdapter httpAdapter = katharsis.getHttpAdapter();
 			HttpAdapterRequest request = httpAdapter.newRequest(url, method, requestBody);
+			
+			LOGGER.debug("requesting {} {}", method, url);
+			if(requestBody != null){
+				LOGGER.debug("request body: {}", requestBody);
+			}
 
 			request.header("Content-Type", CONTENT_TYPE);
 			request.header("Accept", CONTENT_TYPE);
@@ -75,6 +86,7 @@ public class AbstractStub {
 			}
 
 			String body = response.body();
+			LOGGER.debug("response body: {}", body);
 			ObjectMapper objectMapper = katharsis.getObjectMapper();
 			if (getResponse) {
 				return objectMapper.readValue(body, BaseResponseContext.class);

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/ClientDataLinksContainerSerializer.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/ClientDataLinksContainerSerializer.java
@@ -1,0 +1,29 @@
+package io.katharsis.client.internal;
+
+import io.katharsis.client.internal.proxy.ObjectProxy;
+import io.katharsis.jackson.serializer.DataLinksContainerSerializer;
+import io.katharsis.resource.field.ResourceField;
+import io.katharsis.response.DataLinksContainer;
+import io.katharsis.utils.PropertyUtils;
+
+public class ClientDataLinksContainerSerializer extends DataLinksContainerSerializer {
+
+	@Override
+	protected boolean getIncludeRelationshipData(DataLinksContainer dataLinksContainer, ResourceField field) {
+		// we include relationship data if it is not lazy
+		boolean shouldForceFieldInclusion = super.getIncludeRelationshipData(dataLinksContainer, field);
+		if (shouldForceFieldInclusion) {
+			return true;
+		}
+
+		// we also include relationship data if it is not null and not a unloaded proxy
+		Object relationshipValue = PropertyUtils.getProperty(dataLinksContainer.getData(), field.getUnderlyingName());
+
+		if (relationshipValue instanceof ObjectProxy) {
+			return ((ObjectProxy) relationshipValue).isLoaded();
+		}
+		else {
+			return relationshipValue != null;
+		}
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/ClientJsonApiModuleBuilder.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/ClientJsonApiModuleBuilder.java
@@ -1,0 +1,35 @@
+package io.katharsis.client.internal;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.katharsis.jackson.serializer.BaseResponseSerializer;
+import io.katharsis.jackson.serializer.ContainerSerializer;
+import io.katharsis.jackson.serializer.ErrorResponseSerializer;
+import io.katharsis.jackson.serializer.LinkageContainerSerializer;
+import io.katharsis.jackson.serializer.RelationshipContainerSerializer;
+import io.katharsis.resource.registry.ResourceRegistry;
+
+public class ClientJsonApiModuleBuilder {
+
+	public static final String JSON_API_MODULE_NAME = "JsonApiClientModule";
+
+	/**
+	 * Creates Katharsis Jackson module with all required serializers
+	 *
+	 * @param resourceRegistry initialized registry with all of the required resources
+	 * @param isClient         is katharsis client
+	 * @return {@link com.fasterxml.jackson.databind.Module} with custom serializers
+	 */
+	public SimpleModule build(ResourceRegistry resourceRegistry, boolean isClient) {
+		SimpleModule simpleModule = new SimpleModule(JSON_API_MODULE_NAME, new Version(1, 0, 0, null, null, null));
+
+		simpleModule.addSerializer(new ContainerSerializer(resourceRegistry, isClient))
+				.addSerializer(new ClientDataLinksContainerSerializer())
+				.addSerializer(new RelationshipContainerSerializer(resourceRegistry, isClient))
+				.addSerializer(new LinkageContainerSerializer()).addSerializer(new BaseResponseSerializer(resourceRegistry))
+				.addSerializer(new ErrorResponseSerializer());
+
+		return simpleModule;
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/ResourceRepositoryStubImpl.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/ResourceRepositoryStubImpl.java
@@ -170,7 +170,7 @@ public class ResourceRepositoryStubImpl<T, I extends Serializable> extends Abstr
 		return findAll(url);
 	}
 
-	private DefaultResourceList<T> findAll(String url) {
+	public DefaultResourceList<T> findAll(String url) {
 		BaseResponseContext responseContext = executeGet(url);
 		if (responseContext instanceof CollectionResponseContext) {
 			CollectionResponseContext colResponseContext = (CollectionResponseContext) responseContext;

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/BasicProxyFactory.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/BasicProxyFactory.java
@@ -1,0 +1,82 @@
+package io.katharsis.client.internal.proxy;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.list.DefaultResourceList;
+import io.katharsis.resource.list.ResourceList;
+import io.katharsis.resource.registry.RegistryEntry;
+import io.katharsis.resource.registry.ResourceRegistry;
+import io.katharsis.utils.ClassUtils;
+import io.katharsis.utils.WrappedList;
+
+/**
+ * Basic implementation of {@link ClientProxyFactory}.
+ * 
+ * Note that resources are not really proxied with this implementation. No lazy-loading is happending. Instead, just the ID is set on an empty resource.
+ * Collections are fully proxied and get loaded when accessed.
+ *
+ */
+public class BasicProxyFactory implements ClientProxyFactory {
+
+	private ClientProxyFactoryContext context;
+
+	private Constructor<?> listConstructor;
+
+	private Constructor<?> setConstructor;
+
+	@Override
+	public void init(ClientProxyFactoryContext context) {
+		this.context = context;
+
+		ClassLoader loader = getClass().getClassLoader();
+
+		listConstructor = Proxy.getProxyClass(loader, ObjectProxy.class, ResourceList.class).getConstructors()[0];
+		setConstructor = Proxy.getProxyClass(loader, ObjectProxy.class, Set.class).getConstructors()[0];
+	}
+
+	@Override
+	public <T> T createResourceProxy(Class<T> clazz, Object id, String url) {
+		T instance = ClassUtils.newInstance(clazz);
+
+		ResourceRegistry resourceRegistry = context.getModuleRegistry().getResourceRegistry();
+		RegistryEntry<T> entry = resourceRegistry.getEntry(clazz);
+		ResourceInformation resourceInformation = entry.getResourceInformation();
+		resourceInformation.setId(instance, id);
+
+		return instance;
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public <C extends Collection<T>, T> C createCollectionProxy(Class<T> resourceClass, Class<C> collectionClass, String url) {
+
+		boolean useSet = Set.class.isAssignableFrom(collectionClass);
+		InvocationHandler handler = new CollectionInvocationHandler(resourceClass, url, context, useSet);
+
+		final Constructor<?> constructor = useSet ? setConstructor : listConstructor;
+
+		try {
+			Collection lazyCollection = (Collection) constructor.newInstance(handler);
+			boolean isCustomClass = WrappedList.class.isAssignableFrom(collectionClass);
+			if (isCustomClass) {
+				WrappedList collectionImpl = (WrappedList) collectionClass.newInstance();
+				collectionImpl.setWrappedList((List) lazyCollection);
+				return (C) collectionImpl;
+			}
+			else {
+				return (C) lazyCollection;
+			}
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/ClientProxyFactory.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/ClientProxyFactory.java
@@ -1,0 +1,15 @@
+package io.katharsis.client.internal.proxy;
+
+import java.util.Collection;
+
+/**
+ * Used to create stubs for resources, collections and interfaces.
+ */
+public interface ClientProxyFactory {
+
+	public void init(ClientProxyFactoryContext context);
+
+	<T> T createResourceProxy(Class<T> clazz, Object id, String url);
+
+	<C extends Collection<T>, T> C createCollectionProxy(Class<T> resourceClass, Class<C> collectionClass, String url);
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/ClientProxyFactoryContext.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/ClientProxyFactoryContext.java
@@ -1,0 +1,12 @@
+package io.katharsis.client.internal.proxy;
+
+import io.katharsis.module.ModuleRegistry;
+import io.katharsis.resource.list.DefaultResourceList;
+
+public interface ClientProxyFactoryContext {
+
+	ModuleRegistry getModuleRegistry();
+
+	<T> DefaultResourceList<T> getCollection(Class<T> resourceClass, String url);
+
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/CollectionInvocationHandler.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/CollectionInvocationHandler.java
@@ -1,0 +1,56 @@
+package io.katharsis.client.internal.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+
+public class CollectionInvocationHandler implements InvocationHandler, ObjectProxy {
+
+	private Collection<?> collection;
+
+	private String url;
+
+	private Class<?> resourceClass;
+
+	private ClientProxyFactoryContext context;
+
+	private boolean useSet;
+
+	public CollectionInvocationHandler(Class<?> resourceClass, String url, ClientProxyFactoryContext context, boolean useSet) {
+		this.url = url;
+		this.resourceClass = resourceClass;
+		this.context = context;
+		this.useSet = useSet;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		if (method.getDeclaringClass() == Object.class || method.getDeclaringClass() == ObjectProxy.class) {
+			return method.invoke(this, args);
+		}
+		if (collection == null) {
+			synchronized (this) {
+				if (collection == null) {
+					collection = context.getCollection(resourceClass, url);
+
+					// convert list to set
+					if (useSet) {
+						collection = new HashSet<>(collection);
+					}
+				}
+			}
+		}
+		return method.invoke(collection, args);
+	}
+
+	@Override
+	public String getUrl() {
+		return url;
+	}
+
+	@Override
+	public boolean isLoaded() {
+		return collection != null;
+	}
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/ObjectProxy.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/ObjectProxy.java
@@ -1,0 +1,8 @@
+package io.katharsis.client.internal.proxy;
+
+public interface ObjectProxy {
+
+	public String getUrl();
+
+	public boolean isLoaded();
+}

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/PrimitiveProxy.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/PrimitiveProxy.java
@@ -1,0 +1,6 @@
+package io.katharsis.client.internal.proxy;
+
+
+public interface PrimitiveProxy {
+
+}

--- a/katharsis-client/src/test/java/io/katharsis/ProxyInvocationHandler.java
+++ b/katharsis-client/src/test/java/io/katharsis/ProxyInvocationHandler.java
@@ -1,0 +1,69 @@
+//package io.katharsis;
+//
+//import java.lang.reflect.InvocationHandler;
+//import java.lang.reflect.Method;
+//
+//import io.katharsis.ResourceProxyFactory.ResourceProxy;
+//import io.katharsis.resource.field.ResourceField;
+//
+//public class ProxyInvocationHandler implements InvocationHandler {
+//	
+//
+//
+//	@Override
+//	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+//
+//		if (method.getDeclaringClass() == Object.class) {
+//			return invokeObjectMethod(proxy, method, args);
+//		}
+//		else if (method.getDeclaringClass() == ResourceProxy.class) {
+//			return invokeProxyMethod(proxy, method, args);
+//		}
+//
+//		return invokeBeanMethod(proxy, method, args);
+//	}
+//
+//	private Object invokeBeanMethod(Object proxy, Method method, Object[] args) {
+//		String name = getPropertyName(method);
+//
+//		
+//
+//		System.out.println(method);
+//		return null;
+//	}
+//
+//	private String getPropertyName(Method method) {
+//		String name = method.getName();
+//		if (name.startsWith("is")) {
+//			return Character.toLowerCase(name.charAt(2)) + name.substring(2);
+//		}
+//		else if (name.startsWith("set") || name.startsWith("get") || name.startsWith("has")) {
+//			return Character.toLowerCase(name.charAt(3)) + name.substring(3);
+//		}
+//		throw new IllegalStateException(method.toString());
+//	}
+//
+//	private Object invokeObjectMethod(Object proxy, Method method, Object[] args) {
+//		if (method.getName().equals("equals")) {
+//			Object otherObject = args[0];
+//			return otherObject == proxy;
+//		}
+//		if (method.getName().equals("toString")) {
+//			return resourceClass.getName() + "$" + "[" + url + "]";
+//		}
+//		if (method.getName().equals("hashCode")) {
+//			return url.hashCode();
+//		}
+//		throw new IllegalStateException(method.toString());
+//	}
+//
+//	private Object invokeProxyMethod(Object proxy, Method method, Object[] args) {
+//					if (method.getName().equals("getUrl")) {
+//						return url;
+//					}
+//					if (method.getName().equals("getUrl")) {
+//						return url;
+//					}
+//					throw new IllegalStateException(method.toString());
+//				}
+//}}

--- a/katharsis-client/src/test/java/io/katharsis/ResourceProxyFactory.java
+++ b/katharsis-client/src/test/java/io/katharsis/ResourceProxyFactory.java
@@ -1,0 +1,108 @@
+//package io.katharsis;
+//
+//import java.lang.reflect.Method;
+//import java.util.List;
+//
+//import io.katharsis.client.mock.models.Task;
+//import io.katharsis.resource.field.ResourceFieldNameTransformer;
+//import io.katharsis.resource.information.AnnotationResourceInformationBuilder;
+//import io.katharsis.resource.information.ResourceInformation;
+//import nl.jqno.equalsverifier.internal.cglib.proxy.Enhancer;
+//
+//public class ResourceProxyFactory {
+//
+//	public static void main(String[] args) {
+//		ResourceProxyFactory factory = new ResourceProxyFactory();
+//
+//		AnnotationResourceInformationBuilder informationBuilder = new AnnotationResourceInformationBuilder(
+//				new ResourceFieldNameTransformer());
+//		ResourceInformation information = informationBuilder.build(Task.class);
+//
+//		Task task = factory.createResourceProxy(Task.class, information, 12, "http://");
+//
+//		System.out.println(task);
+//
+//		ResourceProxy proxy = (ResourceProxy) task;
+//		System.out.println(proxy.getResourceUrl());
+//
+//	}
+//
+//	public interface ResourceProxy {
+//
+//		public Object getResourceId();
+//
+//		public String getResourceUrl();
+//
+//		public Object getResourceObject();
+//
+//		public void setResourceId(Object id);
+//
+//		public void setResourceUrl(String url);
+//
+//		public void setResourceObject(Object object);
+//	}
+//
+//	@SuppressWarnings("unchecked")
+//	public <T> T createResourceProxy(final Class<T> resourceClass, final ResourceInformation information, final Object id,
+//			final String url) {
+//
+//		Enhancer enhancer = new Enhancer();
+//		enhancer.setSuperclass(resourceClass);
+//
+//		enhancer.setInterfaces(new Class[] { ResourceProxy.class });
+//
+////		enhancer.setCallbackFilter(filter);
+////		
+////		enhancer.setCallback(new MethodInterceptor() {
+////
+////			@Override
+////			public Object invoke(Object arg0, Method arg1, Object[] arg2) throws Throwable {
+////				// TODO Auto-generated method stub
+////				return null;
+////			}
+////		});
+//
+//		//Class<T> dynamicType = enhancer.createClass();
+//
+//		//		ByteBuddy byteBuddy = new ByteBuddy();
+//		//		Builder<T> subclass = byteBuddy.subclass(resourceClass);
+//		//
+//		//		subclass = subclass.implement(ResourceProxy.class);
+//		//		subclass = subclass.name(resourceClass.getName() + "$");
+//		//
+//		//		String idName = information.getIdField().getUnderlyingName();
+//		//		Junction<MethodDescription> and = ElementMatchers.any()
+//		//				.and(ElementMatchers.not(ElementMatchers.isDeclaredByGeneric(ResourceProxy.class)))
+//		//				.and(ElementMatchers.not(ElementMatchers.isGetter(idName)));
+//		//		ImplementationDefinition<T> anyMethod = subclass.method(and);
+//		//
+//		//		subclass = anyMethod.intercept(InvocationHandlerAdapter.of(new ProxyInvocationHandler()));
+//		//
+//		//		subclass = subclass.defineField("$resourceObject", Object.class, 0);
+//		//		subclass = subclass.defineField("$resourceUrl", String.class, 0);
+//		//		subclass = subclass.defineField("$resourceId", Object.class, 0);
+//		//		subclass = subclass.method(ElementMatchers.named("getResourceId")).intercept(FieldAccessor.ofField("$resourceId"));
+//		//		subclass = subclass.method(ElementMatchers.named("setResourceId")).intercept(FieldAccessor.ofField("$resourceId"));
+//		//		subclass = subclass.method(ElementMatchers.named("getResourceUrl")).intercept(FieldAccessor.ofField("$resourceUrl"));
+//		//		subclass = subclass.method(ElementMatchers.named("setResourceUrl")).intercept(FieldAccessor.ofField("$resourceUrl"));
+//		//		subclass = subclass.method(ElementMatchers.named("getResourcObject")).intercept(FieldAccessor.ofField("$resourceObject"));
+//		//		subclass = subclass.method(ElementMatchers.isGetter(idName)).intercept(FieldAccessor.ofField("$resourceId"));
+//		//Class<T> dynamicType = (Class<T>) subclass.make().load(getClass().getClassLoader()).getLoaded();
+//
+//		try {
+//			T resource = dynamicType.newInstance();
+//			ResourceProxy proxy = (ResourceProxy) resource;
+//			proxy.setResourceId(id);
+//			proxy.setResourceUrl(url);
+//			return resource;
+//		}
+//		catch (InstantiationException | IllegalAccessException e) {
+//			throw new IllegalStateException(e);
+//		}
+//	}
+//
+//	public <T> List<T> createListProxy(Class<T> resourceClass, String url) {
+//		return null;
+//	}
+//
+//}

--- a/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
@@ -1,6 +1,7 @@
 package io.katharsis.client;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.MultivaluedMap;
@@ -37,6 +38,7 @@ public abstract class AbstractClientTest extends JerseyTest {
 		client = new KatharsisClient(getBaseUri().toString());
 		client.addModule(new TestModule());
 		client.setActionStubFactory(JerseyActionStubFactory.newInstance());
+		client.getHttpAdapter().setReceiveTimeout(10000000, TimeUnit.MILLISECONDS);
 		setupClient(client);
 
 		TaskRepository.clear();
@@ -69,7 +71,6 @@ public abstract class AbstractClientTest extends JerseyTest {
 
 		public TestApplication(boolean querySpec) {
 			property(KatharsisProperties.RESOURCE_SEARCH_PACKAGE, "io.katharsis.client.mock");
-			property(KatharsisProperties.RESOURCE_DEFAULT_DOMAIN, "http://test.local");
 
 			if (!querySpec) {
 				feature = new KatharsisTestFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()),

--- a/katharsis-client/src/test/java/io/katharsis/client/ProxiedObjectsClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ProxiedObjectsClientTest.java
@@ -1,0 +1,198 @@
+package io.katharsis.client;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.katharsis.client.internal.proxy.ObjectProxy;
+import io.katharsis.client.mock.models.Project;
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.queryspec.QuerySpec;
+
+public class ProxiedObjectsClientTest extends AbstractClientTest {
+
+	protected QuerySpecResourceRepositoryStub<Task, Long> taskRepo;
+
+	protected QuerySpecResourceRepositoryStub<Project, Long> projectRepo;
+
+	protected QuerySpecRelationshipRepositoryStub<Task, Long, Project, Long> relRepo;
+
+	private QuerySpecResourceRepositoryStub<Schedule, Long> scheduleRepo;
+
+	private QuerySpecRelationshipRepositoryStub<Schedule, Serializable, Task, Serializable> scheduleTaskRepo;
+
+	private QuerySpecRelationshipRepositoryStub<Task, Serializable, Schedule, Serializable> taskScheduleRepo;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		client.setPushAlways(false);
+
+		scheduleRepo = client.getQuerySpecRepository(Schedule.class);
+		taskRepo = client.getQuerySpecRepository(Task.class);
+		projectRepo = client.getQuerySpecRepository(Project.class);
+		relRepo = client.getQuerySpecRepository(Task.class, Project.class);
+		scheduleTaskRepo = client.getQuerySpecRepository(Schedule.class, Task.class);
+		taskScheduleRepo = client.getQuerySpecRepository(Task.class, Schedule.class);
+	}
+
+	@Override
+	protected TestApplication configure() {
+		return new TestApplication(false);
+	}
+
+	@Test
+	public void noProxyForLazy() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("project");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		taskRepo.create(task);
+
+		scheduleTaskRepo.setRelation(schedule, task.getId(), "lazyTask");
+
+		QuerySpec querySpec = new QuerySpec(Task.class);
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		Task proxiedObject = schedule.getLazyTask();
+		Assert.assertNull(proxiedObject);
+
+	}
+
+	@Test
+	public void proxyForNoneLazy() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("project");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		taskRepo.create(task);
+
+		scheduleTaskRepo.setRelation(schedule, task.getId(), "task");
+
+		QuerySpec querySpec = new QuerySpec(Task.class);
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		Task proxiedObject = schedule.getTask();
+		Assert.assertNotNull(proxiedObject);
+		Assert.assertEquals(2L, proxiedObject.getId().longValue());
+		Assert.assertNull(proxiedObject.getName());
+
+	}
+
+	@Test
+	public void proxyForLazySet() {
+		proxyForCollection(true);
+	}
+
+	@Test
+	public void proxyForLazyList() {
+		proxyForCollection(false);
+	}
+
+	private void proxyForCollection(boolean set) {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("project");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		taskRepo.create(task);
+
+		taskScheduleRepo.setRelation(task, schedule.getId(), "schedule");
+
+		// collection must be available as proxy
+		QuerySpec querySpec = new QuerySpec(Task.class);
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		Collection<Task> proxiedTasks = set ? schedule.getTasks() : schedule.getTasksList();
+		Assert.assertNotNull(proxiedTasks);
+
+		// check status without loading
+		ObjectProxy proxy = (ObjectProxy) proxiedTasks;
+		Assert.assertFalse(proxy.isLoaded());
+		Assert.assertNotNull(proxy.getUrl());
+		Assert.assertFalse(proxy.isLoaded());
+
+		// lazy load
+		Assert.assertEquals(1, proxiedTasks.size());
+		Assert.assertTrue(proxy.isLoaded());
+		task = proxiedTasks.iterator().next();
+		Assert.assertEquals(2L, task.getId().longValue());
+	}
+
+	@Test
+	public void saveDoesNotTriggerLazyLoad() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("project");
+		scheduleRepo.create(schedule);
+
+		QuerySpec querySpec = new QuerySpec(Schedule.class);
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		Collection<Task> proxiedTasks = schedule.getTasks();
+		ObjectProxy proxy = (ObjectProxy) proxiedTasks;
+		Assert.assertFalse(proxy.isLoaded());
+
+		// update primitive field
+		schedule.setName("newValue");
+		scheduleRepo.save(schedule);
+
+		// save should not trigger a load of the relation
+		Assert.assertFalse(proxy.isLoaded());
+		Assert.assertSame(proxy, schedule.getTasks());
+
+		// data should be saved
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		Assert.assertEquals("newValue", schedule.getName());
+	}
+
+	@Test
+	public void saveLazyCollectionChange() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("project");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		taskRepo.create(task);
+
+		QuerySpec querySpec = new QuerySpec(Task.class);
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		Collection<Task> proxiedTasks = schedule.getTasks();
+		ObjectProxy proxy = (ObjectProxy) proxiedTasks;
+		Assert.assertFalse(proxy.isLoaded());
+
+		// add task to collection
+		proxiedTasks.add(task);
+		Assert.assertTrue(proxy.isLoaded());
+		Assert.assertEquals(1, proxiedTasks.size());
+		scheduleRepo.save(schedule);
+
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		proxiedTasks = schedule.getTasks();
+		Assert.assertEquals(1, proxiedTasks.size());
+
+		// remove task from collection
+		proxiedTasks.remove(task);
+		Assert.assertEquals(1, proxiedTasks.size());
+		scheduleRepo.save(schedule);
+
+		schedule = scheduleRepo.findOne(1L, querySpec);
+		proxiedTasks = schedule.getTasks();
+		Assert.assertEquals(1, proxiedTasks.size());
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/QuerySpecClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/QuerySpecClientTest.java
@@ -34,15 +34,24 @@ public class QuerySpecClientTest extends AbstractClientTest {
 
 	protected QuerySpecResourceRepositoryStub<Project, Long> projectRepo;
 
+	protected QuerySpecResourceRepositoryStub<Schedule, Long> scheduleRepo;
+
 	protected QuerySpecRelationshipRepositoryStub<Task, Long, Project, Long> relRepo;
+
+	protected QuerySpecRelationshipRepositoryStub<Schedule, Long, Task, Long> scheduleTaskRepo;
+
+	protected QuerySpecRelationshipRepositoryStub<Task, Long, Schedule, Long> taskScheduleRepo;
 
 	@Before
 	public void setup() {
 		super.setup();
 
+		scheduleRepo = client.getQuerySpecRepository(Schedule.class);
 		taskRepo = client.getQuerySpecRepository(Task.class);
 		projectRepo = client.getQuerySpecRepository(Project.class);
 		relRepo = client.getQuerySpecRepository(Task.class, Project.class);
+		scheduleTaskRepo = client.getQuerySpecRepository(Schedule.class, Task.class);
+		taskScheduleRepo = client.getQuerySpecRepository(Task.class, Schedule.class);
 	}
 
 	@Override
@@ -247,23 +256,117 @@ public class QuerySpecClientTest extends AbstractClientTest {
 	}
 
 	@Test
-	@Ignore // get rid of queryparams
 	public void testSetRelation() {
-		Project project = new Project();
-		project.setId(1L);
-		project.setName("project");
-		projectRepo.create(project);
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("schedule");
+		scheduleRepo.create(schedule);
 
 		Task task = new Task();
 		task.setId(2L);
 		task.setName("test");
 		taskRepo.create(task);
 
-		relRepo.setRelation(task, project.getId(), "project");
+		relRepo.setRelation(task, schedule.getId(), "schedule");
 
-		Project relProject = relRepo.findOneTarget(task.getId(), "project", new QuerySpec(Task.class));
-		Assert.assertNotNull(relProject);
-		Assert.assertEquals(project.getId(), relProject.getId());
+		Schedule relSchedule = taskScheduleRepo.findOneTarget(task.getId(), "schedule", new QuerySpec(Schedule.class));
+		Assert.assertNotNull(relSchedule);
+		Assert.assertEquals(schedule.getId(), relSchedule.getId());
+	}
+
+	@Test
+	public void testSaveRelationWithCreate() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("schedule");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		task.setSchedule(schedule);
+		taskRepo.create(task);
+
+		// check relationship available
+		Task savedTask = taskRepo.findOne(task.getId(), new QuerySpec(Task.class));
+		Assert.assertNotNull(savedTask.getSchedule());
+	}
+
+	@Test
+	public void testNullNonLazyRelationWithSave() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("schedule");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		task.setSchedule(schedule);
+		taskRepo.create(task);
+
+		Task savedTask = taskRepo.findOne(task.getId(), new QuerySpec(Task.class));
+		Assert.assertNotNull(savedTask.getSchedule());
+
+		// null
+		savedTask.setSchedule(null);
+		taskRepo.save(savedTask);
+
+		// relation must be null
+		Task updatedTask = taskRepo.findOne(task.getId(), new QuerySpec(Task.class));
+		Assert.assertNull(updatedTask.getSchedule());
+	}
+
+	@Test
+	public void testCannotNullLazyRelationWithSave() {
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		taskRepo.create(task);
+
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("schedule");
+		schedule.setLazyTask(task);
+		scheduleRepo.create(schedule);
+
+		// since lazy, will not be sent to client if not requested
+		QuerySpec querySpec = new QuerySpec(Schedule.class);
+		Schedule savedSchedule = scheduleRepo.findOne(schedule.getId(), querySpec);
+		Assert.assertNull(savedSchedule.getLazyTask());
+		
+		querySpec.includeRelation(Arrays.asList("lazyTask"));
+		savedSchedule = scheduleRepo.findOne(schedule.getId(), querySpec);
+		Assert.assertNotNull(savedSchedule.getLazyTask());
+
+		// null
+		savedSchedule.setLazyTask(task);
+		scheduleRepo.save(savedSchedule);
+
+		// still not null because cannot differantiate between not loaded and nulled
+		Schedule updatedSchedule = scheduleRepo.findOne(schedule.getId(), querySpec);
+		Assert.assertNotNull(updatedSchedule.getLazyTask());
+	}
+
+	@Test
+	public void testSaveRelationWithSave() {
+		Schedule schedule = new Schedule();
+		schedule.setId(1L);
+		schedule.setName("schedule");
+		scheduleRepo.create(schedule);
+
+		Task task = new Task();
+		task.setId(2L);
+		task.setName("test");
+		taskRepo.create(task);
+
+		Task createdTask = taskRepo.findOne(task.getId(), new QuerySpec(Task.class));
+		Assert.assertNull(createdTask.getSchedule());
+		createdTask.setSchedule(schedule);
+		taskRepo.save(createdTask);
+
+		Task updatedTask = taskRepo.findOne(task.getId(), new QuerySpec(Task.class));
+		Assert.assertNotNull(updatedTask.getSchedule());
 	}
 
 	@Test

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/models/Schedule.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/models/Schedule.java
@@ -1,7 +1,12 @@
 package io.katharsis.client.mock.models;
 
+import java.util.List;
+import java.util.Set;
+
 import io.katharsis.resource.annotations.JsonApiId;
 import io.katharsis.resource.annotations.JsonApiResource;
+import io.katharsis.resource.annotations.JsonApiToMany;
+import io.katharsis.resource.annotations.JsonApiToOne;
 
 @JsonApiResource(type = "schedules")
 public class Schedule {
@@ -10,6 +15,18 @@ public class Schedule {
 	private Long id;
 
 	private String name;
+
+	@JsonApiToOne(lazy = false)
+	private Task task;
+
+	@JsonApiToOne(lazy = true)
+	private Task lazyTask;
+
+	@JsonApiToMany(opposite = "schedule")
+	private Set<Task> tasks;
+
+	@JsonApiToMany(opposite = "schedule")
+	private List<Task> tasksList;
 
 	public Long getId() {
 		return id;
@@ -27,4 +44,37 @@ public class Schedule {
 	public void setName(String name) {
 		this.name = name;
 	}
+
+	public Task getTask() {
+		return task;
+	}
+
+	public void setTask(Task task) {
+		this.task = task;
+	}
+
+	public Task getLazyTask() {
+		return lazyTask;
+	}
+
+	public void setLazyTask(Task lazyTask) {
+		this.lazyTask = lazyTask;
+	}
+
+	public Set<Task> getTasks() {
+		return tasks;
+	}
+
+	public void setTasks(Set<Task> tasks) {
+		this.tasks = tasks;
+	}
+
+	public List<Task> getTasksList() {
+		return tasksList;
+	}
+
+	public void setTasksList(List<Task> tasksList) {
+		this.tasksList = tasksList;
+	}
+
 }

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/models/Task.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/models/Task.java
@@ -1,6 +1,8 @@
 package io.katharsis.client.mock.models;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import io.katharsis.resource.annotations.JsonApiId;
 import io.katharsis.resource.annotations.JsonApiIncludeByDefault;
@@ -24,6 +26,9 @@ public class Task {
 	@JsonApiToOne
 	@JsonApiIncludeByDefault
 	private Project project;
+
+	@JsonApiToOne(opposite = "tasks")
+	private Schedule schedule;
 
 	@JsonApiToMany(lazy = false)
 	private List<Project> projects;
@@ -51,6 +56,27 @@ public class Task {
 	public Task setOtherTasks(List<Task> otherTasks) {
 		this.otherTasks = otherTasks;
 		return this;
+	}
+
+	public Schedule getSchedule() {
+		return schedule;
+	}
+
+	public void setSchedule(Schedule schedule) {
+		if (this.schedule != schedule) {
+			if (this.schedule != null) {
+				this.schedule.getTasks().remove(this);
+			}
+			if (schedule != null) {
+				Set<Task> tasks = schedule.getTasks();
+				if (tasks == null) {
+					tasks = new HashSet<>();
+					schedule.setTasks(tasks);
+				}
+				tasks.add(this);
+			}
+			this.schedule = schedule;
+		}
 	}
 
 	public Long getId() {

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
@@ -4,10 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.client.mock.models.Task;
 import io.katharsis.queryspec.QuerySpec;
-import io.katharsis.queryspec.QuerySpecResourceRepositoryBase;
+import io.katharsis.repository.ResourceRepositoryBase;
 
-public class ScheduleRepositoryImpl extends QuerySpecResourceRepositoryBase<Schedule, Long> implements ScheduleRepository {
+public class ScheduleRepositoryImpl extends ResourceRepositoryBase<Schedule, Long> implements ScheduleRepository {
 
 	private static Map<Long, Schedule> schedules = new HashMap<>();
 
@@ -38,6 +39,13 @@ public class ScheduleRepositoryImpl extends QuerySpecResourceRepositoryBase<Sche
 	@Override
 	public <S extends Schedule> S save(S entity) {
 		schedules.put(entity.getId(), entity);
+		
+		if(entity.getTasks() != null){
+			for(Task task : entity.getTasks()){
+				task.setSchedule(entity);
+			}
+		}
+		
 		return null;
 	}
 

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleToTaskRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleToTaskRepository.java
@@ -1,0 +1,13 @@
+package io.katharsis.client.mock.repository;
+
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.queryspec.QuerySpecRelationshipRepositoryBase;
+
+public class ScheduleToTaskRepository extends QuerySpecRelationshipRepositoryBase<Schedule, Long, Task, Long> {
+
+	public ScheduleToTaskRepository() {
+		super(Schedule.class, Task.class);
+	}
+
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/TaskToScheduleRepo.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/TaskToScheduleRepo.java
@@ -1,0 +1,13 @@
+package io.katharsis.client.mock.repository;
+
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.repository.RelationshipRepositoryBase;
+
+public class TaskToScheduleRepo extends RelationshipRepositoryBase<Task, Long, Schedule, Long> {
+
+	public TaskToScheduleRepo() {
+		super(Task.class, Schedule.class);
+	}
+
+}

--- a/katharsis-core/src/main/java/io/katharsis/jackson/JsonApiModuleBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/JsonApiModuleBuilder.java
@@ -29,7 +29,7 @@ public class JsonApiModuleBuilder {
                 new Version(1, 0, 0, null, null, null));
 
         simpleModule.addSerializer(new ContainerSerializer(resourceRegistry, isClient))
-                .addSerializer(new DataLinksContainerSerializer(resourceRegistry))
+                .addSerializer(new DataLinksContainerSerializer())
                 .addSerializer(new RelationshipContainerSerializer(resourceRegistry, isClient))
                 .addSerializer(new LinkageContainerSerializer())
                 .addSerializer(new BaseResponseSerializer(resourceRegistry))

--- a/katharsis-core/src/main/java/io/katharsis/jackson/deserializer/ResourceRelationshipsDeserializer.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/deserializer/ResourceRelationshipsDeserializer.java
@@ -20,40 +20,52 @@ import java.util.Map;
  * @see LinkageData
  */
 public class ResourceRelationshipsDeserializer extends JsonDeserializer<ResourceRelationships> {
-    private static final String DATA_FIELD_NAME = "data";
 
-    @Override
-    public ResourceRelationships deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        JsonNode node = jp.readValueAsTree();
-        if (node == null) {
-            return null;
-        }
-        ResourceRelationships resourceRelationships = new ResourceRelationships();
+	private static final String DATA_FIELD_NAME = "data";
+	
+	private static final String LINKS_FIELD_NAME = "links";
 
-        Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-        while (fields.hasNext()) {
-            Map.Entry<String, JsonNode> field = fields.next();
-            Object value;
-            if (field.getValue() == null) {
-                throw new ParametersDeserializationException("Attribute field cannot be null for: " + field.getKey());
-            } else if (field.getValue().get(DATA_FIELD_NAME) == null) {
-                value = null;
-            } else if (field.getValue().get(DATA_FIELD_NAME).isArray()) {
-                JsonNode fieldData = field.getValue().get(DATA_FIELD_NAME);
-                Iterator<JsonNode> nodeIterator = fieldData.iterator();
-                List<LinkageData> linkageDatas = new LinkedList<>();
+	@Override
+	public ResourceRelationships deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+		JsonNode node = jp.readValueAsTree();
+		if (node == null) {
+			return null;
+		}
+		ResourceRelationships resourceRelationships = new ResourceRelationships();
 
-                while (nodeIterator.hasNext()) {
-                    LinkageData newLinkageData = jp.getCodec().treeToValue(nodeIterator.next(), LinkageData.class);
-                    linkageDatas.add(newLinkageData);
-                }
-                value = linkageDatas;
-            } else {
-                value = jp.getCodec().treeToValue(field.getValue().get(DATA_FIELD_NAME), LinkageData.class);
-            }
-            resourceRelationships.setAdditionalProperty(field.getKey(), value);
-        }
+		Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+		while (fields.hasNext()) {
+			Map.Entry<String, JsonNode> field = fields.next();
+			Object value;
+			if (field.getValue() == null) {
+				throw new ParametersDeserializationException("Attribute field cannot be null for: " + field.getKey());
+			}
 
-        return resourceRelationships;
-    }
+			JsonNode linksNode = field.getValue().get(LINKS_FIELD_NAME);
+			if(linksNode != null){
+				resourceRelationships.setLinks(field.getKey(), linksNode);
+			}
+			JsonNode dataNode = field.getValue().get(DATA_FIELD_NAME);
+			if (dataNode == null) {
+				value = null;
+			}
+			else if (dataNode.isArray()) {
+				Iterator<JsonNode> nodeIterator = dataNode.iterator();
+				List<LinkageData> linkageDatas = new LinkedList<>();
+
+				while (nodeIterator.hasNext()) {
+					LinkageData newLinkageData = jp.getCodec().treeToValue(nodeIterator.next(), LinkageData.class);
+					linkageDatas.add(newLinkageData);
+				}
+				value = linkageDatas;
+			}
+			else {
+				value = jp.getCodec().treeToValue(dataNode, LinkageData.class);
+			}
+
+			resourceRelationships.setAdditionalProperty(field.getKey(), value);
+		}
+
+		return resourceRelationships;
+	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/jackson/serializer/DataLinksContainerSerializer.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/serializer/DataLinksContainerSerializer.java
@@ -1,16 +1,16 @@
 package io.katharsis.jackson.serializer;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+
 import io.katharsis.queryParams.include.Inclusion;
 import io.katharsis.queryParams.params.IncludedRelationsParams;
 import io.katharsis.resource.field.ResourceField;
-import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.response.DataLinksContainer;
 import io.katharsis.response.RelationshipContainer;
-
-import java.io.IOException;
 
 /**
  * Serializes a <i>links</i> field of a resource in data field of JSON API response.
@@ -22,53 +22,51 @@ import java.io.IOException;
  */
 public class DataLinksContainerSerializer extends JsonSerializer<DataLinksContainer> {
 
-    private ResourceRegistry resourceRegistry;
+	@Override
+	public void serialize(DataLinksContainer dataLinksContainer, JsonGenerator gen, SerializerProvider serializers)
+			throws IOException {
+		gen.writeStartObject();
 
-    public DataLinksContainerSerializer(ResourceRegistry resourceRegistry) {
-        this.resourceRegistry = resourceRegistry;
-    }
+		for (ResourceField field : dataLinksContainer.getRelationshipFields()) {
+			boolean includeRelationshipData = getIncludeRelationshipData(dataLinksContainer, field);
+			RelationshipContainer relationshipContainer = new RelationshipContainer(dataLinksContainer, field,
+					includeRelationshipData);
 
-    @Override
-    public void serialize(DataLinksContainer dataLinksContainer, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        gen.writeStartObject();
+			gen.writeObjectField(field.getJsonName(), relationshipContainer);
+		}
 
-        for (ResourceField field : dataLinksContainer.getRelationshipFields()) {
-            boolean forceInclusion = shouldForceFieldInclusion(dataLinksContainer, field);
-            RelationshipContainer relationshipContainer =
-                    new RelationshipContainer(dataLinksContainer, field, forceInclusion);
+		gen.writeEndObject();
+	}
 
-            gen.writeObjectField(field.getJsonName(), relationshipContainer);
-        }
+	protected boolean getIncludeRelationshipData(DataLinksContainer dataLinksContainer, ResourceField field) {
+		return field.getIncludeByDefault() || !field.isLazy()
+				|| isFieldIncluded(dataLinksContainer.getIncludedRelations(), field.getJsonName(), dataLinksContainer);
+	}
 
-        gen.writeEndObject();
-    }
+	protected boolean isFieldIncluded(IncludedRelationsParams includedRelationsParams, String fieldName,
+			DataLinksContainer dataLinksContainer) {
+		if (includedRelationsParams == null || includedRelationsParams.getParams() == null) {
+			return false;
+		}
+		int index = dataLinksContainer.getContainer().getIncludedIndex();
+		for (Inclusion inclusion : includedRelationsParams.getParams()) {
+			if (inclusion.getPathList().size() > index && inclusion.getPathList().get(index).equals(fieldName)) {
+				return true;
+			}
+			else if (dataLinksContainer.getContainer().getAdditionalIndexes() != null) {
+				for (int otherIndexes : dataLinksContainer.getContainer().getAdditionalIndexes()) {
+					if (inclusion.getPathList().size() > otherIndexes
+							&& inclusion.getPathList().get(otherIndexes).equals(fieldName)) {
+						return true;
+					}
+				}
+			}
+		}
 
-    private boolean shouldForceFieldInclusion(DataLinksContainer dataLinksContainer, ResourceField field) {
-        return field.getIncludeByDefault() || !field.isLazy() || isFieldIncluded(dataLinksContainer.getIncludedRelations(), field.getJsonName(), dataLinksContainer);
-    }
+		return false;
+	}
 
-    private boolean isFieldIncluded(IncludedRelationsParams includedRelationsParams, String fieldName, DataLinksContainer dataLinksContainer) {
-        if (includedRelationsParams == null ||
-                includedRelationsParams.getParams() == null) {
-            return false;
-        }
-        int index = dataLinksContainer.getContainer().getIncludedIndex();
-        for (Inclusion inclusion : includedRelationsParams.getParams()) {
-            if (inclusion.getPathList().size() > index && inclusion.getPathList().get(index).equals(fieldName)) {
-                return true;
-            } else if (dataLinksContainer.getContainer().getAdditionalIndexes() != null) {
-                for (int otherIndexes : dataLinksContainer.getContainer().getAdditionalIndexes()) {
-                    if (inclusion.getPathList().size() > otherIndexes && inclusion.getPathList().get(otherIndexes).equals(fieldName)) {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    public Class<DataLinksContainer> handledType() {
-        return DataLinksContainer.class;
-    }
+	public Class<DataLinksContainer> handledType() {
+		return DataLinksContainer.class;
+	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpecRelationshipRepositoryBase.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpecRelationshipRepositoryBase.java
@@ -1,6 +1,7 @@
 package io.katharsis.queryspec;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -105,7 +106,7 @@ public class QuerySpecRelationshipRepositoryBase<T, I extends Serializable, D, J
 		ResourceRepositoryAdapter<T, I> sourceAdapter = getSourceAdapter();
 		Iterable<D> targets = getTargets(targetIds);
 		@SuppressWarnings("unchecked")
-		Collection<D> currentTargets = (Collection<D>) PropertyUtils.getProperty(source, fieldName);
+		Collection<D> currentTargets = getOrCreateCollection(source, fieldName);
 		for (D target : targets) {
 			currentTargets.add(target);
 		}
@@ -117,11 +118,23 @@ public class QuerySpecRelationshipRepositoryBase<T, I extends Serializable, D, J
 		ResourceRepositoryAdapter<T, I> sourceAdapter = getSourceAdapter();
 		Iterable<D> targets = getTargets(targetIds);
 		@SuppressWarnings("unchecked")
-		Collection<D> currentTargets = (Collection<D>) PropertyUtils.getProperty(source, fieldName);
+		Collection<D> currentTargets = getOrCreateCollection(source, fieldName);
 		for (D target : targets) {
 			currentTargets.remove(target);
 		}
 		sourceAdapter.update(source, getSaveQueryAdapter(fieldName));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private Collection<D> getOrCreateCollection(Object source, String fieldName) {
+		 Object property = PropertyUtils.getProperty(source, fieldName);
+		 if(property == null){
+			 Class<?> propertyClass = PropertyUtils.getPropertyClass(source.getClass(), fieldName);
+			 boolean isList = List.class.isAssignableFrom(propertyClass);
+			 property = isList ? new ArrayList() : new HashSet();
+			 PropertyUtils.setProperty(source, fieldName, property);
+		 }
+		return (Collection<D>) property;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpecResourceRepositoryBase.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpecResourceRepositoryBase.java
@@ -20,7 +20,6 @@ import io.katharsis.utils.PreconditionUtil;
  * 
  * @deprecated use ResourceRepositoryBase instead
  */
-@Deprecated
 public abstract class QuerySpecResourceRepositoryBase<T, I extends Serializable>
 		implements QuerySpecResourceRepository<T, I>, ResourceRegistryAware {
 

--- a/katharsis-core/src/main/java/io/katharsis/request/dto/ResourceRelationships.java
+++ b/katharsis-core/src/main/java/io/katharsis/request/dto/ResourceRelationships.java
@@ -1,12 +1,14 @@
 package io.katharsis.request.dto;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.katharsis.jackson.deserializer.ResourceRelationshipsDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.HashMap;
-import java.util.Map;
+import io.katharsis.jackson.deserializer.ResourceRelationshipsDeserializer;
 
 /**
  * @see ResourceRelationshipsDeserializer
@@ -15,14 +17,27 @@ public class ResourceRelationships {
 
     @JsonIgnore
     private final Map<String, Object> linkageList = new HashMap<>();
+    
+    @JsonIgnore
+    private final Map<String, JsonNode> linksMap = new HashMap<>();
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.linkageList;
     }
+    
+    @JsonIgnore
+    public Map<String, JsonNode> getLinks() {
+        return linksMap;
+    }
 
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         this.linkageList.put(name, value);
+    }
+    
+    @JsonIgnore
+    public void setLinks(String name, JsonNode linksNode) {
+        this.linksMap.put(name, linksNode);
     }
 }

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformation.java
@@ -259,4 +259,8 @@ public class ResourceInformation {
 		return PropertyUtils.getProperty(resource, idField.getUnderlyingName());
 	}
 
+	public void setId(Object resource, Object id) {
+		PropertyUtils.setProperty(resource, idField.getUnderlyingName(), id);		
+	}
+
 }

--- a/katharsis-core/src/main/java/io/katharsis/utils/WrappedList.java
+++ b/katharsis-core/src/main/java/io/katharsis/utils/WrappedList.java
@@ -143,4 +143,8 @@ public class WrappedList<T> implements List<T> {
 	public int hashCode() {
 		return list.hashCode();
 	}
+
+	public void setWrappedList(List<T> list) {
+		this.list = list;
+	}
 }


### PR DESCRIPTION
- proxies are no created for all multi-valued relationships
- "primitive" proxy (empty object) is created for non-lazy and not-included single-valuded relationships
- PUSH/POST of lazy relations if not null and initialized (in case ofproxies), make it easier to use without having to rely on a QuerySpec to define which relationships should be updated
- testing