### PR TITLE
#221 Support lazy proxies for katharsis-client

### DIFF
--- a/katharsis-client/src/main/java/io/katharsis/client/internal/ClientStubInvocationHandler.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/ClientStubInvocationHandler.java
@@ -32,20 +32,25 @@ public class ClientStubInvocationHandler implements InvocationHandler {
 
 	@Override
 	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-		if (method.getDeclaringClass().isAssignableFrom(QuerySpecResourceRepositoryStub.class)) {
-			// execute repository method
-			return method.invoke(repositoryStub, args);
+		try {
+			if (method.getDeclaringClass().isAssignableFrom(QuerySpecResourceRepositoryStub.class)) {
+				// execute repository method
+				return method.invoke(repositoryStub, args);
+			}
+			else if (interfaceStubMethodMap.containsKey(method)) {
+				return invokeInterfaceMethod(proxy, method, args);
+			}
+			else if (actionStub != null) {
+				// execute action
+				return method.invoke(actionStub, args);
+			}
+			else {
+				throw new IllegalStateException("cannot execute actions, no " + ActionStubFactory.class.getSimpleName()
+						+ " set with " + KatharsisClient.class.getName());
+			}
 		}
-		else if (interfaceStubMethodMap.containsKey(method)) {
-			return invokeInterfaceMethod(proxy, method, args);
-		}
-		else if (actionStub != null) {
-			// execute action
-			return method.invoke(actionStub, args);
-		}
-		else {
-			throw new IllegalStateException("cannot execute actions, no " + ActionStubFactory.class.getSimpleName() + " set with "
-					+ KatharsisClient.class.getName());
+		catch (InvocationTargetException e) { // NOSONAR ok this way
+			throw e.getCause();
 		}
 	}
 

--- a/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/CollectionInvocationHandler.java
+++ b/katharsis-client/src/main/java/io/katharsis/client/internal/proxy/CollectionInvocationHandler.java
@@ -1,6 +1,7 @@
 package io.katharsis.client.internal.proxy;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,7 +42,12 @@ public class CollectionInvocationHandler implements InvocationHandler, ObjectPro
 				}
 			}
 		}
-		return method.invoke(collection, args);
+		try {
+			return method.invoke(collection, args);
+		}
+		catch (InvocationTargetException e) { // NO SONAR ok this way
+			throw e.getCause();
+		}
 	}
 
 	@Override

--- a/katharsis-client/src/test/java/io/katharsis/client/ExceptionTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/ExceptionTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import io.katharsis.client.mock.models.Task;
 import io.katharsis.client.module.TestException;
+import io.katharsis.client.mock.models.Schedule;
+import io.katharsis.client.mock.repository.ScheduleRepository;
 
 public class ExceptionTest extends AbstractClientTest {
 
@@ -18,12 +20,28 @@ public class ExceptionTest extends AbstractClientTest {
 	}
 
 	@Test
-	public void test() {
+	public void genericRepo() {
 		Task task = new Task();
 		task.setId(10000L);
 		task.setName("test");
 		try {
 			taskRepo.create(task);
+			Assert.fail();
+		}
+		catch (TestException e) {
+			Assert.assertEquals("msg", e.getMessage());
+		}
+	}
+	
+	@Test
+	public void repoWithProxyAndInterface() {
+		ScheduleRepository repo = client.getResourceRepository(ScheduleRepository.class);
+		
+		Schedule schedule = new Schedule();
+		schedule.setId(10000L);
+		schedule.setName("test");
+		try {
+			repo.create(schedule);
 			Assert.fail();
 		}
 		catch (TestException e) {

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.katharsis.client.mock.models.Schedule;
 import io.katharsis.client.mock.models.Task;
+import io.katharsis.client.module.TestException;
 import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.repository.ResourceRepositoryBase;
 
@@ -41,6 +42,10 @@ public class ScheduleRepositoryImpl extends ResourceRepositoryBase<Schedule, Lon
 
 	@Override
 	public <S extends Schedule> S create(S entity) {
+		if (entity.getId() != null && entity.getId() == 10000) {
+			throw new TestException("msg");
+		}
+
 		if (entity.getId() == null) {
 			entity.setId(nextId.incrementAndGet());
 		}

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/repository/ScheduleRepository.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/repository/ScheduleRepository.java
@@ -1,14 +1,14 @@
 package io.katharsis.resource.mock.repository;
 
 import io.katharsis.queryspec.QuerySpec;
-import io.katharsis.queryspec.QuerySpecResourceRepository;
+import io.katharsis.repository.ResourceRepositoryV2;
 import io.katharsis.resource.list.ResourceListBase;
 import io.katharsis.resource.mock.models.Schedule;
 import io.katharsis.response.LinksInformation;
 import io.katharsis.response.MetaInformation;
 import io.katharsis.response.paging.DefaultPagedLinksInformation;
 
-public interface ScheduleRepository extends QuerySpecResourceRepository<Schedule, Long> {
+public interface ScheduleRepository extends ResourceRepositoryV2<Schedule, Long> {
 
 	@Override
 	public ScheduleList findAll(QuerySpec querySpec);


### PR DESCRIPTION
fixed invocationTargetException vs. application specific exception when going trough a proxy. Consumer no longer receives a invocationTargetException. Instead he gets the proper application exception.