### PR TITLE
#260 katharsis-jpa should respect getters not just fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Because of the usage of JSON API, Katharsis can be used with many other librarie
 
 
 ## Documentation and examples
-Documentation, along with example projects and project details are available on project website [katharsis.io](http://katharsis.io) and [katharsis-jsonapi.readthedocs.io](http://katharsis-jsonapi.readthedocs.io/)
-
+Documentation, along with example projects and project details are available on project website [katharsis.io](http://katharsis.io)
 
 ## Chat
 Need to directly talk to us? Write on gitter: 

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/AnnotationResourceInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/AnnotationResourceInformationBuilder.java
@@ -247,7 +247,7 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			return null;
 		}
 
-		public static boolean getIncludeByDefault(List<Annotation> annotations) {
+		public static boolean getIncludeByDefault(Collection<Annotation> annotations) {
     		for (Annotation annotation : annotations) {
 				if(annotation instanceof JsonApiIncludeByDefault){
 					return true;
@@ -256,11 +256,11 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			return false;
 		}
 
-    	public static LookupIncludeBehavior getLookupIncludeBehavior(List<Annotation> annotations) {
+    	public static LookupIncludeBehavior getLookupIncludeBehavior(Collection<Annotation> annotations) {
     		return getLookupIncludeBehavior(annotations, LookupIncludeBehavior.NONE);
     	}
     	
-    	public static LookupIncludeBehavior getLookupIncludeBehavior(List<Annotation> annotations, LookupIncludeBehavior defaultBehavior) {
+    	public static LookupIncludeBehavior getLookupIncludeBehavior(Collection<Annotation> annotations, LookupIncludeBehavior defaultBehavior) {
     		for (Annotation annotation : annotations) {
     			 if(annotation instanceof JsonApiLookupIncludeAutomatically){
     				 JsonApiLookupIncludeAutomatically includeAnnotation = (JsonApiLookupIncludeAutomatically) annotation;
@@ -284,7 +284,7 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
          * @param defaultValue default value if it cannot be determined
          * @return is lazy
          */
-    	public static boolean isLazy(List<Annotation> annotations, boolean defaultValue) {
+    	public static boolean isLazy(Collection<Annotation> annotations, boolean defaultValue) {
 	        JsonApiIncludeByDefault includeByDefaultAnnotation = null;
 	        JsonApiToMany toManyAnnotation = null;
 	        JsonApiToOne toOneAnnotation = null;

--- a/katharsis-core/src/main/java/io/katharsis/utils/ClassUtils.java
+++ b/katharsis-core/src/main/java/io/katharsis/utils/ClassUtils.java
@@ -1,8 +1,5 @@
 package io.katharsis.utils;
 
-import io.katharsis.resource.exception.ResourceException;
-import io.katharsis.utils.java.Optional;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -12,6 +9,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import io.katharsis.resource.exception.ResourceException;
+import io.katharsis.utils.java.Optional;
 
 /**
  * Provides reflection methods for parsing information about a class.
@@ -90,6 +90,29 @@ public class ClassUtils {
 
 		return null;
 	}
+
+	public static Method findGetter(Class<?> beanClass, String fieldName) {
+		String upperCaseName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+		try {
+		    return beanClass.getMethod("get" + upperCaseName);
+		} catch (NoSuchMethodException e) {
+			try {
+				return beanClass.getMethod("is" + upperCaseName);
+			} catch (NoSuchMethodException e1) {
+				return null;
+			}
+		}
+	}
+	
+	public static Method findSetter(Class<?> beanClass, String fieldName, Class<?> fieldType) {
+        String upperCaseName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+
+        try{
+        	return beanClass.getMethod("set" + upperCaseName, fieldType);
+        } catch (NoSuchMethodException e1) {
+			return null;
+		}
+    }
 
 	/**
 	 * <p>

--- a/katharsis-core/src/main/java/io/katharsis/utils/PropertyUtils.java
+++ b/katharsis-core/src/main/java/io/katharsis/utils/PropertyUtils.java
@@ -228,17 +228,12 @@ public class PropertyUtils {
     }
 
     private Method getGetter(Class<?> beanClass, String fieldName) throws NoSuchMethodException {
-        String upperCaseName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
-
-        try {
-            return beanClass.getMethod("get" + upperCaseName);
-        } catch (NoSuchMethodException e) {
-            try {
-                return beanClass.getMethod("is" + upperCaseName);
-            } catch (NoSuchMethodException e1) {
-                throw new RepositoryMethodException(String.format("Unable to find accessor method for %s.%s",beanClass.getName(),fieldName));
-            }
-        }
+    	Method getter = ClassUtils.findGetter(beanClass, fieldName);
+    	if(getter != null){
+    		return getter;
+    	}else{
+    		throw new RepositoryMethodException(String.format("Unable to find accessor method for %s.%s",beanClass.getName(),fieldName));
+    	}
     }
 
     /**
@@ -318,10 +313,12 @@ public class PropertyUtils {
     }
 
     private Method getSetter(Object bean, String fieldName, Class<?> fieldType) throws NoSuchMethodException {
-        Class<?> beanClass = bean.getClass();
-
-        String upperCaseName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
-
-        return beanClass.getMethod("set" + upperCaseName, fieldType);
+    	Class<? extends Object> beanClass = bean.getClass();
+    	Method setter = ClassUtils.findSetter(beanClass, fieldName, fieldType);
+    	if(setter != null){
+    		return setter;
+    	}else{
+    		throw new RepositoryMethodException(String.format("Unable to find accessor method for %s.%s",beanClass.getName(),fieldName));
+    	}
     }
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaResourceInformationBuilder.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaResourceInformationBuilder.java
@@ -2,10 +2,9 @@ package io.katharsis.jpa.internal;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -266,15 +265,7 @@ public class JpaResourceInformationBuilder implements ResourceInformationBuilder
 		Class<?> type = attr.getType().getImplementationClass();
 		Type genericType = attr.getType().getImplementationType();
 
-		Class<?> beanClass = attr.getParent().getImplementationClass();
-		Field declaredField;
-		try {
-			declaredField = beanClass.getDeclaredField(attr.getName());
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
-		List<Annotation> annotations = Arrays.asList(declaredField.getAnnotations());
+		Collection<Annotation> annotations = attr.getAnnotations();
 
 		// use JPA annotations as default
 		String oppositeName = null;
@@ -302,8 +293,8 @@ public class JpaResourceInformationBuilder implements ResourceInformationBuilder
 
 		MetaKey primaryKey = meta.getPrimaryKey();
 		boolean id = primaryKey.getElements().contains(attr);
-		boolean linksInfo = declaredField.getAnnotation(JsonApiLinksInformation.class) != null;
-		boolean metaInfo = declaredField.getAnnotation(JsonApiMetaInformation.class) != null;
+		boolean linksInfo = attr.getAnnotation(JsonApiLinksInformation.class) != null;
+		boolean metaInfo = attr.getAnnotation(JsonApiMetaInformation.class) != null;
 		boolean association = isAssociation(meta, attr);
 		ResourceFieldType resourceFieldType = ResourceFieldType.get(id, linksInfo, metaInfo, association);
 

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/meta/MetaAttribute.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/meta/MetaAttribute.java
@@ -1,5 +1,8 @@
 package io.katharsis.jpa.internal.meta;
 
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
 public interface MetaAttribute extends MetaTypedElement {
 
 	public MetaAttribute getOppositeAttribute();
@@ -27,5 +30,9 @@ public interface MetaAttribute extends MetaTypedElement {
 	public boolean isVersion();
 
 	public boolean isId();
+
+	public Collection<Annotation> getAnnotations();
+
+	public <T extends Annotation> T getAnnotation(Class<T> clazz);
 
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/meta/impl/MetaDataObjectImpl.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/meta/impl/MetaDataObjectImpl.java
@@ -55,8 +55,6 @@ public class MetaDataObjectImpl extends MetaTypeImpl implements MetaDataObject {
 	@SuppressWarnings("unchecked")
 	private List<MetaDataObject>[] subTypesCache = new List[4];
 
-	private HashMap<String, MetaDataObject> subTypesMapCache;
-
 	private MetaKey primaryKey;
 
 	private Set<MetaKey> keys = new HashSet<>();
@@ -114,7 +112,6 @@ public class MetaDataObjectImpl extends MetaTypeImpl implements MetaDataObject {
 
 	@SuppressWarnings("unchecked")
 	private void clearCache() {
-		subTypesMapCache = null;
 		subTypesCache = new List[4];
 	}
 

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/meta/impl/MetaMapAttributeImpl.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/meta/impl/MetaMapAttributeImpl.java
@@ -1,5 +1,8 @@
 package io.katharsis.jpa.internal.meta.impl;
 
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
 import io.katharsis.jpa.internal.meta.MetaAttribute;
 import io.katharsis.jpa.internal.meta.MetaDataObject;
 import io.katharsis.jpa.internal.meta.MetaMapAttribute;
@@ -101,6 +104,16 @@ public class MetaMapAttributeImpl extends MetaElementImpl implements MetaMapAttr
 
 	@Override
 	public boolean isId() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Collection<Annotation> getAnnotations() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T extends Annotation> T getAnnotation(Class<T> clazz) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/MethodAnnotatedEntityTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/MethodAnnotatedEntityTest.java
@@ -1,0 +1,74 @@
+package io.katharsis.jpa;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.katharsis.client.QuerySpecResourceRepositoryStub;
+import io.katharsis.jpa.internal.meta.MetaAttribute;
+import io.katharsis.jpa.internal.meta.MetaEntity;
+import io.katharsis.jpa.internal.meta.MetaKey;
+import io.katharsis.jpa.internal.meta.MetaLookup;
+import io.katharsis.jpa.model.MethodAnnotatedEntity;
+import io.katharsis.queryspec.QuerySpec;
+
+public class MethodAnnotatedEntityTest extends AbstractJpaJerseyTest {
+
+	@Test
+	public void testMeta() {
+		MethodAnnotatedEntity entity = new MethodAnnotatedEntity();
+		entity.setId(13L);
+		entity.setStringValue("test");
+
+		MetaLookup lookup = new MetaLookup();
+		MetaEntity meta = lookup.getMeta(MethodAnnotatedEntity.class).asEntity();
+		MetaKey primaryKey = meta.getPrimaryKey();
+		Assert.assertNotNull(primaryKey);
+		Assert.assertEquals(1, primaryKey.getElements().size());
+
+		MetaAttribute stringValueAttr = meta.getAttribute("stringValue");
+		Assert.assertNotNull(stringValueAttr);
+		Assert.assertEquals("stringValue", stringValueAttr.getName());
+		Assert.assertEquals("test", stringValueAttr.getValue(entity));
+
+		MetaAttribute idAttr = meta.getAttribute("id");
+		Assert.assertNotNull(idAttr);
+		Assert.assertEquals("id", idAttr.getName());
+		Assert.assertEquals(13L, idAttr.getValue(entity));
+		Assert.assertTrue(idAttr.isId());
+
+	}
+
+	@Test
+	public void testMethodAnnotatedFields() {
+		// tests whether JPA annotations on methods are supported as well
+		QuerySpecResourceRepositoryStub<MethodAnnotatedEntity, Long> methodRepo = client
+				.getQuerySpecRepository(MethodAnnotatedEntity.class);
+
+		MethodAnnotatedEntity task = new MethodAnnotatedEntity();
+		task.setId(1L);
+		task.setStringValue("test");
+		methodRepo.save(task);
+
+		// check retrievable with findAll
+		List<MethodAnnotatedEntity> list = methodRepo.findAll(new QuerySpec(MethodAnnotatedEntity.class));
+		Assert.assertEquals(1, list.size());
+		MethodAnnotatedEntity savedTask = list.get(0);
+		Assert.assertEquals(task.getId(), savedTask.getId());
+		Assert.assertEquals(task.getStringValue(), savedTask.getStringValue());
+
+		// check retrievable with findAll(ids)
+		list = methodRepo.findAll(Arrays.asList(1L), new QuerySpec(MethodAnnotatedEntity.class));
+		Assert.assertEquals(1, list.size());
+		savedTask = list.get(0);
+		Assert.assertEquals(task.getId(), savedTask.getId());
+		Assert.assertEquals(task.getStringValue(), savedTask.getStringValue());
+
+		// check retrievable with findOne
+		savedTask = methodRepo.findOne(1L, new QuerySpec(MethodAnnotatedEntity.class));
+		Assert.assertEquals(task.getId(), savedTask.getId());
+		Assert.assertEquals(task.getStringValue(), savedTask.getStringValue());
+	}
+}

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/model/MethodAnnotatedEntity.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/model/MethodAnnotatedEntity.java
@@ -1,0 +1,39 @@
+package io.katharsis.jpa.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class MethodAnnotatedEntity {
+
+	public static final String ATTR_id = "id";
+
+	public static final String ATTR_stringValue = "stringValue";
+
+	private Long _id;
+
+	private String _stringValue;
+
+	public MethodAnnotatedEntity() {
+
+	}
+
+	@Id
+	public Long getId() {
+		return _id;
+	}
+
+	public void setId(Long id) {
+		this._id = id;
+	}
+
+	public String getStringValue() {
+		return _stringValue;
+	}
+
+	@Column
+	public void setStringValue(String stringValue) {
+		this._stringValue = stringValue;
+	}
+}


### PR DESCRIPTION
- Annotations are now collected from getters, setters and fields (if a field with the same name is found).
- MetaAttribute now provides access to annotations.