### PR TITLE
Spring boot auto configuration for katharsis-jpa

### DIFF
--- a/katharsis-examples/spring-boot-simple-example/src/main/resources/application.properties
+++ b/katharsis-examples/spring-boot-simple-example/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 katharsis.resourcePackage=io.katharsis.example.springboot.simple.domain
 katharsis.domainName=http://localhost:8080
 katharsis.pathPrefix=/api
+katharsis.default-page-limit=
+katharsis.jpa.enabled=false

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaModule.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaModule.java
@@ -64,7 +64,7 @@ import io.katharsis.utils.PreconditionUtil;
  * <li>Paging</li>
  * <li>Mapping to DTOs</li>
  * <li>Criteria API and QueryDSL support</li>
- * <li>Computated attributes that map JPA Criteria/QueryDSL expressions to DTO attributes</li>
+ * <li>Computed attributes that map JPA Criteria/QueryDSL expressions to DTO attributes</li>
  * <li>JpaRepositoryFilter to customize the repositories</li>
  * <li>Client and server support</li>
  * <li>No need for katharsis annotations by default. Reads the entity annotations.</li>

--- a/katharsis-spring/pom.xml
+++ b/katharsis-spring/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -37,8 +38,8 @@
     </developers>
 
     <properties>
-        <spring.version>4.1.8.RELEASE</spring.version>
-        <spring-boot.version>1.3.1.RELEASE</spring-boot.version>
+        <spring.version>4.3.4.RELEASE</spring.version>
+        <spring-boot.version>1.4.2.RELEASE</spring-boot.version>
 
         <javax.servlet.version>3.0.1</javax.servlet.version>
         <json-unit-fluent.version>1.5.3</json-unit-fluent.version>
@@ -94,6 +95,19 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.katharsis</groupId>
+            <artifactId>katharsis-jpa</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <optional>true</optional>
@@ -111,13 +125,12 @@
             <version>${json-unit-fluent.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- only used to compile and test, application has to specify dependency if it makes use of JPA features -->
         <dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-orm</artifactId>
-			<optional>true</optional>
-			<version>${spring.version}</version>
-		</dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/katharsis-spring/src/main/java/io/katharsis/spring/boot/KatharsisJpaProperties.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/boot/KatharsisJpaProperties.java
@@ -1,0 +1,35 @@
+package io.katharsis.spring.boot;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for katharsis-jpa
+ */
+@ConfigurationProperties("katharsis.jpa")
+@Getter
+@Setter
+public class KatharsisJpaProperties {
+
+    /**
+     * The katharsis-jpa query factory type to use.
+     */
+    private JpaQueryFactoryType queryFactory;
+
+    /**
+     * Whether to enable the katharsis jpa auto configuration.
+     */
+    private Boolean enabled = true;
+
+    public enum JpaQueryFactoryType {
+        /**
+         * {@link io.katharsis.jpa.query.criteria.JpaCriteriaQueryFactory}
+         */
+        CRITERIA,
+        /**
+         * {@link io.katharsis.jpa.query.querydsl.QuerydslQueryFactory}
+         */
+        QUERYDSL,
+    }
+}

--- a/katharsis-spring/src/main/java/io/katharsis/spring/boot/autoconfigure/KatharsisJpaAutoConfiguration.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/boot/autoconfigure/KatharsisJpaAutoConfiguration.java
@@ -1,0 +1,79 @@
+package io.katharsis.spring.boot.autoconfigure;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import io.katharsis.jpa.JpaModule;
+import io.katharsis.jpa.query.criteria.JpaCriteriaQueryFactory;
+import io.katharsis.jpa.query.querydsl.QuerydslQueryFactory;
+import io.katharsis.spring.boot.KatharsisJpaProperties;
+import io.katharsis.spring.boot.KatharsisSpringBootProperties;
+import io.katharsis.spring.boot.v3.KatharsisConfigV3;
+import io.katharsis.spring.jpa.SpringTransactionRunner;
+
+/**
+ * @link EnableAutoConfiguration Auto-configuration} for Katharsis' JPA module.
+ * <p>
+ * Activates when there is a bean of type {@link javax.persistence.EntityManagerFactory} and
+ * {@link javax.persistence.EntityManager} on the classpath and there is no other existing
+ * {@link io.katharsis.jpa.JpaModule} configured.
+ * <p>
+ * Disable with the property <code>katharsis.jpa.enabled = false</code>
+ * <p>
+ * This configuration class will activate <em>after</em> the Hibernate auto-configuration.
+ */
+@Configuration
+@ConditionalOnBean({EntityManager.class, EntityManagerFactory.class})
+@ConditionalOnClass(JpaModule.class)
+@ConditionalOnProperty(prefix = "katharsis.jpa", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnMissingBean(JpaModule.class)
+@EnableConfigurationProperties({KatharsisJpaProperties.class, KatharsisSpringBootProperties.class})
+@AutoConfigureAfter(HibernateJpaAutoConfiguration.class)
+@AutoConfigureBefore
+@Import({ KatharsisConfigV3.class})
+public class KatharsisJpaAutoConfiguration {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private EntityManagerFactory emf;
+
+    @Autowired
+    private KatharsisJpaProperties jpaProperties;
+
+    @Bean
+    public SpringTransactionRunner transactionRunner() {
+        return new SpringTransactionRunner();
+    }
+
+    @Bean
+    public JpaModule jpaModule() {
+        JpaModule module = JpaModule.newServerModule(emf, em, transactionRunner());
+
+        if (jpaProperties.getQueryFactory() != null) {
+            switch (jpaProperties.getQueryFactory()) {
+                case CRITERIA:
+                    module.setQueryFactory(JpaCriteriaQueryFactory.newInstance());
+                    break;
+                case QUERYDSL:
+                    module.setQueryFactory(QuerydslQueryFactory.newInstance());
+                    break;
+            }
+        }
+        return module;
+    }
+}

--- a/katharsis-spring/src/main/resources/META-INF/spring.factories
+++ b/katharsis-spring/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configure
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  io.katharsis.spring.boot.autoconfigure.KatharsisJpaAutoConfiguration

--- a/katharsis-spring/src/test/java/io/katharsis/spring/boot/SpringBootSimpleExampleApplicationTests.java
+++ b/katharsis-spring/src/test/java/io/katharsis/spring/boot/SpringBootSimpleExampleApplicationTests.java
@@ -1,22 +1,20 @@
 package io.katharsis.spring.boot;
 
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.*;
+import static org.junit.Assert.*;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
-import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.junit.Assert.assertEquals;
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringBootSimpleExampleApplication.class)
-@WebIntegrationTest(randomPort = true)
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 public class SpringBootSimpleExampleApplicationTests {
 
@@ -27,7 +25,7 @@ public class SpringBootSimpleExampleApplicationTests {
     public void testTestEndpointWithQueryParams() throws Exception {
         TestRestTemplate testRestTemplate = new TestRestTemplate();
         ResponseEntity<String> response = testRestTemplate
-            .getForEntity("http://localhost:" + this.port + "/api/tasks?filter[tasks][name]=John", String.class);
+                .getForEntity("http://localhost:" + this.port + "/api/tasks?filter[tasks][name]=John", String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertThatJson(response.getBody()).node("data[0].attributes.name").isStringEqualTo("John");
         assertThatJson(response.getBody()).node("data[0].links.self").isStringEqualTo("http://localhost:8080/api/tasks/1");
@@ -38,7 +36,7 @@ public class SpringBootSimpleExampleApplicationTests {
     public void testTestCustomEndpoint() throws Exception {
         TestRestTemplate testRestTemplate = new TestRestTemplate();
         ResponseEntity<String> response = testRestTemplate
-            .getForEntity("http://localhost:" + this.port + "/api/custom", String.class);
+                .getForEntity("http://localhost:" + this.port + "/api/custom", String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(response.getBody(), "hello");
     }


### PR DESCRIPTION
This adds auto config for katharsis-jpa in a spring boot application. No java configuration is required in order to standup a basic katharsis api backed by JPA.

Includes several katharsis.jpa properties for more configuration.

The auto configuration is triggered when:

* the beans `EntityManager` and `EntityManagerFactory` exist
* property `katharsis.jpa.enabled=null/true` 
* and only if no other `JpaModule` bean has been created.
