### PR TITLE
Fix property name handling for included resources 

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/jackson/serializer/include/IncludedRelationshipExtractor.java
+++ b/katharsis-core/src/main/java/io/katharsis/jackson/serializer/include/IncludedRelationshipExtractor.java
@@ -60,7 +60,7 @@ public class IncludedRelationshipExtractor {
         List<ResourceField> relationshipFields = getRelationshipFields(resource);
         for (ResourceField resourceField : relationshipFields) {
             if (resourceField.getIncludeByDefault() || isFieldIncluded(response, resourceField.getJsonName(), index, topResourceType)) {
-                Object targetDataObj = PropertyUtils.getProperty(resource, resourceField.getJsonName());
+                Object targetDataObj = PropertyUtils.getProperty(resource, resourceField.getUnderlyingName());
                 if (targetDataObj == null) {
                     continue;
                 }


### PR DESCRIPTION
Change to use the underlying name when accessing the actual field in the object.  This resolves issue #267 