### PR TITLE
#280 Fix katharsis-cdi deployment issue

### DIFF
--- a/katharsis-cdi/src/main/java/io/katharsis/cdi/internal/CdiTransactionRunner.java
+++ b/katharsis-cdi/src/main/java/io/katharsis/cdi/internal/CdiTransactionRunner.java
@@ -16,6 +16,9 @@ public class CdiTransactionRunner implements TransactionRunner {
 
 	private CdiTransactionRunnerImpl impl;
 
+    // A no args constructor is required. See #280 for details.
+	public CdiTransactionRunner() {}
+
 	@Inject
 	public CdiTransactionRunner(CdiTransactionRunnerImpl impl) {
 		this.impl = impl;


### PR DESCRIPTION
Add a noargs constructor to CdiTransactionRunner in order to fix a deployment issue that occurred at least on TomEE 7.0.2