### PR TITLE
drop the (few) lombock usage with something different #276

### DIFF
--- a/katharsis-core/pom.xml
+++ b/katharsis-core/pom.xml
@@ -135,11 +135,6 @@
             <version>${json-path.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.16.8</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/katharsis-examples/vertx-simple/pom.xml
+++ b/katharsis-examples/vertx-simple/pom.xml
@@ -12,12 +12,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.16.10</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>io.katharsis</groupId>
 			<artifactId>katharsis-vertx</artifactId>
 			<version>2.8.3-SNAPSHOT</version>

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/KatharsisVerticle.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/KatharsisVerticle.java
@@ -13,63 +13,68 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.RouterImpl;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class KatharsisVerticle extends AbstractVerticle {
 
-    final Vertx vertx;
-    private Handler<RoutingContext> requestHandler;
+  final Vertx vertx;
 
-    @Override
-    public void start(final Future<Void> fut) throws Exception {
-        // We don't use default methods to be compatible with Java 7.
-        // Create a router object.
-        final Router router = new RouterImpl(vertx);
+  private Handler<RoutingContext> requestHandler;
 
-        // Bind "/" to our hello message - so we are still compatible.
-        router.route("/").handler(helloHandler());
+  public KatharsisVerticle(Vertx vertx) {
+    this.vertx = vertx;
+  }
 
-        KatharsisHandler katharsisGlue = KatharsisHandlerFactory.create(Main.class.getPackage().getName(), "/api");
+  @Override
+  public void start(final Future<Void> fut) throws Exception {
+    // We don't use default methods to be compatible with Java 7.
+    // Create a router object.
+    final Router router = new RouterImpl(vertx);
 
-        router.route("/api/*").handler(katharsisGlue);
+    // Bind "/" to our hello message - so we are still compatible.
+    router.route("/").handler(helloHandler());
 
-        // Create the HTTP server and pass the "accept" method to the request handler.
-        vertx.createHttpServer()
-                // We do this instead of lambda to be compatible with Java 7.
-                .requestHandler(new Handler<HttpServerRequest>() {
-                    @Override
-                    public void handle(HttpServerRequest request) {
-                        router.accept(request);
-                    }
-                })
-                // Retrieve the port from the configuration,
-                // default to 8080.
-                .listen(config().getInteger("http.port", 8080),
-                        // We do this instead of lambda to be compatible with Java 7.
-                        new Handler<AsyncResult<HttpServer>>() {
-                            @Override
-                            public void handle(AsyncResult<HttpServer> result) {
-                                if (result.succeeded()) {
-                                    fut.complete();
-                                } else {
-                                    fut.fail(result.cause());
-                                }
-                            }
-                        }
-                );
-    }
+    KatharsisHandler katharsisGlue = KatharsisHandlerFactory.create(Main.class.getPackage().getName(), "/api");
 
-    // We do this instead of lambda to be compatible with Java 7.
-    private Handler<RoutingContext> helloHandler() {
-        return new Handler<RoutingContext>() {
-            @Override
-            public void handle(RoutingContext routingContext) {
-                HttpServerResponse response = routingContext.response();
-                response.putHeader("content-type", "text/html")
-                        .end("<h1>Hello from my first Vert.x 3 application</h1>" +
-                                "<a href='/api/projects'>/api/projects</a>");
-            }
-        };
-    }
+    router.route("/api/*").handler(katharsisGlue);
+
+    // Create the HTTP server and pass the "accept" method to the request handler.
+    vertx.createHttpServer()
+        // We do this instead of lambda to be compatible with Java 7.
+        .requestHandler(new Handler<HttpServerRequest>() {
+
+          @Override
+          public void handle(HttpServerRequest request) {
+            router.accept(request);
+          }
+        })
+        // Retrieve the port from the configuration,
+        // default to 8080.
+        .listen(config().getInteger("http.port", 8080),
+            // We do this instead of lambda to be compatible with Java 7.
+            new Handler<AsyncResult<HttpServer>>() {
+
+              @Override
+              public void handle(AsyncResult<HttpServer> result) {
+                if (result.succeeded()) {
+                  fut.complete();
+                }
+                else {
+                  fut.fail(result.cause());
+                }
+              }
+            });
+  }
+
+  // We do this instead of lambda to be compatible with Java 7.
+  private Handler<RoutingContext> helloHandler() {
+    return new Handler<RoutingContext>() {
+
+      @Override
+      public void handle(RoutingContext routingContext) {
+        HttpServerResponse response = routingContext.response();
+        response.putHeader("content-type", "text/html")
+            .end("<h1>Hello from my first Vert.x 3 application</h1>" + "<a href='/api/projects'>/api/projects</a>");
+      }
+    };
+  }
 }

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/Main.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/Main.java
@@ -1,18 +1,14 @@
 package io.katharsis.vertx.examples;
 
-
 import io.vertx.core.Vertx;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public class Main {
 
-    public static void main(String[] args) {
-        log.info("Hello ");
-        // We don't use default methods from Vertx.vertx() to be compatible with Java 7.
-        Vertx vertx = Vertx.factory.vertx();
+  public static void main(String[] args) {
+    // We don't use default methods from Vertx.vertx() to be compatible with Java 7.
+    Vertx vertx = Vertx.factory.vertx();
 
-        vertx.deployVerticle(new KatharsisVerticle(vertx));
+    vertx.deployVerticle(new KatharsisVerticle(vertx));
 
-    }
+  }
 }

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/domain/Project.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/domain/Project.java
@@ -2,20 +2,37 @@ package io.katharsis.vertx.examples.domain;
 
 import io.katharsis.resource.annotations.JsonApiId;
 import io.katharsis.resource.annotations.JsonApiResource;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonApiResource(type = "projects")
 public class Project {
 
-    @JsonApiId
-    private Long id;
-    private String name;
+  @JsonApiId
+  private Long id;
 
+  private String name;
+
+  public Project() {
+
+  }
+
+  public Project(long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
 }

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/domain/Task.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/domain/Task.java
@@ -1,28 +1,53 @@
 package io.katharsis.vertx.examples.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.katharsis.resource.annotations.JsonApiId;
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.annotations.JsonApiToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonApiResource(type = "tasks")
 public class Task {
 
-    @JsonApiId
-    private Long id;
+  @JsonApiId
+  private Long id;
 
-    private String name;
+  private String name;
 
-    @JsonApiToOne
-    @JsonProperty("task-project")
-    private Project project;
+  @JsonApiToOne
+  @JsonProperty("task-project")
+  private Project project;
 
+  public Task() {
+    // nothing to do
+  }
+
+  public Task(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Project getProject() {
+    return project;
+  }
+
+  public void setProject(Project project) {
+    this.project = project;
+  }
 }

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/repository/ProjectRepository.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/repository/ProjectRepository.java
@@ -1,45 +1,44 @@
 package io.katharsis.vertx.examples.repository;
 
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.katharsis.legacy.queryParams.QueryParams;
 import io.katharsis.legacy.repository.ResourceRepository;
 import io.katharsis.vertx.examples.domain.Project;
-import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
-
-@Slf4j
 public class ProjectRepository implements ResourceRepository<Project, Long> {
 
-    @Override
-    public Project findOne(Long aLong, QueryParams queryParams) {
-        log.info("Find all {} {}", aLong, queryParams);
-        return Project.builder().id(aLong).name("ProfilesRD").build();
-    }
+  private Logger log = LoggerFactory.getLogger(ProjectRepository.class);
 
-    @Override
-    public Iterable<Project> findAll(QueryParams queryParams) {
-        log.info("FInd all {}", queryParams);
-        return findAll(null, queryParams);
-    }
+  @Override
+  public Project findOne(Long aLong, QueryParams queryParams) {
+    log.info("Find all {} {}", aLong, queryParams);
+    return new Project(aLong, "ProfilesRD");
+  }
 
-    @Override
-    public Iterable<Project> findAll(Iterable<Long> longs, QueryParams queryParams) {
-        log.info("Find all {} {}", longs, queryParams);
-        return Arrays.asList(
-                Project.builder().id(1L).name("ProfilesRD").build(),
-                Project.builder().id(2L).name("Great people inside").build()
-        );
-    }
+  @Override
+  public Iterable<Project> findAll(QueryParams queryParams) {
+    log.info("FInd all {}", queryParams);
+    return findAll(null, queryParams);
+  }
 
-    @Override
-    public void delete(Long aLong) {
-        log.info("Delete {}", aLong);
-    }
+  @Override
+  public Iterable<Project> findAll(Iterable<Long> longs, QueryParams queryParams) {
+    log.info("Find all {} {}", longs, queryParams);
+    return Arrays.asList(new Project(1L, "ProfilesRD"), new Project(2L, "Great people inside"));
+  }
 
-    @Override
-    public <S extends Project> S save(S entity) {
-        log.info("Save project {}", entity);
-        return entity;
-    }
+  @Override
+  public void delete(Long aLong) {
+    log.info("Delete {}", aLong);
+  }
+
+  @Override
+  public <S extends Project> S save(S entity) {
+    log.info("Save project {}", entity);
+    return entity;
+  }
 }

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/repository/TaskRepository.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/repository/TaskRepository.java
@@ -1,43 +1,44 @@
 package io.katharsis.vertx.examples.repository;
 
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.katharsis.legacy.queryParams.QueryParams;
 import io.katharsis.legacy.repository.ResourceRepository;
 import io.katharsis.vertx.examples.domain.Task;
-import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
-
-@Slf4j
 public class TaskRepository implements ResourceRepository<Task, Long> {
 
-    @Override
-    public Task findOne(Long aLong, QueryParams queryParams) {
-        log.info("Find one {} {}", aLong, queryParams);
-        return Task.builder()
-                .id(aLong).name("Some task " + aLong)
-                .build();
-    }
+  private Logger log = LoggerFactory.getLogger(TaskRepository.class);
 
-    @Override
-    public Iterable<Task> findAll(QueryParams queryParams) {
-        log.info("find all {}", queryParams);
-        return findAll(null, queryParams);
-    }
+  @Override
+  public Task findOne(Long aLong, QueryParams queryParams) {
+    log.info("Find one {} {}", aLong, queryParams);
+    return new Task(aLong, "Some task " + aLong);
+  }
 
-    @Override
-    public Iterable<Task> findAll(Iterable<Long> longs, QueryParams queryParams) {
-        log.info("find all {} {}", longs, queryParams);
-        return Arrays.asList(Task.builder().id(1L).name("First task").build());
-    }
+  @Override
+  public Iterable<Task> findAll(QueryParams queryParams) {
+    log.info("find all {}", queryParams);
+    return findAll(null, queryParams);
+  }
 
-    @Override
-    public void delete(Long aLong) {
-        log.info("Delete Task {}", aLong);
-    }
+  @Override
+  public Iterable<Task> findAll(Iterable<Long> longs, QueryParams queryParams) {
+    log.info("find all {} {}", longs, queryParams);
+    return Arrays.asList(new Task(1L, "First task"));
+  }
 
-    @Override
-    public <S extends Task> S save(S entity) {
-        log.info("Save task {}", entity);
-        return entity;
-    }
+  @Override
+  public void delete(Long aLong) {
+    log.info("Delete Task {}", aLong);
+  }
+
+  @Override
+  public <S extends Task> S save(S entity) {
+    log.info("Save task {}", entity);
+    return entity;
+  }
 }

--- a/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/repository/TaskToProjectRepository.java
+++ b/katharsis-examples/vertx-simple/src/main/java/io/katharsis/vertx/examples/repository/TaskToProjectRepository.java
@@ -1,45 +1,48 @@
 package io.katharsis.vertx.examples.repository;
 
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.katharsis.legacy.queryParams.QueryParams;
 import io.katharsis.legacy.repository.RelationshipRepository;
 import io.katharsis.vertx.examples.domain.Project;
 import io.katharsis.vertx.examples.domain.Task;
-import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
-
-@Slf4j
 public class TaskToProjectRepository implements RelationshipRepository<Task, Long, Project, Long> {
 
-    @Override
-    public void setRelation(Task source, Long targetId, String fieldName) {
-        log.info("Set relation {} {} {}", source, targetId, fieldName);
-    }
+  private Logger log = LoggerFactory.getLogger(TaskToProjectRepository.class);
 
-    @Override
-    public void setRelations(Task source, Iterable<Long> targetIds, String fieldName) {
-        log.info("Set relationS {} {} {}", source, targetIds, fieldName);
-    }
+  @Override
+  public void setRelation(Task source, Long targetId, String fieldName) {
+    log.info("Set relation {} {} {}", source, targetId, fieldName);
+  }
 
-    @Override
-    public void addRelations(Task source, Iterable<Long> targetIds, String fieldName) {
-        log.info("Add relations {} {} {}", source, targetIds, fieldName);
-    }
+  @Override
+  public void setRelations(Task source, Iterable<Long> targetIds, String fieldName) {
+    log.info("Set relationS {} {} {}", source, targetIds, fieldName);
+  }
 
-    @Override
-    public void removeRelations(Task source, Iterable<Long> targetIds, String fieldName) {
-        log.info("Remove relations {} {} {}", source, targetIds, fieldName);
-    }
+  @Override
+  public void addRelations(Task source, Iterable<Long> targetIds, String fieldName) {
+    log.info("Add relations {} {} {}", source, targetIds, fieldName);
+  }
 
-    @Override
-    public Project findOneTarget(Long sourceId, String fieldName, QueryParams queryParams) {
-        log.info("Find one target {} {} {}", sourceId, fieldName, queryParams);
-        return Project.builder().id(sourceId).name("find one target " + fieldName).build();
-    }
+  @Override
+  public void removeRelations(Task source, Iterable<Long> targetIds, String fieldName) {
+    log.info("Remove relations {} {} {}", source, targetIds, fieldName);
+  }
 
-    @Override
-    public Iterable<Project> findManyTargets(Long sourceId, String fieldName, QueryParams queryParams) {
-        log.info("Find many targets {} {} {}", sourceId, fieldName, queryParams);
-        return Arrays.asList(Project.builder().id(sourceId).name("find many targets " + fieldName).build());
-    }
+  @Override
+  public Project findOneTarget(Long sourceId, String fieldName, QueryParams queryParams) {
+    log.info("Find one target {} {} {}", sourceId, fieldName, queryParams);
+    return new Project(sourceId, "find one target " + fieldName);
+  }
+
+  @Override
+  public Iterable<Project> findManyTargets(Long sourceId, String fieldName, QueryParams queryParams) {
+    log.info("Find many targets {} {} {}", sourceId, fieldName, queryParams);
+    return Arrays.asList(new Project(sourceId, "find many targets " + fieldName));
+  }
 }

--- a/katharsis-spring/src/main/java/io/katharsis/spring/boot/KatharsisJpaProperties.java
+++ b/katharsis-spring/src/main/java/io/katharsis/spring/boot/KatharsisJpaProperties.java
@@ -1,35 +1,47 @@
 package io.katharsis.spring.boot;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration properties for katharsis-jpa
  */
 @ConfigurationProperties("katharsis.jpa")
-@Getter
-@Setter
 public class KatharsisJpaProperties {
 
-    /**
-     * The katharsis-jpa query factory type to use.
-     */
-    private JpaQueryFactoryType queryFactory;
+  /**
+   * The katharsis-jpa query factory type to use.
+   */
+  private JpaQueryFactoryType queryFactory;
 
-    /**
-     * Whether to enable the katharsis jpa auto configuration.
-     */
-    private Boolean enabled = true;
+  /**
+   * Whether to enable the katharsis jpa auto configuration.
+   */
+  private Boolean enabled = true;
 
-    public enum JpaQueryFactoryType {
-        /**
-         * {@link io.katharsis.jpa.query.criteria.JpaCriteriaQueryFactory}
-         */
-        CRITERIA,
-        /**
-         * {@link io.katharsis.jpa.query.querydsl.QuerydslQueryFactory}
-         */
-        QUERYDSL,
-    }
+  public enum JpaQueryFactoryType {
+    /**
+     * {@link io.katharsis.jpa.query.criteria.JpaCriteriaQueryFactory}
+     */
+    CRITERIA,
+    /**
+     * {@link io.katharsis.jpa.query.querydsl.QuerydslQueryFactory}
+     */
+    QUERYDSL,
+  }
+
+  public JpaQueryFactoryType getQueryFactory() {
+    return queryFactory;
+  }
+
+  public void setQueryFactory(JpaQueryFactoryType queryFactory) {
+    this.queryFactory = queryFactory;
+  }
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
 }

--- a/katharsis-test/pom.xml
+++ b/katharsis-test/pom.xml
@@ -135,11 +135,6 @@
             <version>${json-path.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.16.8</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/katharsis-vertx/pom.xml
+++ b/katharsis-vertx/pom.xml
@@ -64,12 +64,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.16.10</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>io.katharsis</groupId>
             <artifactId>katharsis-core</artifactId>
             <version>${project.version}</version>

--- a/katharsis-vertx/src/main/java/io/katharsis/vertx/DefaultParameterProvider.java
+++ b/katharsis-vertx/src/main/java/io/katharsis/vertx/DefaultParameterProvider.java
@@ -1,34 +1,45 @@
 package io.katharsis.vertx;
 
+import java.lang.reflect.Method;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.legacy.internal.RepositoryMethodParameterProvider;
 import io.vertx.ext.web.RoutingContext;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-import java.lang.reflect.Method;
 
 /**
  * The {@link RepositoryMethodParameterProvider RepositoryMethodParameterProvider}
  * allows you to inject object into your repository methods.
  */
-@Data
-@RequiredArgsConstructor
 public class DefaultParameterProvider implements RepositoryMethodParameterProvider {
 
-    private final ObjectMapper mapper;
-    private final RoutingContext ctx;
+  private final ObjectMapper mapper;
 
-    @Override
-    public <T> T provide(Method method, int parameterIndex) {
-        Class<?> parameter = method.getParameterTypes()[parameterIndex];
-        Object returnValue = null;
-        if (RoutingContext.class.isAssignableFrom(parameter)) {
-            returnValue = ctx;
-        } else if (ObjectMapper.class.isAssignableFrom(parameter)) {
-            returnValue = mapper;
-        }
-        return (T) returnValue;
+  private final RoutingContext ctx;
+
+  public DefaultParameterProvider(ObjectMapper mapper, RoutingContext ctx) {
+    this.mapper = mapper;
+    this.ctx = ctx;
+  }
+
+  @Override
+  public <T> T provide(Method method, int parameterIndex) {
+    Class<?> parameter = method.getParameterTypes()[parameterIndex];
+    Object returnValue = null;
+    if (RoutingContext.class.isAssignableFrom(parameter)) {
+      returnValue = ctx;
     }
+    else if (ObjectMapper.class.isAssignableFrom(parameter)) {
+      returnValue = mapper;
+    }
+    return (T) returnValue;
+  }
+
+  public ObjectMapper getMapper() {
+    return mapper;
+  }
+
+  public RoutingContext getCtx() {
+    return ctx;
+  }
 }

--- a/katharsis-vertx/src/main/java/io/katharsis/vertx/DefaultParameterProviderFactory.java
+++ b/katharsis-vertx/src/main/java/io/katharsis/vertx/DefaultParameterProviderFactory.java
@@ -4,25 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.legacy.internal.RepositoryMethodParameterProvider;
 import io.vertx.ext.web.RoutingContext;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * Parameter Factory - injects objects from the request context in the repository method.
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class DefaultParameterProviderFactory implements ParameterProviderFactory {
 
-    private ObjectMapper mapper;
+  private ObjectMapper mapper;
 
-    @Override
-    public RepositoryMethodParameterProvider provider(RoutingContext ctx) {
-        return new DefaultParameterProvider(mapper, ctx);
-    }
+  @Override
+  public RepositoryMethodParameterProvider provider(RoutingContext ctx) {
+    return new DefaultParameterProvider(mapper, ctx);
+  }
+
+  public ObjectMapper getMapper() {
+    return mapper;
+  }
 
 }

--- a/katharsis-vertx/src/main/java/io/katharsis/vertx/KatharsisHandler.java
+++ b/katharsis-vertx/src/main/java/io/katharsis/vertx/KatharsisHandler.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.core.internal.dispatcher.RequestDispatcher;
@@ -21,99 +24,109 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.EncodeException;
 import io.vertx.ext.web.RoutingContext;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Vertx handler to Katharsis resource controller. Vertx delegates request processing to Katharsis controller.
  */
-@Slf4j
-@Value
-@RequiredArgsConstructor
 public class KatharsisHandler implements Handler<RoutingContext> {
 
-    private final ObjectMapper mapper;
-    private final String webPath;
-    private final PathBuilder pathBuilder;
-    private final ParameterProviderFactory parameterProviderFactory;
-    private final RequestDispatcher requestDispatcher;
+  private static final Logger LOGGER = LoggerFactory.getLogger(KatharsisHandler.class);
 
-    @Override
-    public void handle(RoutingContext ctx) {
+  private final ObjectMapper mapper;
 
-        JsonPath jsonPath = buildPath(ctx);
-        String requestMethod = ctx.request().method().name();
+  private final String webPath;
 
-        Map<String, Set<String>> parameters = getParameters(ctx);
+  private final PathBuilder pathBuilder;
 
-        RepositoryMethodParameterProvider provider = parameterProviderFactory.provider(ctx);
-        Document body = requestBody(ctx.getBodyAsString());
+  private final ParameterProviderFactory parameterProviderFactory;
 
-        try {
-            Response response = requestDispatcher.dispatchRequest(jsonPath, requestMethod, parameters, provider, body);
+  private final RequestDispatcher requestDispatcher;
 
-            ctx.response()
-                    .setStatusCode(response.getHttpStatus())
-                    .putHeader(HttpHeaders.CONTENT_TYPE, JsonApiMediaTypeHandler.APPLICATION_JSON_API)
-                    .end(encode(response.getDocument()));
+  public KatharsisHandler(ObjectMapper mapper, String webPath, PathBuilder pathBuilder,
+      ParameterProviderFactory parameterProviderFactory, RequestDispatcher requestDispatcher) {
+    super();
+    this.mapper = mapper;
+    this.webPath = webPath;
+    this.pathBuilder = pathBuilder;
+    this.parameterProviderFactory = parameterProviderFactory;
+    this.requestDispatcher = requestDispatcher;
+  }
 
-        } catch (Exception e) {
-            throw new KatharsisVertxException("Exception during dispatch " + e.getMessage());
-        }
+  @Override
+  public void handle(RoutingContext ctx) {
+
+    JsonPath jsonPath = buildPath(ctx);
+    String requestMethod = ctx.request().method().name();
+
+    Map<String, Set<String>> parameters = getParameters(ctx);
+
+    RepositoryMethodParameterProvider provider = parameterProviderFactory.provider(ctx);
+    Document body = requestBody(ctx.getBodyAsString());
+
+    try {
+      Response response = requestDispatcher.dispatchRequest(jsonPath, requestMethod, parameters, provider, body);
+
+      ctx.response().setStatusCode(response.getHttpStatus())
+          .putHeader(HttpHeaders.CONTENT_TYPE, JsonApiMediaTypeHandler.APPLICATION_JSON_API).end(encode(response.getDocument()));
+
     }
-
-    protected JsonPath buildPath(RoutingContext ctx) {
-        return buildPath(ctx.request().path());
+    catch (Exception e) {
+      throw new KatharsisVertxException("Exception during dispatch " + e.getMessage());
     }
+  }
 
-    protected JsonPath buildPath(@NonNull String path) {
-        //TODO: ieugen path need to be cleaned
-        String cleaned = Paths.get(path).toString().replace('\\', '/');
-        String transformed = cleaned.substring(webPath.length());
-        log.trace("Path is {}", transformed);
-        return pathBuilder.buildPath(transformed);
+  protected JsonPath buildPath(RoutingContext ctx) {
+    return buildPath(ctx.request().path());
+  }
+
+  protected JsonPath buildPath(String path) {
+    //TODO: ieugen path need to be cleaned
+    String cleaned = Paths.get(path).toString().replace('\\', '/');
+    String transformed = cleaned.substring(webPath.length());
+    LOGGER.trace("Path is {}", transformed);
+    return pathBuilder.buildPath(transformed);
+  }
+
+  protected Map<String, Set<String>> getParameters(RoutingContext ctx) {
+    Map<String, Set<String>> transformed = new HashMap<>();
+
+    QueryStringDecoder decoder = new QueryStringDecoder(ctx.request().uri());
+
+    for (Map.Entry<String, List<String>> param : decoder.parameters().entrySet()) {
+      transformed.put(param.getKey(), new HashSet<>(param.getValue()));
     }
+    return transformed;
+  }
 
-    protected Map<String, Set<String>> getParameters(RoutingContext ctx) {
-        Map<String, Set<String>> transformed = new HashMap<>();
-
-        QueryStringDecoder decoder = new QueryStringDecoder(ctx.request().uri());
-
-        for (Map.Entry<String, List<String>> param : decoder.parameters().entrySet()) {
-            transformed.put(param.getKey(), new HashSet<>(param.getValue()));
-        }
-        return transformed;
+  protected Document requestBody(String body) {
+    if (body == null || body.length() == 0) {
+      return null;
     }
+    return decodeValue(body, Document.class);
+  }
 
-    protected Document requestBody(String body) {
-        if (body == null || body.length() == 0) {
-            return null;
-        }
-        return decodeValue(body, Document.class);
+  /**
+   * Taken from io.vertx.json.Json.
+   */
+  protected <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
+    try {
+      return mapper.readValue(str, clazz);
     }
+    catch (Exception e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage());
+    }
+  }
 
-    /**
-     * Taken from io.vertx.json.Json.
-     */
-    protected <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
-        try {
-            return mapper.readValue(str, clazz);
-        } catch (Exception e) {
-            throw new DecodeException("Failed to decode:" + e.getMessage());
-        }
+  /**
+   * Taken from io.vertx.json.Json.
+   */
+  protected String encode(Object obj) throws EncodeException {
+    try {
+      return mapper.writeValueAsString(obj);
     }
-
-    /**
-     * Taken from io.vertx.json.Json.
-     */
-    protected String encode(Object obj) throws EncodeException {
-        try {
-            return mapper.writeValueAsString(obj);
-        } catch (Exception e) {
-            throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
-        }
+    catch (Exception e) {
+      throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }
+  }
 
 }

--- a/katharsis-vertx/src/main/java/io/katharsis/vertx/KatharsisHandlerFactory.java
+++ b/katharsis-vertx/src/main/java/io/katharsis/vertx/KatharsisHandlerFactory.java
@@ -26,88 +26,77 @@ import io.katharsis.resource.registry.ConstantServiceUrlProvider;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.ServiceUrlProvider;
 import io.vertx.core.json.Json;
-import lombok.NonNull;
 
 public class KatharsisHandlerFactory {
 
-    public static KatharsisHandler create(@NonNull String packagesToScan,
-                                          @NonNull String webPath) {
+  public static KatharsisHandler create(String packagesToScan, String webPath) {
 
-        return create(packagesToScan, webPath, Json.mapper);
+    return create(packagesToScan, webPath, Json.mapper);
+  }
+
+  public static KatharsisHandler create(String packagesToScan, String webPath, ObjectMapper objectMapper) {
+
+    return create(packagesToScan, webPath, objectMapper, new DefaultParameterProviderFactory());
+  }
+
+  public static KatharsisHandler create(String packagesToScan, String webPath, ObjectMapper objectMapper,
+      ParameterProviderFactory parameterProviderFactory) {
+
+    ExceptionMapperRegistry exceptionMapperRegistry = buildExceptionMapperRegistry(packagesToScan);
+    ModuleRegistry moduleRegistry = buildModuleRegistry(objectMapper, packagesToScan);
+    ResourceRegistry resourceRegistry = buildRegistry(packagesToScan, webPath, moduleRegistry);
+
+    JsonApiModuleBuilder jsonApiModuleBuilder = new JsonApiModuleBuilder();
+    objectMapper.registerModule(jsonApiModuleBuilder.build(resourceRegistry, false));
+
+    RequestDispatcher requestDispatcher = createRequestDispatcher(objectMapper, moduleRegistry, exceptionMapperRegistry,
+        resourceRegistry);
+
+    PathBuilder pathBuilder = new PathBuilder(resourceRegistry);
+
+    return new KatharsisHandler(objectMapper, webPath, pathBuilder, parameterProviderFactory, requestDispatcher);
+  }
+
+  private static RequestDispatcher createRequestDispatcher(ObjectMapper objectMapper, ModuleRegistry moduleRegistry,
+      ExceptionMapperRegistry exceptionMapperRegistry, ResourceRegistry resourceRegistry) {
+    TypeParser typeParser = new TypeParser();
+    ControllerRegistryBuilder controllerRegistryBuilder = new ControllerRegistryBuilder(resourceRegistry, typeParser,
+        objectMapper, new EmptyPropertiesProvider());
+
+    ControllerRegistry controllerRegistry = controllerRegistryBuilder.build();
+
+    // TODO QuerySpec processing support
+    QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
+    QueryAdapterBuilder queryAdapterBuilder = new QueryParamsAdapterBuilder(queryParamsBuilder, resourceRegistry);
+
+    return new RequestDispatcher(moduleRegistry, controllerRegistry, exceptionMapperRegistry, queryAdapterBuilder);
+  }
+
+  public static ModuleRegistry buildModuleRegistry(ObjectMapper objectMapper, String packageToScan) {
+    ModuleRegistry moduleRegistry = new ModuleRegistry();
+    ResourceFieldNameTransformer resourceFieldNameTransformer = new ResourceFieldNameTransformer(
+        objectMapper.getSerializationConfig());
+    ModuleRegistry registry = new ModuleRegistry();
+    registry.addModule(new CoreModule(packageToScan, resourceFieldNameTransformer));
+    return moduleRegistry;
+  }
+
+  public static ResourceRegistry buildRegistry(String packageToScan, String webPath, ModuleRegistry moduleRegistry) {
+    ResourceRegistryBuilder registryBuilder = new ResourceRegistryBuilder(new SampleJsonServiceLocator(),
+        new AnnotationResourceInformationBuilder(new ResourceFieldNameTransformer()));
+
+    ServiceUrlProvider serviceUrlProvider = new ConstantServiceUrlProvider(webPath);
+    return registryBuilder.build(packageToScan, moduleRegistry, serviceUrlProvider);
+  }
+
+  private static ExceptionMapperRegistry buildExceptionMapperRegistry(String resourceSearchPackage) {
+    ExceptionMapperRegistryBuilder mapperRegistryBuilder = new ExceptionMapperRegistryBuilder();
+    try {
+      return mapperRegistryBuilder.build(resourceSearchPackage);
     }
-
-    public static KatharsisHandler create(@NonNull String packagesToScan,
-                                          @NonNull String webPath,
-                                          @NonNull ObjectMapper objectMapper) {
-
-        return create(packagesToScan, webPath, objectMapper, new DefaultParameterProviderFactory());
+    catch (Exception e) {
+      throw Throwables.propagate(e);
     }
-
-    public static KatharsisHandler create(@NonNull String packagesToScan,
-                                          @NonNull String webPath,
-                                          @NonNull ObjectMapper objectMapper,
-                                          @NonNull ParameterProviderFactory parameterProviderFactory) {
-
-        ExceptionMapperRegistry exceptionMapperRegistry = buildExceptionMapperRegistry(packagesToScan);
-        ModuleRegistry moduleRegistry = buildModuleRegistry(objectMapper, packagesToScan);
-        ResourceRegistry resourceRegistry = buildRegistry(packagesToScan, webPath, moduleRegistry);
-
-
-        JsonApiModuleBuilder jsonApiModuleBuilder = new JsonApiModuleBuilder();
-        objectMapper.registerModule(jsonApiModuleBuilder.build(resourceRegistry, false));
-
-        RequestDispatcher requestDispatcher = createRequestDispatcher(objectMapper, moduleRegistry,
-                exceptionMapperRegistry, resourceRegistry);
-
-        PathBuilder pathBuilder = new PathBuilder(resourceRegistry);
-
-        return new KatharsisHandler(objectMapper, webPath,
-                pathBuilder, parameterProviderFactory, requestDispatcher);
-    }
-
-    private static RequestDispatcher createRequestDispatcher(@NonNull ObjectMapper objectMapper,
-                                                             @NonNull ModuleRegistry moduleRegistry,
-                                                             @NonNull ExceptionMapperRegistry exceptionMapperRegistry,
-                                                             @NonNull ResourceRegistry resourceRegistry) {
-        TypeParser typeParser = new TypeParser();
-        ControllerRegistryBuilder controllerRegistryBuilder =
-                new ControllerRegistryBuilder(resourceRegistry, typeParser, objectMapper, new EmptyPropertiesProvider());
-
-        ControllerRegistry controllerRegistry = controllerRegistryBuilder.build();
-
-        // TODO QuerySpec processing support
-        QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
-        QueryAdapterBuilder queryAdapterBuilder = new QueryParamsAdapterBuilder(queryParamsBuilder, resourceRegistry);
-
-        return new RequestDispatcher(moduleRegistry, controllerRegistry, exceptionMapperRegistry, queryAdapterBuilder);
-    }
-
-    public static ModuleRegistry buildModuleRegistry(@NonNull ObjectMapper objectMapper,
-                                                     @NonNull String packageToScan) {
-        ModuleRegistry moduleRegistry = new ModuleRegistry();
-        ResourceFieldNameTransformer resourceFieldNameTransformer = new ResourceFieldNameTransformer(
-                objectMapper.getSerializationConfig());
-        ModuleRegistry registry = new ModuleRegistry();
-        registry.addModule(new CoreModule(packageToScan, resourceFieldNameTransformer));
-        return moduleRegistry;
-    }
-
-    public static ResourceRegistry buildRegistry(@NonNull String packageToScan, @NonNull String webPath, @NonNull ModuleRegistry moduleRegistry) {
-        ResourceRegistryBuilder registryBuilder = new ResourceRegistryBuilder(
-                new SampleJsonServiceLocator(),
-                new AnnotationResourceInformationBuilder(new ResourceFieldNameTransformer()));
-
-        ServiceUrlProvider serviceUrlProvider = new ConstantServiceUrlProvider(webPath);
-        return registryBuilder.build(packageToScan, moduleRegistry, serviceUrlProvider);
-    }
-
-    private static ExceptionMapperRegistry buildExceptionMapperRegistry(String resourceSearchPackage) {
-        ExceptionMapperRegistryBuilder mapperRegistryBuilder = new ExceptionMapperRegistryBuilder();
-        try {
-            return mapperRegistryBuilder.build(resourceSearchPackage);
-        } catch (Exception e) {
-            throw Throwables.propagate(e);
-        }
-    }
+  }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
 				<version>${reflections.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.projectlombok</groupId>
-				<artifactId>lombok</artifactId>
-				<version>1.16.8</version>
-			</dependency>
-			<dependency>
 				<groupId>net.jodah</groupId>
 				<artifactId>typetools</artifactId>
 				<version>${typetools.version}</version>


### PR DESCRIPTION
most recent IntelliJ versions provides similar functionality (code folding) for any Java source file, partly obsoleting the need for lombock (like the getter/setters).