### PR TITLE
Metamodule extensions #289

### DIFF
--- a/katharsis-meta/src/main/java/io/katharsis/meta/MetaModule.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/MetaModule.java
@@ -8,7 +8,7 @@ import io.katharsis.core.internal.resource.AnnotationResourceInformationBuilder;
 import io.katharsis.core.internal.utils.PreconditionUtil;
 import io.katharsis.legacy.registry.DefaultResourceInformationBuilderContext;
 import io.katharsis.meta.internal.MetaRelationshipRepository;
-import io.katharsis.meta.internal.MetaResourceRepository;
+import io.katharsis.meta.internal.MetaResourceRepositoryImpl;
 import io.katharsis.meta.model.MetaAttribute;
 import io.katharsis.meta.model.MetaCollectionType;
 import io.katharsis.meta.model.MetaDataObject;
@@ -79,7 +79,7 @@ public class MetaModule implements Module, InitializingModule {
 
 		for (Class<? extends MetaElement> metaClass : metaClasses) {
 			if (context.isServer()) {
-				context.addRepository(new MetaResourceRepository<>(lookup, metaClass));
+				context.addRepository(new MetaResourceRepositoryImpl<>(lookup, metaClass));
 
 				HashSet<Class<? extends MetaElement>> targetResourceClasses = new HashSet<>();
 				ResourceInformation information = informationBuilder.build(metaClass);

--- a/katharsis-meta/src/main/java/io/katharsis/meta/internal/MetaResourceRepositoryImpl.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/internal/MetaResourceRepositoryImpl.java
@@ -10,11 +10,11 @@ import io.katharsis.queryspec.QuerySpec;
 import io.katharsis.repository.ResourceRepositoryBase;
 import io.katharsis.resource.list.ResourceList;
 
-public class MetaResourceRepository<T> extends ResourceRepositoryBase<T, String> {
+public class MetaResourceRepositoryImpl<T> extends ResourceRepositoryBase<T, String> {
 
 	private MetaLookup lookup;
 
-	public MetaResourceRepository(MetaLookup lookup, Class<T> resourceClass) {
+	public MetaResourceRepositoryImpl(MetaLookup lookup, Class<T> resourceClass) {
 		super(resourceClass);
 		this.lookup = lookup;
 	}

--- a/katharsis-meta/src/main/java/io/katharsis/meta/internal/ResourceMetaProviderImpl.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/internal/ResourceMetaProviderImpl.java
@@ -1,11 +1,15 @@
 package io.katharsis.meta.internal;
 
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.katharsis.core.internal.repository.adapter.ResourceRepositoryAdapter;
 import io.katharsis.core.internal.resource.AnnotationResourceInformationBuilder;
 import io.katharsis.core.internal.utils.ClassUtils;
 import io.katharsis.core.internal.utils.PreconditionUtil;
@@ -17,14 +21,24 @@ import io.katharsis.meta.model.MetaElement;
 import io.katharsis.meta.model.MetaKey;
 import io.katharsis.meta.model.resource.MetaJsonObject;
 import io.katharsis.meta.model.resource.MetaResource;
+import io.katharsis.meta.model.resource.MetaResourceAction;
+import io.katharsis.meta.model.resource.MetaResourceAction.MetaRepositoryActionType;
 import io.katharsis.meta.model.resource.MetaResourceField;
+import io.katharsis.meta.model.resource.MetaResourceRepository;
 import io.katharsis.meta.provider.MetaProviderBase;
 import io.katharsis.meta.provider.MetaProviderContext;
+import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.repository.ResourceRepositoryV2;
+import io.katharsis.repository.information.RepositoryAction;
+import io.katharsis.repository.information.ResourceRepositoryInformation;
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.information.ResourceField;
 import io.katharsis.resource.information.ResourceFieldNameTransformer;
 import io.katharsis.resource.information.ResourceFieldType;
 import io.katharsis.resource.information.ResourceInformation;
+import io.katharsis.resource.links.LinksInformation;
+import io.katharsis.resource.list.ResourceListBase;
+import io.katharsis.resource.meta.MetaInformation;
 import io.katharsis.resource.registry.RegistryEntry;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.ResourceRegistryAware;
@@ -47,7 +61,7 @@ public class ResourceMetaProviderImpl extends MetaProviderBase implements Resour
 		// information builder, so only accept if a MetaResource was explicitly requested
 		if (resourceRegistry != null && (metaClass == MetaResource.class || metaClass == MetaJsonObject.class)) {
 			Class<?> clazz = ClassUtils.getRawType(type);
-			if (resourceRegistry.hasEntry(clazz)) {
+			if (resourceRegistry.getEntryForClass(clazz) != null) {
 				return true;
 			}
 		}
@@ -106,8 +120,68 @@ public class ResourceMetaProviderImpl extends MetaProviderBase implements Resour
 			// enforce setup of meta data
 			for (RegistryEntry entry : resourceRegistry.getResources()) {
 				ResourceInformation information = entry.getResourceInformation();
-				context.getLookup().getMeta(information.getResourceClass(), MetaResource.class);
+				MetaResource metaResource = context.getLookup().getMeta(information.getResourceClass(), MetaResource.class);
+
+				ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
+
+				ResourceRepositoryAdapter<?, Serializable> resourceRepository = entry.getResourceRepository(null);
+				if (resourceRepository != null) {
+					MetaResourceRepository repository = discoverRepository(repositoryInformation, metaResource,
+							resourceRepository, context);
+					context.add(repository);
+				}
 			}
+		}
+	}
+
+	private MetaResourceRepository discoverRepository(ResourceRepositoryInformation repositoryInformation,
+			MetaResource metaResource, ResourceRepositoryAdapter<?, Serializable> resourceRepository,
+			MetaProviderContext context) {
+
+		MetaResourceRepository meta = new MetaResourceRepository();
+		meta.setResourceType(metaResource);
+		meta.setName(metaResource.getName() + "Repository");
+		meta.setId(metaResource.getId() + "Repository");
+
+		for (RepositoryAction action : repositoryInformation.getActions().values()) {
+			MetaResourceAction metaAction = new MetaResourceAction();
+			metaAction.setName(action.getName());
+			metaAction.setActionType(MetaRepositoryActionType.valueOf(action.getActionType().toString()));
+			metaAction.setParent(meta);
+		}
+
+		// TODO avoid use of ResourceRepositoryAdapter by enriching ResourceRepositoryInformation
+		Object repository = resourceRepository.getResourceRepository();
+		if (repository instanceof ResourceRepositoryV2) {
+			setListInformationTypes(repository, context, meta);
+		}
+		return meta;
+	}
+
+	private void setListInformationTypes(Object repository, MetaProviderContext context, MetaResourceRepository meta) {
+
+		try {
+			Method findMethod = repository.getClass().getMethod("findAll", QuerySpec.class);
+			Class<?> listType = findMethod.getReturnType();
+
+			if (ResourceListBase.class.equals(listType.getSuperclass())
+					&& listType.getGenericSuperclass() instanceof ParameterizedType) {
+				ParameterizedType genericSuperclass = (ParameterizedType) listType.getGenericSuperclass();
+
+				Class<?> metaType = ClassUtils.getRawType(genericSuperclass.getActualTypeArguments()[1]);
+				Class<?> linksType = ClassUtils.getRawType(genericSuperclass.getActualTypeArguments()[2]);
+				if (!metaType.equals(MetaInformation.class)) {
+					MetaDataObject listMetaType = context.getLookup().getMeta(metaType, MetaJsonObject.class);
+					meta.setListMetaType(listMetaType);
+				}
+				if (!linksType.equals(LinksInformation.class)) {
+					MetaDataObject listLinksType = context.getLookup().getMeta(linksType, MetaJsonObject.class);
+					meta.setListLinksType(listLinksType);
+				}
+			}
+		}
+		catch (SecurityException | NoSuchMethodException e) {
+			throw new IllegalStateException(e);
 		}
 	}
 

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/resource/MetaResourceAction.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/resource/MetaResourceAction.java
@@ -1,0 +1,23 @@
+package io.katharsis.meta.model.resource;
+
+import io.katharsis.meta.model.MetaElement;
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "meta/resourceAction")
+public class MetaResourceAction extends MetaElement {
+
+	public enum MetaRepositoryActionType {
+		REPOSITORY,
+		RESOURCE
+	}
+
+	private MetaRepositoryActionType actionType;
+
+	public MetaRepositoryActionType getActionType() {
+		return actionType;
+	}
+
+	public void setActionType(MetaRepositoryActionType actionType) {
+		this.actionType = actionType;
+	}
+}

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/resource/MetaResourceRepository.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/resource/MetaResourceRepository.java
@@ -1,0 +1,39 @@
+package io.katharsis.meta.model.resource;
+
+import io.katharsis.meta.model.MetaDataObject;
+import io.katharsis.meta.model.MetaElement;
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "meta/resourceRepository")
+public class MetaResourceRepository extends MetaElement {
+
+	private MetaResource resourceType;
+
+	private MetaDataObject listMetaType;
+
+	private MetaDataObject listLinksType;
+
+	public void setResourceType(MetaResource resourceType) {
+		this.resourceType = resourceType;
+	}
+
+	public MetaResource getResourceType() {
+		return resourceType;
+	}
+
+	public MetaDataObject getListMetaType() {
+		return listMetaType;
+	}
+
+	public void setListMetaType(MetaDataObject listMetaType) {
+		this.listMetaType = listMetaType;
+	}
+
+	public MetaDataObject getListLinksType() {
+		return listLinksType;
+	}
+
+	public void setListLinksType(MetaDataObject listLinksType) {
+		this.listLinksType = listLinksType;
+	}
+}

--- a/katharsis-meta/src/test/java/io/katharsis/meta/AbstractMetaTest.java
+++ b/katharsis-meta/src/test/java/io/katharsis/meta/AbstractMetaTest.java
@@ -6,6 +6,7 @@ import io.katharsis.core.internal.boot.KatharsisBoot;
 import io.katharsis.core.internal.boot.ReflectionsServiceDiscovery;
 import io.katharsis.legacy.locator.SampleJsonServiceLocator;
 import io.katharsis.resource.registry.ConstantServiceUrlProvider;
+import io.katharsis.rs.internal.JaxrsModule;
 
 public class AbstractMetaTest {
 
@@ -14,6 +15,7 @@ public class AbstractMetaTest {
 	@Before
 	public void setup() {
 		boot = new KatharsisBoot();
+		boot.addModule(new JaxrsModule(null));
 		boot.setServiceUrlProvider(new ConstantServiceUrlProvider("http://localhost"));
 		boot.setServiceDiscovery(new ReflectionsServiceDiscovery("io.katharsis.meta.mock.model", new SampleJsonServiceLocator()));
 		configure();

--- a/katharsis-meta/src/test/java/io/katharsis/meta/MetaModuleTest.java
+++ b/katharsis-meta/src/test/java/io/katharsis/meta/MetaModuleTest.java
@@ -42,7 +42,9 @@ public class MetaModuleTest extends AbstractMetaJerseyTest {
 			}
 			else {
 				Assert.assertTrue(elem.getId(), elem.getId().startsWith("app.resources.")
-						|| elem.getId().startsWith("io.katharsis.meta.") || elem.getId().startsWith("io.katharsis.jpa."));
+						|| elem.getId().startsWith("io.katharsis.meta.")
+						|| elem.getId().startsWith("io.katharsis.resource.")
+						|| elem.getId().startsWith("io.katharsis.jpa."));
 			}
 		}
 	}


### PR DESCRIPTION
added meta information about repositories with MetaResourceRepository. It allows to query the set of available repositories and holds information about the contained resource, available actions, meta and
links information. Exposed as MetaResourceRepository.