### PR TITLE
#318 Add UT for Hyphen is allowed in resource name

### DIFF
--- a/katharsis-core/src/test/java/io/katharsis/queryspec/repository/DefaultQuerySpecDeserializerTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/repository/DefaultQuerySpecDeserializerTest.java
@@ -26,6 +26,7 @@ import io.katharsis.queryspec.SortSpec;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.mock.models.Project;
 import io.katharsis.resource.mock.models.Task;
+import io.katharsis.resource.mock.models.TaskWithLookup;
 import io.katharsis.resource.registry.ResourceRegistry;
 
 public class DefaultQuerySpecDeserializerTest extends AbstractQuerySpecTest {
@@ -358,6 +359,20 @@ public class DefaultQuerySpecDeserializerTest extends AbstractQuerySpecTest {
 		add(params, "fields", "name");
 
 		QuerySpec actualSpec = deserializer.deserialize(taskInformation, params);
+		Assert.assertEquals(expectedSpec, actualSpec);
+	}
+
+	@Test
+	public void testHyphenIsAllowedInResourceName(){
+
+		QuerySpec expectedSpec = new QuerySpec(Task.class);
+		expectedSpec.addSort(new SortSpec(Arrays.asList("id"), Direction.ASC));
+
+		Map<String, Set<String>> params = new HashMap<>();
+		add(params, "sort[task-with-lookup]", "id");
+
+		ResourceInformation taskWithLookUpInformation = resourceRegistry.getEntryForClass(TaskWithLookup.class).getResourceInformation();
+		QuerySpec actualSpec = deserializer.deserialize(taskWithLookUpInformation, params);
 		Assert.assertEquals(expectedSpec, actualSpec);
 	}
 


### PR DESCRIPTION
Add UT for Hyphen is allowed in resource name to make sure this function is working in next release