### PR TITLE
improve JAXRS / JSONAPI interoperability #340

### DIFF
--- a/katharsis-client/src/test/java/io/katharsis/client/action/BasicActionTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/action/BasicActionTest.java
@@ -97,4 +97,17 @@ public class BasicActionTest extends AbstractClientTest {
 		Assert.assertEquals("GET", actionContext.getMethod());
 		Assert.assertTrue(actionContext.getJsonPath() instanceof ActionPath);
 	}
+
+	@Test
+	public void testInvokeJsonApiAction() {
+		String result = scheduleRepo.jsonApiAction("hello");
+		Assert.assertEquals("jsonApiAction: hello", result);
+
+		// check filters
+		ArgumentCaptor<DocumentFilterContext> contexts = ArgumentCaptor.forClass(DocumentFilterContext.class);
+		Mockito.verify(filter, Mockito.times(1)).filter(contexts.capture(), Mockito.any(DocumentFilterChain.class));
+		DocumentFilterContext actionContext = contexts.getAllValues().get(0);
+		Assert.assertEquals("GET", actionContext.getMethod());
+		Assert.assertTrue(actionContext.getJsonPath() instanceof ActionPath);
+	}
 }

--- a/katharsis-client/src/test/java/io/katharsis/client/action/JsonApiActionResponseTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/action/JsonApiActionResponseTest.java
@@ -1,14 +1,5 @@
 package io.katharsis.client.action;
 
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.slf4j.bridge.SLF4JBridgeHandler;
-
 import io.katharsis.client.AbstractClientTest;
 import io.katharsis.client.KatharsisTestFeature;
 import io.katharsis.client.mock.models.Schedule;
@@ -21,6 +12,13 @@ import io.katharsis.repository.filter.DocumentFilterChain;
 import io.katharsis.repository.filter.DocumentFilterContext;
 import io.katharsis.repository.response.Response;
 import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public class JsonApiActionResponseTest extends AbstractClientTest {
 
@@ -131,6 +129,22 @@ public class JsonApiActionResponseTest extends AbstractClientTest {
 		ArgumentCaptor<DocumentFilterContext> contexts = ArgumentCaptor.forClass(DocumentFilterContext.class);
 		Mockito.verify(filter, Mockito.times(2)).filter(contexts.capture(), Mockito.any(DocumentFilterChain.class));
 		DocumentFilterContext actionContext = contexts.getAllValues().get(1);
+		Assert.assertEquals("GET", actionContext.getMethod());
+		Assert.assertTrue(actionContext.getJsonPath() instanceof ActionPath);
+	}
+
+	@Test
+	public void testInvokeJsonApiAction() {
+		// response should be received in json api format
+		String url = getBaseUri() + "schedules/jsonApiAction?msg=hello";
+		io.restassured.response.Response response = RestAssured.get(url);
+		Assert.assertEquals(200, response.getStatusCode());
+		response.then().assertThat().body("data", Matchers.equalTo("jsonApiAction: hello"));
+
+		// check filters
+		ArgumentCaptor<DocumentFilterContext> contexts = ArgumentCaptor.forClass(DocumentFilterContext.class);
+		Mockito.verify(filter, Mockito.times(1)).filter(contexts.capture(), Mockito.any(DocumentFilterChain.class));
+		DocumentFilterContext actionContext = contexts.getAllValues().get(0);
 		Assert.assertEquals("GET", actionContext.getMethod());
 		Assert.assertTrue(actionContext.getJsonPath() instanceof ActionPath);
 	}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package io.katharsis.client.mock.repository;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
 import io.katharsis.client.mock.models.Schedule;
@@ -12,6 +13,7 @@ import io.katharsis.resource.links.DefaultPagedLinksInformation;
 import io.katharsis.resource.links.LinksInformation;
 import io.katharsis.resource.list.ResourceListBase;
 import io.katharsis.resource.meta.MetaInformation;
+import io.katharsis.rs.type.JsonApiMediaType;
 
 @Path("schedules")
 public interface ScheduleRepository extends ResourceRepositoryV2<Schedule, Long> {
@@ -31,7 +33,12 @@ public interface ScheduleRepository extends ResourceRepositoryV2<Schedule, Long>
 	@GET
 	@Path("{id}/resourceAction")
 	public String resourceAction(@PathParam("id") long id, @QueryParam(value = "msg") String msg);
-	
+
+	@GET
+	@Path("jsonApiAction")
+	@Produces(JsonApiMediaType.APPLICATION_JSON_API)
+	public String jsonApiAction(@QueryParam(value = "msg") String msg);
+
 	@Override
 	public ScheduleList findAll(QuerySpec querySpec);
 

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ScheduleRepositoryImpl.java
@@ -27,6 +27,11 @@ public class ScheduleRepositoryImpl extends ResourceRepositoryBase<Schedule, Lon
 	}
 
 	@Override
+	public String jsonApiAction(String msg) {
+		return "jsonApiAction: " + msg;
+	}
+
+	@Override
 	public String resourceAction(long id, String msg) {
 		Schedule schedule = findOne(id, new QuerySpec(Schedule.class));
 		return "resource action: " + msg + "@" + schedule.getName();

--- a/katharsis-core/src/main/java/io/katharsis/core/internal/boot/KatharsisBoot.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/boot/KatharsisBoot.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-
 import io.katharsis.core.internal.dispatcher.ControllerRegistry;
 import io.katharsis.core.internal.dispatcher.ControllerRegistryBuilder;
 import io.katharsis.core.internal.dispatcher.RequestDispatcher;
@@ -347,6 +346,10 @@ public class KatharsisBoot {
 
 	public String getWebPathPrefix() {
 		return getProperty(KatharsisProperties.WEB_PATH_PREFIX);
+	}
+
+	public boolean isNullDataResponseEnabled() {
+		return Boolean.parseBoolean(getProperty(KatharsisProperties.NULL_DATA_RESPONSE_ENABLED));
 	}
 
 	public ServiceDiscovery getServiceDiscovery() {

--- a/katharsis-core/src/main/java/io/katharsis/core/properties/KatharsisProperties.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/properties/KatharsisProperties.java
@@ -62,4 +62,15 @@ public class KatharsisProperties {
      * @since 2.8.2
      */
     public static final String INCLUDE_AUTOMATICALLY_OVERWRITE = "katharsis.config.include.automatically.overwrite";
+
+    /**
+     * <p>
+     *     Set a boolean whether Katharsis should return a JSON API response with data field set to {@code null}
+     *     if an action returns a {@code null} value.
+     * </p>
+     * <p>
+     *     JAX-RS default default is to return a 204 response.
+     * </p>
+     */
+    public static final String NULL_DATA_RESPONSE_ENABLED = "katharsis.config.null.data.response.enabled";
 }

--- a/katharsis-examples/jersey-example/src/main/java/io/katharsis/example/jersey/JerseyApplication.java
+++ b/katharsis-examples/jersey-example/src/main/java/io/katharsis/example/jersey/JerseyApplication.java
@@ -22,6 +22,8 @@ public class JerseyApplication extends ResourceConfig {
     public JerseyApplication() {
         property(KatharsisProperties.RESOURCE_SEARCH_PACKAGE, "io.katharsis.example.jersey.domain");
         property(KatharsisProperties.RESOURCE_DEFAULT_DOMAIN, APPLICATION_URL);
+        // if set to true, an empty JSON response will be returned instead of a 204 response without content
+        property(KatharsisProperties.NULL_DATA_RESPONSE_ENABLED, false);
         register(KatharsisDynamicFeature.class);
         register(new AbstractBinder() {
             @Override

--- a/katharsis-rs/src/main/java/io/katharsis/rs/JsonApiResponseFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/JsonApiResponseFilter.java
@@ -1,8 +1,8 @@
 package io.katharsis.rs;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
-
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -11,19 +11,20 @@ import javax.ws.rs.core.UriInfo;
 import io.katharsis.core.internal.boot.KatharsisBoot;
 import io.katharsis.core.internal.resource.DocumentMapper;
 import io.katharsis.repository.response.JsonApiResponse;
+import io.katharsis.resource.Document;
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.list.ResourceListBase;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.resource.registry.ServiceUrlProvider;
 import io.katharsis.rs.resource.registry.UriInfoServiceUrlProvider;
 import io.katharsis.rs.type.JsonApiMediaType;
+import io.katharsis.utils.Nullable;
 
 /**
  * Uses the Katharsis {@link DocumentMapper} to create a JSON API response for
- * custom JAX-RS actions returning Katharsis resources.
+ * custom JAX-RS actions.
  */
 public class JsonApiResponseFilter implements ContainerResponseFilter {
-
 
 	private KatharsisFeature feature;
 
@@ -59,13 +60,17 @@ public class JsonApiResponseFilter implements ContainerResponseFilter {
 				// use the Katharsis document mapper to create a JSON API response
 				responseContext.setEntity(documentMapper.toDocument(jsonApiResponse, null));
 				responseContext.getHeaders().put("Content-Type", Arrays.asList((Object)JsonApiMediaType.APPLICATION_JSON_API));
-				
 			}
 			finally {
 				if (serviceUrlProvider instanceof UriInfoServiceUrlProvider) {
 					((UriInfoServiceUrlProvider) serviceUrlProvider).onRequestFinished();
 				}
 			}
+		}
+		else if (wrapResponse(responseContext)) {
+			Document document = new Document();
+			document.setData(Nullable.of(response));
+			responseContext.setEntity(document);
 		}
 	}
 
@@ -82,6 +87,21 @@ public class JsonApiResponseFilter implements ContainerResponseFilter {
 		boolean singleResource = response.getClass().getAnnotation(JsonApiResource.class) != null;
 		boolean resourceList = ResourceListBase.class.isAssignableFrom(response.getClass());
 		return singleResource || resourceList;
+	}
+
+	/**
+	 * Checks the media type of the response and the type of the response data to determine whether
+	 * the response should be wrapped with the necessary JSON API tags.
+	 * @param responseContext the context for the current response
+	 * @return <code>true</code>, if the media type is {@link JsonApiMediaType#APPLICATION_JSON_API} and the
+	 * 			response is not already in JSON API format,<br />
+	 * 			<code>false</code>, otherwise.
+	 */
+	private boolean wrapResponse(ContainerResponseContext responseContext) {
+		boolean mediaTypeJsonApi = JsonApiMediaType.APPLICATION_JSON_API_TYPE.equals(responseContext.getMediaType());
+		Object response = responseContext.getEntity();
+		boolean alreadyJsonApi = response instanceof Document || response instanceof InputStream;
+		return mediaTypeJsonApi && !alreadyJsonApi;
 	}
 
 }

--- a/katharsis-rs/src/main/java/io/katharsis/rs/JsonApiResponseFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/JsonApiResponseFilter.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import io.katharsis.core.internal.boot.KatharsisBoot;
@@ -39,6 +40,13 @@ public class JsonApiResponseFilter implements ContainerResponseFilter {
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
 		Object response = responseContext.getEntity();
 		if (response == null) {
+			if (feature.getBoot().isNullDataResponseEnabled()) {
+				Document document = new Document();
+				document.setData(Nullable.nullValue());
+				responseContext.setEntity(document);
+				responseContext.setStatus(Response.Status.OK.getStatusCode());
+				responseContext.getHeaders().put("Content-Type", Arrays.asList((Object) JsonApiMediaType.APPLICATION_JSON_API));
+			}
 			return;
 		}
 		
@@ -47,7 +55,7 @@ public class JsonApiResponseFilter implements ContainerResponseFilter {
 			KatharsisBoot boot = feature.getBoot();
 			ResourceRegistry resourceRegistry = boot.getResourceRegistry();
 			DocumentMapper documentMapper = boot.getDocumentMapper();
-			
+
 			ServiceUrlProvider serviceUrlProvider = resourceRegistry.getServiceUrlProvider();
 			try {
 				UriInfo uriInfo = requestContext.getUriInfo();


### PR DESCRIPTION
Enhanced the JsonApiResponseFilter by wrapping general responses into a "data" section.
Wrapping is only done if the JAX-RS action has a @Produces("application/vnd.api+json") annotation and the response is not already in JSON API format.