### PR TITLE
Catch JsonIgnore early when parsing annotated resource classes

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/core/internal/resource/AnnotationResourceInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/resource/AnnotationResourceInformationBuilder.java
@@ -107,7 +107,8 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			ResourceFieldType resourceFieldType = AnnotatedResourceField.getResourceFieldType(annotations);
 			String oppositeResourceType = resourceFieldType == ResourceFieldType.RELATIONSHIP ? getResourceType(field.getGenericType(), context) : null;
 			AnnotatedResourceField resourceField = new AnnotatedResourceField(jsonName, underlyingName, field.getType(), field.getGenericType(), oppositeResourceType, annotations);
-			if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
+			if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())
+                    || resourceField.isAnnotationPresent(JsonIgnore.class)) {
 				fieldWrappers.add(new ResourceFieldWrapper(resourceField, true));
 			} else {
 				fieldWrappers.add(new ResourceFieldWrapper(resourceField, false));
@@ -134,7 +135,7 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			ResourceFieldType resourceFieldType = AnnotatedResourceField.getResourceFieldType(annotations);
 			String oppositeResourceType = resourceFieldType == ResourceFieldType.RELATIONSHIP ? getResourceType(getter.getGenericReturnType(), context) : null;
 			AnnotatedResourceField resourceField = new AnnotatedResourceField(jsonName, underlyingName, getter.getReturnType(), getter.getGenericReturnType(), oppositeResourceType, annotations);
-			if (Modifier.isStatic(getter.getModifiers())) {
+			if (Modifier.isStatic(getter.getModifiers()) || resourceField.isAnnotationPresent(JsonIgnore.class)) {
 				fieldWrappers.add(new ResourceFieldWrapper(resourceField, true));
 			} else {
 				fieldWrappers.add(new ResourceFieldWrapper(resourceField, false));

--- a/katharsis-core/src/test/java/io/katharsis/resource/ResourceInformationBuilderTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/ResourceInformationBuilderTest.java
@@ -1,6 +1,6 @@
 package io.katharsis.resource;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Collection;
 import java.util.concurrent.Future;
@@ -13,18 +13,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.katharsis.core.internal.resource.AnnotationResourceInformationBuilder;
-import io.katharsis.errorhandling.exception.MultipleJsonApiLinksInformationException;
-import io.katharsis.errorhandling.exception.MultipleJsonApiMetaInformationException;
-import io.katharsis.errorhandling.exception.RepositoryAnnotationNotFoundException;
-import io.katharsis.errorhandling.exception.ResourceDuplicateIdException;
-import io.katharsis.errorhandling.exception.ResourceIdNotFoundException;
+import io.katharsis.errorhandling.exception.*;
 import io.katharsis.legacy.registry.DefaultResourceInformationBuilderContext;
-import io.katharsis.resource.annotations.JsonApiId;
-import io.katharsis.resource.annotations.JsonApiLinksInformation;
-import io.katharsis.resource.annotations.JsonApiMetaInformation;
+import io.katharsis.resource.annotations.*;
 import io.katharsis.resource.annotations.JsonApiRelation;
-import io.katharsis.resource.annotations.JsonApiResource;
-import io.katharsis.resource.annotations.JsonApiToOne;
 import io.katharsis.resource.annotations.LookupIncludeBehavior;
 import io.katharsis.resource.annotations.SerializeType;
 import io.katharsis.resource.information.ResourceFieldNameTransformer;
@@ -32,6 +24,7 @@ import io.katharsis.resource.information.ResourceFieldType;
 import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.information.ResourceInformationBuilderContext;
+import io.katharsis.resource.mock.models.ShapeResource;
 import io.katharsis.resource.mock.models.Task;
 import io.katharsis.resource.mock.models.UnAnnotatedTask;
 import io.katharsis.utils.parser.TypeParser;
@@ -149,6 +142,22 @@ public class ResourceInformationBuilderTest {
 		ResourceInformation resourceInformation = resourceInformationBuilder.build(DifferentTypes.class);
 
 		assertThat(resourceInformation.getRelationshipFields()).isNotNull().hasSize(1).extracting("type").contains(String.class);
+	}
+
+
+	// github #350
+	@Test
+	public void shouldDiscardParametrizedTypeWithJsonIgnore() throws Exception {
+		ResourceInformation resourceInformation = resourceInformationBuilder.build(ShapeResource.class);
+
+		// if we get this far, that is good, it means parsing the class didn't trigger the
+		// IllegalStateException when calling ClassUtils#getRawType on a parameterized type T
+
+
+		assertThat(resourceInformation.findAttributeFieldByName("type")).isNotNull();
+		// This assert fails, because JsonIgnore is on the getter not the field itself
+		// assertThat(resourceInformation.findAttributeFieldByName("delegate")).isNull();
+		assertThat(resourceInformation.getIdField().getUnderlyingName()).isNotNull().isEqualTo("id");
 	}
 
 	@Test

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/models/AbstractResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/models/AbstractResource.java
@@ -1,0 +1,25 @@
+package io.katharsis.resource.mock.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.katharsis.resource.annotations.JsonApiId;
+
+public abstract class AbstractResource<T extends Identifiable<String>> {
+
+    protected T delegate;
+
+    public AbstractResource(T delegate) {
+        this.delegate = delegate;
+    }
+
+    @JsonIgnore
+    public T getDelegate() {
+        return delegate;
+    }
+
+    @JsonApiId
+    public String getId()
+    {
+        return delegate.getId();
+    }
+}

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/models/Identifiable.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/models/Identifiable.java
@@ -1,0 +1,7 @@
+package io.katharsis.resource.mock.models;
+
+import java.io.Serializable;
+
+public interface Identifiable<T extends Serializable & Comparable<T>> {
+    T getId();
+}

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/models/ShapeResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/models/ShapeResource.java
@@ -1,0 +1,44 @@
+package io.katharsis.resource.mock.models;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "shapes")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
+public class ShapeResource extends AbstractResource<ShapeResource.Shape> {
+
+    public ShapeResource(Shape delegate) {
+        super(delegate);
+    }
+
+    public String getType() {
+        return getDelegate().getType();
+    }
+
+    public static class Shape implements Identifiable<String> {
+
+        private String id;
+
+        private String type;
+
+        public Shape(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+}


### PR DESCRIPTION
See #350

I'm not actually 100% happy with this solution, but maybe it will have to do for now.

With this commit an `IllegalStateException` is no longer thrown when parsing a resource class with a parameterized field type.

However, the parameterized type still appears in the ResourceInformation for the type, because the JsonIgnore is on the getter not the field itself. I think Katharsis should respect `@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)` if possible.

What do you think @remmeier should that parameterized type show up at all in the  ResourceInformation?

Perhaps we can open another ticket to track that issue.