### PR TITLE
Catch JsonIgnore early when parsing annotated resource classes #350

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/core/internal/resource/AnnotationResourceInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/resource/AnnotationResourceInformationBuilder.java
@@ -110,11 +110,11 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			ResourceFieldType resourceFieldType = AnnotatedResourceField.getResourceFieldType(annotations);
 			String oppositeResourceType = resourceFieldType == ResourceFieldType.RELATIONSHIP ? getResourceType(field.getGenericType(), context) : null;
 			AnnotatedResourceField resourceField = new AnnotatedResourceField(jsonName, underlyingName, field.getType(), field.getGenericType(), oppositeResourceType, annotations);
-			if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
-				fieldWrappers.add(new ResourceFieldWrapper(resourceField, true));
-			} else {
-				fieldWrappers.add(new ResourceFieldWrapper(resourceField, false));
-			}
+
+			boolean shouldBeDiscarded = Modifier.isTransient(field.getModifiers())
+					|| Modifier.isStatic(field.getModifiers())
+					|| resourceField.isAnnotationPresent(JsonIgnore.class);
+			fieldWrappers.add(new ResourceFieldWrapper(resourceField, shouldBeDiscarded));
 		}
 		return fieldWrappers;
 	}
@@ -137,11 +137,8 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			ResourceFieldType resourceFieldType = AnnotatedResourceField.getResourceFieldType(annotations);
 			String oppositeResourceType = resourceFieldType == ResourceFieldType.RELATIONSHIP ? getResourceType(getter.getGenericReturnType(), context) : null;
 			AnnotatedResourceField resourceField = new AnnotatedResourceField(jsonName, underlyingName, getter.getReturnType(), getter.getGenericReturnType(), oppositeResourceType, annotations);
-			if (Modifier.isStatic(getter.getModifiers())) {
-				fieldWrappers.add(new ResourceFieldWrapper(resourceField, true));
-			} else {
-				fieldWrappers.add(new ResourceFieldWrapper(resourceField, false));
-			}
+			boolean shouldBeDiscarded = Modifier.isStatic(getter.getModifiers()) || resourceField.isAnnotationPresent(JsonIgnore.class);
+			fieldWrappers.add(new ResourceFieldWrapper(resourceField, shouldBeDiscarded));
 		}
 		return fieldWrappers;
 	}

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/models/AbstractResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/models/AbstractResource.java
@@ -1,0 +1,25 @@
+package io.katharsis.resource.mock.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.katharsis.resource.annotations.JsonApiId;
+
+public abstract class AbstractResource<T extends Identifiable<String>> {
+
+    protected T delegate;
+
+    public AbstractResource(T delegate) {
+        this.delegate = delegate;
+    }
+
+    @JsonIgnore
+    public T getDelegate() {
+        return delegate;
+    }
+
+    @JsonApiId
+    public String getId()
+    {
+        return delegate.getId();
+    }
+}

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/models/Identifiable.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/models/Identifiable.java
@@ -1,0 +1,7 @@
+package io.katharsis.resource.mock.models;
+
+import java.io.Serializable;
+
+public interface Identifiable<T extends Serializable & Comparable<T>> {
+    T getId();
+}

--- a/katharsis-core/src/test/java/io/katharsis/resource/mock/models/ShapeResource.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/mock/models/ShapeResource.java
@@ -1,0 +1,44 @@
+package io.katharsis.resource.mock.models;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "shapes")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
+public class ShapeResource extends AbstractResource<ShapeResource.Shape> {
+
+    public ShapeResource(Shape delegate) {
+        super(delegate);
+    }
+
+    public String getType() {
+        return getDelegate().getType();
+    }
+
+    public static class Shape implements Identifiable<String> {
+
+        private String id;
+
+        private String type;
+
+        public Shape(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+}


### PR DESCRIPTION
See #350

I'm not actually 100% happy with this solution, but maybe it will have to do for now.

With this commit an `IllegalStateException` is no longer thrown when parsing a resource class with a parameterized field type.

However, the parameterized type still appears in the ResourceInformation for the type, because the JsonIgnore is on the getter not the field itself. I think Katharsis should respect `@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)` if possible.

What do you think @remmeier should that parameterized type show up at all in the  ResourceInformation?

Perhaps we can open another ticket to track that issue.