### PR TITLE
properly support inheritance #278

### DIFF
--- a/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/AbstractClientTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.katharsis.client.action.JerseyActionStubFactory;
 import io.katharsis.client.mock.repository.ProjectRepository;
+import io.katharsis.client.mock.repository.ProjectToTaskRepository;
 import io.katharsis.client.mock.repository.ScheduleRepositoryImpl;
 import io.katharsis.client.mock.repository.TaskRepository;
 import io.katharsis.client.mock.repository.TaskToProjectRepository;
@@ -47,6 +48,7 @@ public abstract class AbstractClientTest extends JerseyTest {
 		TaskRepository.clear();
 		ProjectRepository.clear();
 		TaskToProjectRepository.clear();
+		ProjectToTaskRepository.clear();
 		ScheduleRepositoryImpl.clear();
 
 		Assert.assertNotNull(client.getActionStubFactory());

--- a/katharsis-client/src/test/java/io/katharsis/client/InheritanceClientTest.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/InheritanceClientTest.java
@@ -1,0 +1,108 @@
+package io.katharsis.client;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.katharsis.client.internal.proxy.ObjectProxy;
+import io.katharsis.client.mock.models.Project;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.client.mock.models.TaskSubType;
+import io.katharsis.queryspec.Direction;
+import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.queryspec.SortSpec;
+import io.katharsis.repository.RelationshipRepositoryV2;
+import io.katharsis.repository.ResourceRepositoryV2;
+
+public class InheritanceClientTest extends AbstractClientTest {
+
+	protected ResourceRepositoryV2<Task, Long> taskRepo;
+
+	protected ResourceRepositoryV2<Project, Long> projectRepo;
+
+	protected RelationshipRepositoryV2<Project, Long, Task, Long> relRepo;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		taskRepo = client.getRepositoryForType(Task.class);
+		projectRepo = client.getRepositoryForType(Project.class);
+		relRepo = client.getRepositoryForType(Project.class, Task.class);
+
+		Task baseTask = new Task();
+		baseTask.setId(Long.valueOf(1));
+		baseTask.setName("baseTask");
+		taskRepo.create(baseTask);
+
+		TaskSubType taskSubType = new TaskSubType();
+		taskSubType.setId(Long.valueOf(2));
+		taskSubType.setName("taskSubType");
+		taskSubType.setSubTypeValue(13);
+		taskRepo.create(taskSubType);
+
+		Project project = new Project();
+		project.setId(1L);
+		project.setName("project0");
+		project.setTasks(Arrays.asList(baseTask, taskSubType));
+		projectRepo.create(project);
+
+		relRepo.addRelations(project, Arrays.asList(baseTask.getId(), taskSubType.getId()), "tasks");
+	}
+
+	@Override
+	protected TestApplication configure() {
+		return new TestApplication(true);
+	}
+
+	@Test
+	public void testFindAll() {
+		QuerySpec querySpec = new QuerySpec(Task.class);
+		querySpec.addSort(new SortSpec(Arrays.asList("name"), Direction.ASC));
+		List<Task> tasks = taskRepo.findAll(querySpec);
+		Assert.assertEquals(2, tasks.size());
+
+		Assert.assertEquals("baseTask", tasks.get(0).getName());
+		Assert.assertEquals("taskSubType", tasks.get(1).getName());
+	}
+
+	@Test
+	public void testIncludePoloymorphCollectionWithoutInclude() {
+		doTestIncludePoloymorphCollection(false);
+	}
+
+	@Test
+	public void testIncludePoloymorphCollectionWithInclude() {
+		doTestIncludePoloymorphCollection(true);
+	}
+
+	private void doTestIncludePoloymorphCollection(boolean include) {
+		QuerySpec querySpec = new QuerySpec(Project.class);
+		if (include) {
+			querySpec.includeRelation(Arrays.asList("tasks"));
+		}
+		List<Project> projects = projectRepo.findAll(querySpec);
+		Assert.assertEquals(1, projects.size());
+		Project project = projects.get(0);
+
+		List<Task> tasks = project.getTasks();
+		if (include) {
+			Assert.assertFalse(tasks instanceof ObjectProxy);
+		} else {
+			ObjectProxy proxy = (ObjectProxy) tasks;
+			Assert.assertFalse(proxy.isLoaded());
+		}
+
+		if (tasks.get(0).getName().equals("baseTask")) {
+			Assert.assertEquals("baseTask", tasks.get(0).getName());
+			Assert.assertEquals("taskSubType", tasks.get(1).getName());
+		} else {
+			Assert.assertEquals("baseTask", tasks.get(1).getName());
+			Assert.assertEquals("taskSubType", tasks.get(0).getName());
+		}
+	}
+
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/models/TaskSubType.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/models/TaskSubType.java
@@ -1,0 +1,17 @@
+package io.katharsis.client.mock.models;
+
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "tasksSubType")
+public class TaskSubType extends Task {
+
+	private int subTypeValue;
+
+	public int getSubTypeValue() {
+		return subTypeValue;
+	}
+
+	public void setSubTypeValue(int subTypeValue) {
+		this.subTypeValue = subTypeValue;
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ProjectToTaskRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/ProjectToTaskRepository.java
@@ -1,0 +1,107 @@
+package io.katharsis.client.mock.repository;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.katharsis.client.mock.models.Project;
+import io.katharsis.client.mock.models.Task;
+import io.katharsis.queryspec.QuerySpec;
+import io.katharsis.repository.RelationshipRepositoryV2;
+import io.katharsis.resource.list.DefaultResourceList;
+import io.katharsis.resource.list.ResourceList;
+import junit.framework.Assert;
+
+public class ProjectToTaskRepository implements RelationshipRepositoryV2<Project, Long, Task, Long> {
+
+	private static final ConcurrentMap<Relation<Project>, Integer> THREAD_LOCAL_REPOSITORY = new ConcurrentHashMap<>();
+
+	private TaskRepository taskRepo = new TaskRepository();
+	
+	public static void clear() {
+		THREAD_LOCAL_REPOSITORY.clear();
+	}
+
+	@Override
+	public void setRelation(Project source, Long targetId, String fieldName) {
+		removeRelations(fieldName);
+		if (targetId != null) {
+			THREAD_LOCAL_REPOSITORY.put(new Relation<>(source, targetId, fieldName), 0);
+		}
+	}
+
+	@Override
+	public void setRelations(Project source, Iterable<Long> targetIds, String fieldName) {
+		removeRelations(fieldName);
+		if (targetIds != null) {
+			for (Long targetId : targetIds) {
+				THREAD_LOCAL_REPOSITORY.put(new Relation<>(source, targetId, fieldName), 0);
+			}
+		}
+	}
+
+	@Override
+	public void addRelations(Project source, Iterable<Long> targetIds, String fieldName) {
+		for (Long targetId : targetIds) {
+			THREAD_LOCAL_REPOSITORY.put(new Relation<>(source, targetId, fieldName), 0);
+		}
+	}
+
+	@Override
+	public void removeRelations(Project source, Iterable<Long> targetIds, String fieldName) {
+		for (Long targetId : targetIds) {
+			Iterator<Relation<Project>> iterator = THREAD_LOCAL_REPOSITORY.keySet().iterator();
+			while (iterator.hasNext()) {
+				Relation<Project> next = iterator.next();
+				if (next.getFieldName().equals(fieldName) && next.getTargetId().equals(targetId)) {
+					iterator.remove();
+				}
+			}
+		}
+	}
+
+	public void removeRelations(String fieldName) {
+		Iterator<Relation<Project>> iterator = THREAD_LOCAL_REPOSITORY.keySet().iterator();
+		while (iterator.hasNext()) {
+			Relation<Project> next = iterator.next();
+			if (next.getFieldName().equals(fieldName)) {
+				iterator.remove();
+			}
+		}
+	}
+
+	@Override
+	public Task findOneTarget(Long sourceId, String fieldName, QuerySpec queryParams) {
+		for (Relation<Project> relation : THREAD_LOCAL_REPOSITORY.keySet()) {
+			if (relation.getSource().getId().equals(sourceId) && relation.getFieldName().equals(fieldName)) {
+				Task task = taskRepo.findOne((long)relation.getTargetId(), null);
+				Assert.assertNotNull(task);
+				return task;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ResourceList<Task> findManyTargets(Long sourceId, String fieldName, QuerySpec queryParams) {
+		DefaultResourceList<Task> tasks = new DefaultResourceList<>();
+		for (Relation<Project> relation : THREAD_LOCAL_REPOSITORY.keySet()) {
+			if (relation.getSource().getId().equals(sourceId) && relation.getFieldName().equals(fieldName)) {
+				Task task = taskRepo.findOne((long)relation.getTargetId(), null);
+				Assert.assertNotNull(task);
+				tasks.add(task);
+			}
+		}
+		return tasks;
+	}
+
+	@Override
+	public Class<Project> getSourceResourceClass() {
+		return Project.class;
+	}
+
+	@Override
+	public Class<Task> getTargetResourceClass() {
+		return Task.class;
+	}
+}

--- a/katharsis-client/src/test/java/io/katharsis/client/mock/repository/TaskSubtypeRepository.java
+++ b/katharsis-client/src/test/java/io/katharsis/client/mock/repository/TaskSubtypeRepository.java
@@ -1,0 +1,49 @@
+package io.katharsis.client.mock.repository;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.katharsis.client.mock.models.TaskSubType;
+import io.katharsis.legacy.repository.annotations.JsonApiDelete;
+import io.katharsis.legacy.repository.annotations.JsonApiFindAll;
+import io.katharsis.legacy.repository.annotations.JsonApiFindAllWithIds;
+import io.katharsis.legacy.repository.annotations.JsonApiFindOne;
+import io.katharsis.legacy.repository.annotations.JsonApiResourceRepository;
+import io.katharsis.legacy.repository.annotations.JsonApiSave;
+import io.katharsis.queryspec.QuerySpec;
+
+@JsonApiResourceRepository(TaskSubType.class)
+public class TaskSubtypeRepository {
+
+	private TaskRepository repo = new TaskRepository();
+
+	private static final ConcurrentHashMap<Long, TaskSubType> map = new ConcurrentHashMap<>();
+
+	public static void clear() {
+		map.clear();
+	}
+
+	@JsonApiSave
+	public <S extends TaskSubType> S save(S entity) {
+		return repo.save(entity);
+	}
+
+	@JsonApiFindOne
+	public TaskSubType findOne(Long aLong, QuerySpec querySpec) {
+		return (TaskSubType) repo.findOne(aLong, querySpec);
+	}
+
+	@JsonApiFindAll
+	public Iterable<TaskSubType> findAll(QuerySpec queryParams) {
+		throw new UnsupportedOperationException();
+	}
+
+	@JsonApiFindAllWithIds
+	public Iterable<TaskSubType> findAll(Iterable<Long> ids, QuerySpec queryParams) {
+		throw new UnsupportedOperationException();
+	}
+
+	@JsonApiDelete
+	public void delete(Long aLong) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/katharsis-core/src/main/java/io/katharsis/core/internal/dispatcher/controller/ResourceUpsert.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/dispatcher/controller/ResourceUpsert.java
@@ -241,19 +241,16 @@ public abstract class ResourceUpsert extends BaseController {
 	                .findRelationshipFieldByName(propertyName);
 	        Class<?> relationshipFieldClass = Generics.getResourceClass(relationshipField.getGenericType(),
 	                relationshipField.getType());
-	        RegistryEntry entry = null;
 	        Class idFieldType = null;
 	        List relationships = new LinkedList<>();
 	        boolean first = true;
 	        
 	        for (ResourceIdentifier resourceId : relationship.getCollectionData().get()) {
-	            if (first) {
-	                entry = resourceRegistry.findEntry(resourceId.getType(), relationshipFieldClass);
+	        	RegistryEntry entry = resourceRegistry.findEntry(resourceId.getType(), relationshipFieldClass);
 	                idFieldType = entry.getResourceInformation()
 	                        .getIdField()
 	                        .getType();
 	                first = false;
-	            }
 	            Serializable castedRelationshipId = typeParser.parse(resourceId.getId(), idFieldType);
 	            
 	            Object relationObject = fetchRelatedObject(entry, castedRelationshipId, parameterProvider, queryAdapter);
@@ -291,7 +288,6 @@ public abstract class ResourceUpsert extends BaseController {
 	        } else {
 	            relationObject = null;
 	        }
-	
 	        PropertyUtils.setProperty(newResource, relationshipFieldByName.getUnderlyingName(), relationObject);
     	}
     }

--- a/katharsis-core/src/main/java/io/katharsis/core/internal/registry/ResourceRegistryImpl.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/registry/ResourceRegistryImpl.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,5 +202,25 @@ public class ResourceRegistryImpl implements ResourceRegistry {
 			url += "/";
 		}
 		return url + resourceInformation.getResourceType();
+	}
+
+	private ConcurrentHashMap<String, ResourceInformation> baseTypeCache = new ConcurrentHashMap<>();
+	
+	@Override
+	public ResourceInformation getBaseResourceInformation(String resourceType) {
+		ResourceInformation baseInformation = baseTypeCache.get(resourceType);
+		if(baseInformation != null){
+			return baseInformation;
+		}
+		
+		RegistryEntry entry = getEntry(resourceType);
+		baseInformation = entry.getResourceInformation();
+		while(baseInformation.getSuperResourceType() != null){
+			entry = getEntry(baseInformation.getSuperResourceType());
+			baseInformation = entry.getResourceInformation();
+		}
+		
+		baseTypeCache.put(resourceType, baseInformation);
+		return baseInformation;
 	}
 }

--- a/katharsis-core/src/main/java/io/katharsis/core/internal/resource/AnnotationResourceInformationBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/resource/AnnotationResourceInformationBuilder.java
@@ -73,7 +73,10 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 
 		DefaultResourceInstanceBuilder<?> instanceBuilder = new DefaultResourceInstanceBuilder(resourceClass);
 
-		return new ResourceInformation(context.getTypeParser(), resourceClass, resourceType, instanceBuilder, (List) resourceFields);
+		Class<?> superclass = resourceClass.getSuperclass();
+		String superResourceType = superclass != Object.class ? context.getResourceType(superclass) : null;
+		
+		return new ResourceInformation(context.getTypeParser(), resourceClass, resourceType, superResourceType, instanceBuilder, (List) resourceFields);
 	}
 
 	@Override

--- a/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/module/ModuleRegistry.java
@@ -320,7 +320,7 @@ public class ModuleRegistry {
 					return builder.getResourceType(resourceClass);
 				}
 			}
-			throw new UnsupportedOperationException("no ResourceInformationBuilder for " + resourceClass.getName() + " available");
+			return null;
 		}
 
 		@Override

--- a/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformation.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformation.java
@@ -69,15 +69,21 @@ public class ResourceInformation {
 
 	private TypeParser parser;
 
-	public ResourceInformation(TypeParser parser, Class<?> resourceClass, String resourceType, List<ResourceField> fields) {
-		this(parser, resourceClass, resourceType, null, fields);
+	/**
+	 * Resource type of the super type.
+	 */
+	private String superResourceType;
+
+	public ResourceInformation(TypeParser parser, Class<?> resourceClass, String resourceType, String superResourceType, List<ResourceField> fields) {
+		this(parser, resourceClass, resourceType, superResourceType, null, fields);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public ResourceInformation(TypeParser parser, Class<?> resourceClass, String resourceType, ResourceInstanceBuilder<?> instanceBuilder, List<ResourceField> fields) {
+	public ResourceInformation(TypeParser parser, Class<?> resourceClass, String resourceType, String superResourceType, ResourceInstanceBuilder<?> instanceBuilder, List<ResourceField> fields) {
 		this.parser = parser;
 		this.resourceClass = resourceClass;
 		this.resourceType = resourceType;
+		this.superResourceType = superResourceType;
 		this.instanceBuilder = instanceBuilder;
 
 		if (fields != null) {
@@ -146,6 +152,10 @@ public class ResourceInformation {
 
 	public String getResourceType() {
 		return resourceType;
+	}
+	
+	public String getSuperResourceType(){
+		return superResourceType;
 	}
 
 	public ResourceInstanceBuilder<?> getInstanceBuilder() {

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/RegistryEntry.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/RegistryEntry.java
@@ -34,6 +34,7 @@ public class RegistryEntry {
 
 	private final List<ResponseRelationshipEntry> relationshipEntries;
 
+	@Deprecated
 	private RegistryEntry parentRegistryEntry = null;
 
 	private ModuleRegistry moduleRegistry;
@@ -111,6 +112,11 @@ public class RegistryEntry {
 	}
 
 	public RegistryEntry getParentRegistryEntry() {
+		String superResourceType = resourceInformation.getSuperResourceType();		
+		if(superResourceType != null){
+			ResourceRegistry resourceRegistry = moduleRegistry.getResourceRegistry();
+			return resourceRegistry.getEntry(superResourceType);
+		}
 		return parentRegistryEntry;
 	}
 
@@ -120,6 +126,7 @@ public class RegistryEntry {
 	 * @param parentRegistryEntry
 	 *            parent resource
 	 */
+	@Deprecated
 	public void setParentRegistryEntry(RegistryEntry parentRegistryEntry) {
 		this.parentRegistryEntry = parentRegistryEntry;
 	}

--- a/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
@@ -23,5 +23,11 @@ public interface ResourceRegistry {
 	public String getResourceUrl(ResourceInformation resourceInformation);
 
 	public RegistryEntry getEntryForClass(Class<?> resourceClass);
+	
+	/**
+	 * @param resourceType
+	 * @return ResourceInformation of the the top most super type of the provided resource.
+	 */
+	public ResourceInformation getBaseResourceInformation(String resourceType);
 
 }

--- a/katharsis-core/src/test/java/io/katharsis/module/TestResourceInformationBuilder.java
+++ b/katharsis-core/src/test/java/io/katharsis/module/TestResourceInformationBuilder.java
@@ -25,7 +25,7 @@ public class TestResourceInformationBuilder implements ResourceInformationBuilde
 		ResourceField idField = new ResourceFieldImpl("testId", "id", ResourceFieldType.ID, Integer.class, null, null);
 		List<ResourceField> fields = Arrays.asList(idField);
 		TypeParser typeParser = context.getTypeParser();
-		ResourceInformation info = new ResourceInformation(typeParser, resourceClass, resourceClass.getSimpleName(), fields);
+		ResourceInformation info = new ResourceInformation(typeParser, resourceClass, resourceClass.getSimpleName(), null, fields);
 		return info;
 	}
 

--- a/katharsis-core/src/test/java/io/katharsis/queryspec/QuerySpecAdapterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/queryspec/QuerySpecAdapterTest.java
@@ -25,7 +25,7 @@ public class QuerySpecAdapterTest {
 		ModuleRegistry moduleRegistry = new ModuleRegistry();
 		ResourceRegistry resourceRegistry = new ResourceRegistryImpl(moduleRegistry, new ConstantServiceUrlProvider("http://localhost"));
 		resourceRegistry.addEntry(Task.class,
-				new RegistryEntry(new ResourceRepositoryInformationImpl(Task.class, "tasks", new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, "tasks", null)), null, null));
+				new RegistryEntry(new ResourceRepositoryInformationImpl(Task.class, "tasks", new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, "tasks", null,  null)), null, null));
 
 		QuerySpec spec = new QuerySpec(Task.class);
 		spec.includeField(Arrays.asList("test"));

--- a/katharsis-core/src/test/java/io/katharsis/resource/ResourceInformationTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/ResourceInformationTest.java
@@ -23,7 +23,7 @@ public class ResourceInformationTest {
 		ResourceField idField = new ResourceFieldImpl("id", "id", ResourceFieldType.ID, field.getType(), field.getGenericType(), null);
 		ResourceField resourceField = new ResourceFieldImpl("value", "value", ResourceFieldType.RELATIONSHIP, field.getType(), field.getGenericType(), "projects");
 		TypeParser typeParser = new TypeParser();
-		ResourceInformation sut = new ResourceInformation(typeParser, Task.class, "tasks", Arrays.asList(idField, resourceField));
+		ResourceInformation sut = new ResourceInformation(typeParser, Task.class, "tasks", null, Arrays.asList(idField, resourceField));
 
 		// WHEN
 		ResourceField result = sut.findRelationshipFieldByName("value");

--- a/katharsis-core/src/test/java/io/katharsis/resource/registry/RegistryEntryTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/registry/RegistryEntryTest.java
@@ -69,7 +69,7 @@ public class RegistryEntryTest {
 	private <T> ResourceRepositoryInformation newRepositoryInformation(Class<T> repositoryClass, String path) {
 		ModuleRegistry moduleRegistry = new ModuleRegistry();
 		TypeParser typeParser = moduleRegistry.getTypeParser();
-		return new ResourceRepositoryInformationImpl(null, path, new ResourceInformation(typeParser, Task.class, path, null));
+		return new ResourceRepositoryInformationImpl(null, path, new ResourceInformation(typeParser, Task.class, path, null, null));
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class RegistryEntryTest {
 		RegistryEntry red = new RegistryEntry(newRepositoryInformation(Long.class, "longs"), null);
 		TypeParser typeParser = moduleRegistry.getTypeParser();
 		EqualsVerifier.forClass(RegistryEntry.class).withPrefabValues(RegistryEntry.class, blue, red)
-				.withPrefabValues(ResourceInformation.class, new ResourceInformation(typeParser, String.class, null, null), new ResourceInformation(typeParser, Long.class, null, null))
+				.withPrefabValues(ResourceInformation.class, new ResourceInformation(typeParser, String.class, null, null, null), new ResourceInformation(typeParser, Long.class, null, null, null, null))
 				.withPrefabValues(Field.class, String.class.getDeclaredField("value"), String.class.getDeclaredField("hash")).withPrefabValues(ModuleRegistry.class, new ModuleRegistry(), new ModuleRegistry())
 				.suppress(Warning.NONFINAL_FIELDS).suppress(Warning.STRICT_INHERITANCE).verify();
 	}

--- a/katharsis-core/src/test/java/io/katharsis/resource/registry/ResourceRegistryTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/resource/registry/ResourceRegistryTest.java
@@ -41,7 +41,7 @@ public class ResourceRegistryTest {
 	}
 
 	private <T> RegistryEntry newRegistryEntry(Class<T> repositoryClass, String path) {
-		return new RegistryEntry(new ResourceRepositoryInformationImpl(null, path, new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, path, null)), null, null);
+		return new RegistryEntry(new ResourceRepositoryInformationImpl(null, path, new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, path, null, null)), null, null);
 	}
 
 	@Test

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaResourceInformationBuilder.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/JpaResourceInformationBuilder.java
@@ -1,11 +1,5 @@
 package io.katharsis.jpa.internal;
 
-import javax.persistence.ElementCollection;
-import javax.persistence.FetchType;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OptimisticLockException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -14,6 +8,14 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToMany;
+import javax.persistence.OptimisticLockException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -101,9 +103,12 @@ public class JpaResourceInformationBuilder implements ResourceInformationBuilder
 
 		List<ResourceField> fields = getFields(meta);
 		Set<String> ignoredFields = getIgnoredFields(meta);
+		
+		Class<?> superclass = resourceClass.getSuperclass();
+		String superResourceType = superclass != Object.class && superclass.getAnnotation(MappedSuperclass.class) == null ? context.getResourceType(superclass) : null;
 
 		TypeParser typeParser = context.getTypeParser();
-		return new JpaResourceInformation(typeParser, meta, resourceClass, resourceType, instanceBuilder, fields,
+		return new JpaResourceInformation(typeParser, meta, resourceClass, resourceType, superResourceType, instanceBuilder, fields,
 				ignoredFields);
 	}
 
@@ -134,9 +139,9 @@ public class JpaResourceInformationBuilder implements ResourceInformationBuilder
 		private Set<String> ignoredFields;
 
 		public JpaResourceInformation(TypeParser typeParser, MetaDataObject meta, Class<?> resourceClass,
-				String resourceType, // NOSONAR
+				String resourceType, String superResourceType,// NOSONAR
 				ResourceInstanceBuilder<?> instanceBuilder, List<ResourceField> fields, Set<String> ignoredFields) {
-			super(typeParser, resourceClass, resourceType, instanceBuilder, fields);
+			super(typeParser, resourceClass, resourceType, superResourceType, instanceBuilder, fields);
 			this.meta = meta;
 			this.ignoredFields = ignoredFields;
 		}


### PR DESCRIPTION
some further improvements towards supporting inheritance:

- ResourceInformation carries a pointer to the superResourceType
- RegistryEntry properly links to the parent entry (the superType entry)
- KatharsisClient properly deals with polymorhic collections (resources included in a response where not properly resolved due to wrong resourceType usage, leading to proxies instead of actual objects)