### PR TITLE
#289: MetaModule minor improvements

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformationBuilderContext.java
+++ b/katharsis-core/src/main/java/io/katharsis/resource/information/ResourceInformationBuilderContext.java
@@ -5,7 +5,7 @@ import io.katharsis.utils.parser.TypeParser;
 public interface ResourceInformationBuilderContext {
 
 	public String getResourceType(Class<?> clazz);
-
+	
 	public boolean accept(Class<?> type);
 
 	public TypeParser getTypeParser();

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/QueryFilterBuilder.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/QueryFilterBuilder.java
@@ -111,7 +111,7 @@ public final class QueryFilterBuilder<P, F> {
 
 		MetaType valueType = attr.getType();
 		if (valueType instanceof MetaMapType) {
-			valueType = ((MetaMapType) valueType).getValueType();
+			valueType = ((MetaMapType) valueType).getElementType();
 		}
 
 		boolean anyType = AnyTypeObject.class.isAssignableFrom(valueType.getImplementationClass());

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/QuerySortBuilder.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/internal/query/QuerySortBuilder.java
@@ -61,7 +61,7 @@ public class QuerySortBuilder<T, E, O> {
 		MetaAttribute attr = path.getLast();
 		MetaType valueType = attr.getType();
 		if (valueType instanceof MetaMapType) {
-			valueType = ((MetaMapType) valueType).getValueType();
+			valueType = ((MetaMapType) valueType).getElementType();
 		}
 		boolean anyType = AnyTypeObject.class.isAssignableFrom(valueType.getImplementationClass());
 		if (anyType) {

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/meta/JpaMetaProvider.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/meta/JpaMetaProvider.java
@@ -41,6 +41,7 @@ public class JpaMetaProvider extends MetaProviderBase {
 		set.add(MetaMappedSuperclass.class);
 		set.add(MetaEntityAttribute.class);
 		set.add(MetaEmbeddableAttribute.class);
+		set.add(MetaJpaDataObject.class);
 		return set;
 	}
 

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/meta/MetaJpaDataObject.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/meta/MetaJpaDataObject.java
@@ -1,7 +1,9 @@
 package io.katharsis.jpa.meta;
 
 import io.katharsis.meta.model.MetaDataObject;
+import io.katharsis.resource.annotations.JsonApiResource;
 
-public class MetaJpaDataObject extends MetaDataObject {
+@JsonApiResource(type = "meta/jpaDataObject")
+public abstract class MetaJpaDataObject extends MetaDataObject {
 
 }

--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/meta/internal/EmbeddableMetaProvider.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/meta/internal/EmbeddableMetaProvider.java
@@ -28,7 +28,8 @@ public class EmbeddableMetaProvider extends AbstractJpaDataObjectProvider<MetaEm
 	@Override
 	public boolean accept(Type type, Class<? extends MetaElement> metaClass) {
 		boolean hasAnnotation = ClassUtils.getRawType(type).getAnnotation(Embeddable.class) != null;
-		boolean hasType = metaClass == MetaElement.class || metaClass == MetaEmbeddable.class || metaClass == MetaJpaDataObject.class;
+		boolean hasType = metaClass == MetaElement.class || metaClass == MetaEmbeddable.class
+				|| metaClass == MetaJpaDataObject.class;
 		return hasAnnotation && hasType;
 	}
 
@@ -41,9 +42,13 @@ public class EmbeddableMetaProvider extends AbstractJpaDataObjectProvider<MetaEm
 			superMeta = context.getLookup().getMeta(superClazz, MetaJpaDataObject.class);
 		}
 		MetaEmbeddable meta = new MetaEmbeddable();
+		meta.setElementType(meta);
 		meta.setName(rawClazz.getSimpleName());
 		meta.setImplementationType(type);
 		meta.setSuperType((MetaDataObject) superMeta);
+		if (superMeta != null) {
+			((MetaDataObject) superMeta).addSubType(meta);
+		}
 		createAttributes(meta);
 		return meta;
 	}
@@ -51,8 +56,10 @@ public class EmbeddableMetaProvider extends AbstractJpaDataObjectProvider<MetaEm
 	@Override
 	protected MetaAttribute createAttribute(MetaEmbeddable metaDataObject, PropertyDescriptor desc) {
 		MetaEmbeddableAttribute attr = new MetaEmbeddableAttribute();
-		attr.setParent(metaDataObject);
+		attr.setParent(metaDataObject, true);
 		attr.setName(desc.getName());
+		attr.setFilterable(true);
+		attr.setSortable(true);
 		return attr;
 	}
 }

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/AbstractJpaJerseyTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/AbstractJpaJerseyTest.java
@@ -29,6 +29,8 @@ import io.katharsis.jpa.util.TestConfig;
 import io.katharsis.legacy.locator.SampleJsonServiceLocator;
 import io.katharsis.legacy.queryParams.DefaultQueryParamsParser;
 import io.katharsis.legacy.queryParams.QueryParamsBuilder;
+import io.katharsis.meta.MetaModule;
+import io.katharsis.meta.provider.resource.ResourceMetaProvider;
 import io.katharsis.queryspec.DefaultQuerySpecDeserializer;
 import io.katharsis.rs.KatharsisFeature;
 import okhttp3.OkHttpClient.Builder;
@@ -51,6 +53,11 @@ public abstract class AbstractJpaJerseyTest extends JerseyTest {
 		JpaModule module = JpaModule.newClientModule();
 		setupModule(module, false);
 		client.addModule(module);
+		
+		MetaModule metaModule = MetaModule.create();
+		metaModule.addMetaProvider(new ResourceMetaProvider());
+		client.addModule(metaModule);
+		
 		setNetworkTimeout(client, 10000, TimeUnit.SECONDS);
 	}
 
@@ -121,6 +128,10 @@ public abstract class AbstractJpaJerseyTest extends JerseyTest {
 			module.setQueryFactory(QuerydslQueryFactory.newInstance());
 			setupModule(module, true);
 			feature.addModule(module);
+			
+			MetaModule metaModule = MetaModule.create();
+			metaModule.addMetaProvider(new ResourceMetaProvider());
+			feature.addModule(metaModule);
 
 			register(feature);
 

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/meta/MetaAttributeImplTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/meta/MetaAttributeImplTest.java
@@ -46,7 +46,7 @@ public class MetaAttributeImplTest {
 		MetaMapType mapType = attr.getType().asMap();
 		Assert.assertTrue(mapType.isMap());
 		Assert.assertEquals(String.class, mapType.getKeyType().getImplementationClass());
-		Assert.assertEquals(String.class, mapType.getValueType().getImplementationClass());
+		Assert.assertEquals(String.class, mapType.getElementType().getImplementationClass());
 		Assert.assertEquals(String.class, attr.getType().getElementType().getImplementationClass());
 	}
 

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/meta/MetaEntityTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/meta/MetaEntityTest.java
@@ -3,10 +3,12 @@ package io.katharsis.jpa.meta;
 import org.junit.Assert;
 import org.junit.Test;
 
+//import io.katharsis.jpa.model.SequenceEntity;
 import io.katharsis.jpa.model.TestMappedSuperclassWithPk;
 import io.katharsis.jpa.model.TestSubclassWithSuperclassPk;
 import io.katharsis.meta.MetaLookup;
-import io.katharsis.meta.model.MetaKey;
+import io.katharsis.meta.model.MetaDataObject;
+import io.katharsis.meta.model.MetaPrimaryKey;
 
 public class MetaEntityTest {
 
@@ -15,10 +17,11 @@ public class MetaEntityTest {
 		MetaLookup lookup = new MetaLookup();
 		lookup.addProvider(new JpaMetaProvider());
 		MetaEntity meta = lookup.getMeta(TestSubclassWithSuperclassPk.class, MetaEntity.class);
-		MetaKey primaryKey = meta.getPrimaryKey();
+		MetaPrimaryKey primaryKey = meta.getPrimaryKey();
 		Assert.assertNotNull(primaryKey);
 		Assert.assertEquals(1, primaryKey.getElements().size());
 		Assert.assertEquals("id", primaryKey.getElements().get(0).getName());
+		Assert.assertFalse(primaryKey.isGenerated());
 	}
 
 	@Test
@@ -26,9 +29,23 @@ public class MetaEntityTest {
 		MetaLookup lookup = new MetaLookup();
 		lookup.addProvider(new JpaMetaProvider());
 		MetaMappedSuperclass meta = lookup.getMeta(TestMappedSuperclassWithPk.class, MetaMappedSuperclass.class);
-		MetaKey primaryKey = meta.getPrimaryKey();
+		MetaPrimaryKey primaryKey = meta.getPrimaryKey();
 		Assert.assertNotNull(primaryKey);
 		Assert.assertEquals(1, primaryKey.getElements().size());
 		Assert.assertEquals("id", primaryKey.getElements().get(0).getName());
+		Assert.assertFalse(primaryKey.isGenerated());
 	}
+
+	// FIXME
+//	@Test
+//	public void testGeneratedPrimaryKey() {
+//		MetaLookup lookup = new MetaLookup();
+//		lookup.addProvider(new JpaMetaProvider());
+//		MetaDataObject meta = lookup.getMeta(SequenceEntity.class).asDataObject();
+//		MetaPrimaryKey primaryKey = meta.getPrimaryKey();
+//		Assert.assertNotNull(primaryKey);
+//		Assert.assertEquals(1, primaryKey.getElements().size());
+//		Assert.assertEquals("id", primaryKey.getElements().get(0).getName());
+//		Assert.assertTrue(primaryKey.isGenerated());
+//	}
 }

--- a/katharsis-jpa/src/test/java/io/katharsis/jpa/meta/MetaLookupTest.java
+++ b/katharsis-jpa/src/test/java/io/katharsis/jpa/meta/MetaLookupTest.java
@@ -16,7 +16,7 @@ public class MetaLookupTest {
 	public void testObjectArrayMeta() {
 		MetaLookup lookup = new MetaLookup();
 		lookup.addProvider(new JpaMetaProvider());
-		
+
 		MetaArrayType meta = lookup.getArrayMeta(TestEntity[].class, MetaEntity.class);
 		MetaType elementType = meta.getElementType();
 		Assert.assertTrue(elementType instanceof MetaDataObject);

--- a/katharsis-meta/src/main/java/io/katharsis/meta/MetaLookup.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/MetaLookup.java
@@ -210,12 +210,13 @@ public class MetaLookup {
 		Class<?> clazz = (Class<?>) type;
 		if (clazz.isEnum()) {
 			MetaEnumType enumType = new MetaEnumType();
+			enumType.setElementType(enumType);
 			enumType.setImplementationType(type);
 			enumType.setName(clazz.getSimpleName());
 			for (Object literalObj : clazz.getEnumConstants()) {
 				MetaLiteral literal = new MetaLiteral();
 				literal.setName(literalObj.toString());
-				literal.setParent(enumType);
+				literal.setParent(enumType, true);
 			}
 			return enumType;
 		}
@@ -226,6 +227,7 @@ public class MetaLookup {
 			MetaPrimitiveType primitiveType = (MetaPrimitiveType) idElementMap.get(id);
 			if (primitiveType == null) {
 				primitiveType = new MetaPrimitiveType();
+				primitiveType.setElementType(primitiveType);
 				primitiveType.setImplementationType(type);
 				primitiveType.setName(clazz.getSimpleName().toLowerCase());
 				primitiveType.setId(id);
@@ -275,7 +277,7 @@ public class MetaLookup {
 
 			mapMeta.setImplementationType(paramType);
 			mapMeta.setKeyType(keyType);
-			mapMeta.setValueType(valueType);
+			mapMeta.setElementType(valueType);
 			return mapMeta;
 		}
 		else if (paramType.getRawType() instanceof Class

--- a/katharsis-meta/src/main/java/io/katharsis/meta/MetaModule.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/MetaModule.java
@@ -17,6 +17,7 @@ import io.katharsis.meta.model.MetaInterface;
 import io.katharsis.meta.model.MetaKey;
 import io.katharsis.meta.model.MetaListType;
 import io.katharsis.meta.model.MetaMapType;
+import io.katharsis.meta.model.MetaPrimaryKey;
 import io.katharsis.meta.model.MetaPrimitiveType;
 import io.katharsis.meta.model.MetaSetType;
 import io.katharsis.meta.model.MetaType;
@@ -69,6 +70,7 @@ public class MetaModule implements Module, InitializingModule {
 		metaClasses.add(MetaSetType.class);
 		metaClasses.add(MetaType.class);
 		metaClasses.add(MetaInterface.class);
+		metaClasses.add(MetaPrimaryKey.class);
 		for (MetaProvider provider : lookup.getProviders()) {
 			metaClasses.addAll(provider.getMetaTypes());
 		}

--- a/katharsis-meta/src/main/java/io/katharsis/meta/internal/MetaDataObjectProvider.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/internal/MetaDataObjectProvider.java
@@ -22,9 +22,13 @@ public abstract class MetaDataObjectProvider extends MetaDataObjectProviderBase<
 			superMeta = context.getLookup().getMeta(superClazz, getMetaClass());
 		}
 		MetaDataObject meta = newDataObject();
+		meta.setElementType(meta);
 		meta.setName(rawClazz.getSimpleName());
 		meta.setImplementationType(type);
 		meta.setSuperType((MetaDataObject) superMeta);
+		if (superMeta != null) {
+			((MetaDataObject) superMeta).addSubType(meta);
+		}
 		createAttributes(meta);
 		return meta;
 	}
@@ -38,8 +42,8 @@ public abstract class MetaDataObjectProvider extends MetaDataObjectProviderBase<
 			MetaDataObject parent = attr.getParent();
 			Type implementationType = PropertyUtils.getPropertyType(parent.getImplementationClass(), attr.getName());
 			MetaElement metaType = context.getLookup().getMeta(implementationType, getMetaClass(), true);
-			if(metaType == null){
-				 metaType = context.getLookup().getMeta(implementationType);
+			if (metaType == null) {
+				metaType = context.getLookup().getMeta(implementationType);
 			}
 			attr.setType(metaType.asType());
 		}

--- a/katharsis-meta/src/main/java/io/katharsis/meta/internal/MetaDataObjectProviderBase.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/internal/MetaDataObjectProviderBase.java
@@ -28,7 +28,9 @@ public abstract class MetaDataObjectProviderBase<T extends MetaDataObject> exten
 	protected MetaAttribute createAttribute(T metaDataObject, PropertyDescriptor desc) {
 		MetaAttribute attr = new MetaAttribute();
 		attr.setName(desc.getName());
-		attr.setParent(metaDataObject);
+		attr.setParent(metaDataObject, true);
+		attr.setFilterable(true);
+		attr.setSortable(true);
 		return attr;
 	}
 }

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaArrayType.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaArrayType.java
@@ -1,20 +1,8 @@
 package io.katharsis.meta.model;
 
 import io.katharsis.resource.annotations.JsonApiResource;
-import io.katharsis.resource.annotations.JsonApiToOne;
 
 @JsonApiResource(type = "meta/arrayType")
 public class MetaArrayType extends MetaType {
 
-	@JsonApiToOne
-	private MetaType elementType;
-
-	public void setElementType(MetaType elementType) {
-		this.elementType = elementType;
-	}
-
-	@Override
-	public MetaType getElementType() {
-		return elementType;
-	}
 }

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaAttribute.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaAttribute.java
@@ -15,13 +15,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.katharsis.core.internal.utils.ClassUtils;
 import io.katharsis.core.internal.utils.PreconditionUtil;
+import io.katharsis.resource.annotations.JsonApiRelation;
 import io.katharsis.resource.annotations.JsonApiResource;
-import io.katharsis.resource.annotations.JsonApiToOne;
+import io.katharsis.resource.annotations.SerializeType;
 
 @JsonApiResource(type = "meta/attribute")
 public class MetaAttribute extends MetaElement {
 
-	@JsonApiToOne
+	@JsonApiRelation(serialize=SerializeType.LAZY)
 	private MetaType type;
 
 	private boolean association;
@@ -41,7 +42,13 @@ public class MetaAttribute extends MetaElement {
 
 	private boolean version;
 
-	@JsonApiToOne
+	private boolean primaryKeyAttribute;
+
+	private boolean sortable;
+
+	private boolean filterable;
+
+	@JsonApiRelation(serialize=SerializeType.LAZY)
 	private MetaAttribute oppositeAttribute;
 
 	private void initAccessors() {
@@ -177,5 +184,29 @@ public class MetaAttribute extends MetaElement {
 
 	public void setType(MetaType type) {
 		this.type = type;
+	}
+
+	public boolean isPrimaryKeyAttribute() {
+		return primaryKeyAttribute;
+	}
+
+	public void setPrimaryKeyAttribute(boolean primaryKeyAttribute) {
+		this.primaryKeyAttribute = primaryKeyAttribute;
+	}
+
+	public boolean isSortable() {
+		return sortable;
+	}
+
+	public void setSortable(boolean sortable) {
+		this.sortable = sortable;
+	}
+
+	public boolean isFilterable() {
+		return filterable;
+	}
+
+	public void setFilterable(boolean filterable) {
+		this.filterable = filterable;
 	}
 }

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaCollectionType.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaCollectionType.java
@@ -9,22 +9,9 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.katharsis.resource.annotations.JsonApiResource;
-import io.katharsis.resource.annotations.JsonApiToOne;
 
 @JsonApiResource(type = "meta/collectionType")
 public abstract class MetaCollectionType extends MetaType {
-
-	@JsonApiToOne
-	private MetaType elementType;
-
-	@Override
-	public MetaType getElementType() {
-		return elementType;
-	}
-
-	public void setElementType(MetaType elementType) {
-		this.elementType = elementType;
-	}
 
 	@JsonIgnore
 	public <T> Collection<T> newInstance() {

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaElement.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaElement.java
@@ -7,9 +7,10 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.katharsis.resource.annotations.JsonApiId;
+import io.katharsis.resource.annotations.JsonApiRelation;
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.annotations.JsonApiToMany;
-import io.katharsis.resource.annotations.JsonApiToOne;
+import io.katharsis.resource.annotations.SerializeType;
 
 @JsonApiResource(type = "meta/element")
 public class MetaElement {
@@ -19,7 +20,7 @@ public class MetaElement {
 
 	private String name;
 
-	@JsonApiToOne(opposite = "children")
+	@JsonApiRelation(serialize=SerializeType.LAZY, opposite = "children")
 	private MetaElement parent;
 
 	@JsonApiToMany(opposite = "parent")
@@ -54,7 +55,7 @@ public class MetaElement {
 	}
 
 	public void setParent(MetaElement parent) {
-		setParent(parent, true);
+		this.parent = parent;
 	}
 
 	public void setParent(MetaElement parent, boolean attach) {

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaMapType.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaMapType.java
@@ -1,30 +1,21 @@
 package io.katharsis.meta.model;
 
+import io.katharsis.resource.annotations.JsonApiRelation;
 import io.katharsis.resource.annotations.JsonApiResource;
-import io.katharsis.resource.annotations.JsonApiToOne;
+import io.katharsis.resource.annotations.SerializeType;
 
 @JsonApiResource(type = "meta/mapType")
 public class MetaMapType extends MetaType {
 
-	@JsonApiToOne
+	@JsonApiRelation(serialize=SerializeType.LAZY)
 	private MetaType keyType;
-
-	@JsonApiToOne
-	private MetaType valueType;
 
 	public MetaType getKeyType() {
 		return keyType;
-	}
-
-	public MetaType getValueType() {
-		return valueType;
 	}
 
 	public void setKeyType(MetaType keyType) {
 		this.keyType = keyType;
 	}
 
-	public void setValueType(MetaType valueType) {
-		this.valueType = valueType;
-	}
 }

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaPrimaryKey.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaPrimaryKey.java
@@ -1,0 +1,17 @@
+package io.katharsis.meta.model;
+
+import io.katharsis.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "meta/primaryKey")
+public class MetaPrimaryKey extends MetaKey {
+
+	private boolean generated;
+
+	public boolean isGenerated() {
+		return generated;
+	}
+
+	public void setGenerated(boolean generated) {
+		this.generated = generated;
+	}
+}

--- a/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaType.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/model/MetaType.java
@@ -5,8 +5,9 @@ import java.lang.reflect.Type;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.katharsis.core.internal.utils.ClassUtils;
+import io.katharsis.resource.annotations.JsonApiRelation;
 import io.katharsis.resource.annotations.JsonApiResource;
-import io.katharsis.resource.annotations.JsonApiToOne;
+import io.katharsis.resource.annotations.SerializeType;
 
 @JsonApiResource(type = "meta/type")
 public class MetaType extends MetaElement {
@@ -14,7 +15,8 @@ public class MetaType extends MetaElement {
 	@JsonIgnore
 	private Type implementationType;
 
-	private MetaType elementType;
+	@JsonApiRelation(serialize=SerializeType.LAZY)
+    private MetaType elementType;
 
 	@JsonIgnore
 	public Class<?> getImplementationClass() {
@@ -53,24 +55,17 @@ public class MetaType extends MetaElement {
 		return (MetaMapType) this;
 	}
 
-	@JsonApiToOne
 	public MetaType getElementType() {
-		// FIXME move out
 		if (elementType == null) {
-			if (isCollection()) {
-				return asCollection().getElementType();
-			}
-			else if (isMap()) {
-				return asMap().getValueType();
-			}
-			else {
-				return this;
-			}
+		  throw new IllegalStateException(getClass().getName());
 		}
 		return elementType;
 	}
 
 	public void setElementType(MetaType elementType) {
+		if(elementType == null){
+			throw new NullPointerException();
+		}
 		this.elementType = elementType;
 	}
 }

--- a/katharsis-meta/src/main/java/io/katharsis/meta/provider/MetaProviderContext.java
+++ b/katharsis-meta/src/main/java/io/katharsis/meta/provider/MetaProviderContext.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 
 import io.katharsis.meta.MetaLookup;
 import io.katharsis.meta.model.MetaElement;
-import io.katharsis.utils.parser.TypeParser;
 
 public interface MetaProviderContext {
 

--- a/katharsis-meta/src/test/java/io/katharsis/meta/AbstractMetaJerseyTest.java
+++ b/katharsis-meta/src/test/java/io/katharsis/meta/AbstractMetaJerseyTest.java
@@ -9,6 +9,9 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Before;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import io.katharsis.client.KatharsisClient;
 import io.katharsis.client.http.okhttp.OkHttpAdapter;
 import io.katharsis.client.http.okhttp.OkHttpAdapterListenerBase;
@@ -52,6 +55,8 @@ public abstract class AbstractMetaJerseyTest extends JerseyTest {
 		public TestApplication() {
 			property(KatharsisProperties.RESOURCE_SEARCH_PACKAGE, "io.katharsis.meta.mock.model");
 			KatharsisFeature feature = new KatharsisFeature();
+			ObjectMapper objectMapper = feature.getObjectMapper();
+			objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
 			feature.addModule(createModule());
 			register(feature);
 		}

--- a/katharsis-meta/src/test/java/io/katharsis/meta/TestMultipleMetaForSameType.java
+++ b/katharsis-meta/src/test/java/io/katharsis/meta/TestMultipleMetaForSameType.java
@@ -83,6 +83,7 @@ public class TestMultipleMetaForSameType extends AbstractMetaTest {
 			Class<?> rawType = ClassUtils.getRawType(type);
 			MetaDummyDataObject dummy = new MetaDummyDataObject();
 			dummy.setName(rawType.getSimpleName());
+			dummy.setElementType(dummy);
 			dummy.setImplementationType(type);
 			return dummy;
 		}


### PR DESCRIPTION
- new MetaPrimaryKey extends MetaKey
- MetaPrimaryKey holds whether key is generated or not
- removed some redundant elementType attributes from various types
- started simplifying meta classes by moving further logic out (like elementType computation)
- more testing (which double checks general inheritance support as well)
- replaced deprecated annotations by JsonApiRelation
- sortable/filterable attribute for MetaAttribute in meta model