### PR TITLE
Fix bug when using jpa entity with mapped dto

### DIFF
--- a/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaEntityRepository.java
+++ b/katharsis-jpa/src/main/java/io/katharsis/jpa/JpaEntityRepository.java
@@ -110,7 +110,7 @@ public class JpaEntityRepository<T, I extends Serializable> extends JpaRepositor
 		EntityManager em = module.getEntityManager();
 		em.persist(entity);
 		
-		I id = (I) PropertyUtils.getProperty(resource, primaryKeyAttr.getName());
+		I id = (I) em.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(entity);
 
 		// fetch again since we may have to fetch tuple data and do DTO mapping
 		QuerySpec querySpec = new QuerySpec(repositoryConfig.getResourceClass());


### PR DESCRIPTION
When using katharsis-jpa with mapped entity dto,  the resource dto's primary key field is never set when  id is auto generated value, which leads to error.