### PR TITLE
Set UTF-8 charset in Scanner object in KatharsisFilter

### DIFF
--- a/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/katharsis-rs/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -213,7 +213,7 @@ public class KatharsisFilter implements ContainerRequestFilter {
         if (is == null) {
             return null;
         }
-        Scanner s = new Scanner(is).useDelimiter("\\A");
+        Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
         String requestBody = s.hasNext() ? s.next() : "";
         if (requestBody == null || requestBody.isEmpty()) {
             return null;


### PR DESCRIPTION
When the Scanner object is created, it should not use the system's charset, but use a specified charset, UTF-8. See KatharsisInvoker.java, where it's already done like that.