### PR TITLE
fixed flaky test in testIncludeRelationsMultipleSame Test

### DIFF
--- a/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/AbstractQueryParamsTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/AbstractQueryParamsTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractQueryParamsTest {
 
 			@Override
 			public Set<Class<?>> getResourceRepositoryClasses() {
-				Set<Class<?>> set = new HashSet<>();
+				Set<Class<?>> set = new LinkedHashSet<>();
 				set.addAll(super.getResourceRepositoryClasses());
 				set.add(ScheduleRepositoryImpl.class); // not yet recognized by reflections for some reason
 				return set;
@@ -56,6 +56,6 @@ public abstract class AbstractQueryParamsTest {
 	}
 
 	protected static void addParams(Map<String, Set<String>> params, String key, String ... values ) {
-		params.put(key, new HashSet<String>(Arrays.asList(values)));
+		params.put(key, new LinkedHashSet<String>(Arrays.asList(values)));
 	}
 }

--- a/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/DefaultQueryParamsConverterTest.java
+++ b/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/DefaultQueryParamsConverterTest.java
@@ -361,8 +361,8 @@ public class DefaultQueryParamsConverterTest extends AbstractQueryParamsTest {
         QueryParams expectedParams = defaultQueryParamsWithOffset0(params);
 
         QuerySpec inputSpec = new QuerySpec(Task.class);
-        inputSpec.includeRelation(Collections.singletonList("projects"));
         inputSpec.includeRelation(Collections.singletonList("project"));
+        inputSpec.includeRelation(Collections.singletonList("projects"));
 
         transitivityCheckTask(inputSpec, expectedParams);
 


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/DefaultQueryParamsConverterTest.java#L358)

Test Overview:
_________________________________________________________________________________________________________
In the above test, the [addParams](https://github.com/njain2208/katharsis-framework/blob/36c7411dcf9ae6515c539ec7f38976749939614b/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/DefaultQueryParamsConverterTest.java#L360) method utilizes a non-deterministic HashMap to store parameters. This lack of determinism results in a change in the order of 'project' and 'projects' within the includedRelations array, consequently causing the test to fail.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR]   DefaultQueryParamsConverterTest.testIncludeRelationsMultipleSame:367->transitivityCheckTask:442 transitivity check expected:<QuerySpec{resourceClass=class io.katharsis.resource.mock.models.Task, limit=null, offset=0, filters=[], sort=[], includedFields=[], includedRelations=[project, projects], relatedSpecs={}}> but was:<QuerySpec{resourceClass=class io.katharsis.resource.mock.models.Task, limit=null, offset=0, filters=[], sort=[], includedFields=[], includedRelations=[projects, project], relatedSpecs={}}>
```

You can reproduce the issue by running the following commands:

```
mvn install -pl katharsis-core -am -DskipTests
mvn test -pl katharsis-core  -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame
mvn -pl katharsis-core edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame
```

Fix:
_________________________________________________________________________________________________________
To fix the issue I decided to store all of the parameters in a LinkedHashSet so it returns the element in which it is stored.

https://github.com/njain2208/katharsis-framework/blob/36c7411dcf9ae6515c539ec7f38976749939614b/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/AbstractQueryParamsTest.java#L49-L60